### PR TITLE
chore: AtlasによるDBマイグレーション管理を導入 (#6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,14 @@
 # プロジェクト開発ルール
 
 エージェントの行動規範・開発フロー・テスト設計・Git ワークフローはすべて [AGENT.md](AGENT.md) に記載されている。必ず参照すること。
+
+## DBマイグレーション
+
+スキーマ管理には **Atlas**（宣言モード）を使用する。
+
+- スキーマ定義: `db/schema.hcl`（このファイルを編集してスキーマを変更する）
+- Atlas設定: `atlas.hcl`
+- 適用コマンド: `atlas schema apply --env local`
+- 差分確認: `atlas schema apply --env local --dry-run`
+
+**スキーマを変更するときは必ず `db/schema.hcl` を編集し、`atlas schema apply` で適用する。`database.ts` の `initializeSchema` は新規インストール時の初期化専用であり、マイグレーションには使用しない。**

--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# chat-app
+
+リアルタイムチャットアプリケーション。
+
+## 技術スタック
+
+- **フロントエンド:** React + TypeScript + Vite
+- **バックエンド:** Node.js + Express + Socket.IO + TypeScript
+- **データベース:** SQLite (better-sqlite3)
+- **DBマイグレーション:** [Atlas](https://atlasgo.io/)
+
+## セットアップ
+
+```bash
+npm install
+npm run build
+npm run dev
+```
+
+## DBマイグレーション
+
+スキーマ管理には **Atlas** を使用する（宣言モード）。
+
+### Atlas のインストール
+
+```bash
+# macOS / Linux
+curl -sSf https://atlasgo.sh | sh
+```
+
+### スキーマ定義
+
+`db/schema.hcl` がDBの正規スキーマ定義。テーブルの追加・変更はこのファイルを編集する。
+
+### 主なコマンド
+
+```bash
+# スキーマの差分確認（実行せず内容を表示）
+atlas schema apply --env local --dry-run
+
+# スキーマをDBに適用
+atlas schema apply --env local
+
+# 現在のDBスキーマをHCL形式で確認
+atlas schema inspect --env local
+```
+
+### 設定ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `atlas.hcl` | Atlasプロジェクト設定（接続先・スキーマソース） |
+| `db/schema.hcl` | 宣言型スキーマ定義（正規スキーマ） |

--- a/atlas.hcl
+++ b/atlas.hcl
@@ -1,0 +1,12 @@
+// Atlas プロジェクト設定ファイル
+// 宣言モード: db/schema.hcl を正規スキーマとして管理する
+
+data "hcl_schema" "app" {
+  path = "db/schema.hcl"
+}
+
+env "local" {
+  src = data.hcl_schema.app.url
+  url = "sqlite://packages/server/data/chat.db"
+  dev = "sqlite://file?mode=memory&_fk=1"
+}

--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -1,0 +1,266 @@
+// Atlas 宣言モード スキーマ定義
+// このファイルがDBの正規スキーマ。変更はこのファイルを編集し atlas schema apply で適用する。
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+  }
+  column "username" {
+    null = false
+    type = text
+  }
+  column "email" {
+    null = false
+    type = text
+  }
+  column "password_hash" {
+    null = false
+    type = text
+  }
+  column "avatar_url" {
+    null = true
+    type = text
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  column "updated_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  column "display_name" {
+    null = true
+    type = text
+  }
+  column "location" {
+    null = true
+    type = text
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  index "users_username" {
+    unique  = true
+    columns = [column.username]
+  }
+  index "users_email" {
+    unique  = true
+    columns = [column.email]
+  }
+}
+
+table "channels" {
+  schema = schema.main
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+  }
+  column "name" {
+    null = false
+    type = text
+  }
+  column "description" {
+    null = true
+    type = text
+  }
+  column "created_by" {
+    null = false
+    type = integer
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.created_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  index "channels_name" {
+    unique  = true
+    columns = [column.name]
+  }
+}
+
+table "channel_members" {
+  schema = schema.main
+  column "channel_id" {
+    null = false
+    type = integer
+  }
+  column "user_id" {
+    null = false
+    type = integer
+  }
+  column "joined_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  primary_key {
+    columns = [column.channel_id, column.user_id]
+  }
+  foreign_key "0" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "1" {
+    columns     = [column.channel_id]
+    ref_columns = [table.channels.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+}
+
+table "messages" {
+  schema = schema.main
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+  }
+  column "channel_id" {
+    null = false
+    type = integer
+  }
+  column "user_id" {
+    null = false
+    type = integer
+  }
+  column "content" {
+    null = false
+    type = text
+  }
+  column "is_edited" {
+    null    = false
+    type    = integer
+    default = 0
+  }
+  column "is_deleted" {
+    null    = false
+    type    = integer
+    default = 0
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  column "updated_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  foreign_key "1" {
+    columns     = [column.channel_id]
+    ref_columns = [table.channels.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+}
+
+table "mentions" {
+  schema = schema.main
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+  }
+  column "message_id" {
+    null = false
+    type = integer
+  }
+  column "mentioned_user_id" {
+    null = false
+    type = integer
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.mentioned_user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "1" {
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+}
+
+table "push_subscriptions" {
+  schema = schema.main
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+  }
+  column "user_id" {
+    null = false
+    type = integer
+  }
+  column "endpoint" {
+    null = false
+    type = text
+  }
+  column "p256dh" {
+    null = false
+    type = text
+  }
+  column "auth" {
+    null = false
+    type = text
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  index "push_subscriptions_endpoint" {
+    unique  = true
+    columns = [column.endpoint]
+  }
+}
+
+schema "main" {
+}

--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -1,46 +1,57 @@
 // Atlas 宣言モード スキーマ定義
 // このファイルがDBの正規スキーマ。変更はこのファイルを編集し atlas schema apply で適用する。
+// comment 属性は MySQL / PostgreSQL 等の移行時にDB上のコメントとして適用される（SQLiteでは無視）。
 
 table "users" {
-  schema = schema.main
+  schema  = schema.main
+  comment = "ユーザー"
   column "id" {
     null           = true
     type           = integer
     auto_increment = true
+    comment        = "ユーザーID"
   }
   column "username" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "ユーザー名（ログインID）"
   }
   column "email" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "メールアドレス"
   }
   column "password_hash" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "パスワードハッシュ"
   }
   column "avatar_url" {
-    null = true
-    type = text
+    null    = true
+    type    = text
+    comment = "アバター画像URL"
   }
   column "created_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "作成日時"
   }
   column "updated_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "更新日時"
   }
   column "display_name" {
-    null = true
-    type = text
+    null    = true
+    type    = text
+    comment = "表示名"
   }
   column "location" {
-    null = true
-    type = text
+    null    = true
+    type    = text
+    comment = "所在地"
   }
   primary_key {
     columns = [column.id]
@@ -56,28 +67,34 @@ table "users" {
 }
 
 table "channels" {
-  schema = schema.main
+  schema  = schema.main
+  comment = "チャンネル"
   column "id" {
     null           = true
     type           = integer
     auto_increment = true
+    comment        = "チャンネルID"
   }
   column "name" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "チャンネル名"
   }
   column "description" {
-    null = true
-    type = text
+    null    = true
+    type    = text
+    comment = "チャンネル説明"
   }
   column "created_by" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "作成者ユーザーID"
   }
   column "created_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "作成日時"
   }
   primary_key {
     columns = [column.id]
@@ -95,19 +112,23 @@ table "channels" {
 }
 
 table "channel_members" {
-  schema = schema.main
+  schema  = schema.main
+  comment = "チャンネルメンバー"
   column "channel_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "チャンネルID"
   }
   column "user_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "ユーザーID"
   }
   column "joined_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "参加日時"
   }
   primary_key {
     columns = [column.channel_id, column.user_id]
@@ -127,43 +148,52 @@ table "channel_members" {
 }
 
 table "messages" {
-  schema = schema.main
+  schema  = schema.main
+  comment = "メッセージ"
   column "id" {
     null           = true
     type           = integer
     auto_increment = true
+    comment        = "メッセージID"
   }
   column "channel_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "チャンネルID"
   }
   column "user_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "投稿者ユーザーID"
   }
   column "content" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "メッセージ本文"
   }
   column "is_edited" {
     null    = false
     type    = integer
     default = 0
+    comment = "編集済みフラグ（0: 未編集, 1: 編集済み）"
   }
   column "is_deleted" {
     null    = false
     type    = integer
     default = 0
+    comment = "削除フラグ（0: 有効, 1: 削除済み）"
   }
   column "created_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "投稿日時"
   }
   column "updated_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "更新日時"
   }
   primary_key {
     columns = [column.id]
@@ -183,24 +213,29 @@ table "messages" {
 }
 
 table "mentions" {
-  schema = schema.main
+  schema  = schema.main
+  comment = "メンション"
   column "id" {
     null           = true
     type           = integer
     auto_increment = true
+    comment        = "メンションID"
   }
   column "message_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "メッセージID"
   }
   column "mentioned_user_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "メンション対象ユーザーID"
   }
   column "created_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "メンション日時"
   }
   primary_key {
     columns = [column.id]
@@ -220,32 +255,39 @@ table "mentions" {
 }
 
 table "push_subscriptions" {
-  schema = schema.main
+  schema  = schema.main
+  comment = "プッシュ通知サブスクリプション"
   column "id" {
     null           = true
     type           = integer
     auto_increment = true
+    comment        = "サブスクリプションID"
   }
   column "user_id" {
-    null = false
-    type = integer
+    null    = false
+    type    = integer
+    comment = "ユーザーID"
   }
   column "endpoint" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "プッシュエンドポイントURL"
   }
   column "p256dh" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "公開鍵（p256dh）"
   }
   column "auth" {
-    null = false
-    type = text
+    null    = false
+    type    = text
+    comment = "認証シークレット"
   }
   column "created_at" {
     null    = false
     type    = text
     default = sql("datetime('now')")
+    comment = "登録日時"
   }
   primary_key {
     columns = [column.id]


### PR DESCRIPTION
## 概要

Issue #6 の対応。DBマイグレーションツールとして Atlas を導入した。

## 変更内容

- `db/schema.hcl` — 宣言型スキーマ定義ファイル（正規スキーマ）。既存DBから生成。
- `atlas.hcl` — Atlasプロジェクト設定（接続先・スキーマソースの指定）。
- `README.md` — プロジェクト概要とAtlasの使い方を新規作成。
- `CLAUDE.md` — マイグレーション運用ルールを追記。

## Atlas 運用フロー

```bash
# スキーマ変更の差分確認
atlas schema apply --env local --dry-run

# DBへ適用
atlas schema apply --env local
```

スキーマ変更は `db/schema.hcl` を編集して `atlas schema apply` で適用する。`database.ts` の `initializeSchema` は新規インストール時の初期化専用。

## テスト計画

- [x] `npm run build` 通過
- [x] `npm run test` 通過（88 tests passed）
- [x] `atlas schema apply --env local --dry-run` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)