### PR TITLE
feat: チャット画面表示時に最新メッセージへ自動スクロール (#3)

### DIFF
--- a/packages/client/src/__tests__/MessageList.test.tsx
+++ b/packages/client/src/__tests__/MessageList.test.tsx
@@ -177,4 +177,129 @@ describe('MessageList', () => {
       expect(mockScrollIntoView).toHaveBeenCalledOnce();
     });
   });
+
+  describe('初回ロード時の自動スクロール', () => {
+    it('メッセージが空から非空になったとき（初回ロード）、スクロール位置に関わらず最下部へ scrollIntoView が呼ばれる', () => {
+      const scrollIntoView = vi.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { rerender } = render(
+        <MessageList messages={[]} loading={false} onLoadMore={vi.fn()} currentUserId={1} />,
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      rerender(
+        <MessageList
+          messages={[makeMessage(1)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+    });
+
+    it('messages が再び空になった後に新たなメッセージが渡されたとき（チャンネル切り替え）、最下部へ scrollIntoView が呼ばれる', () => {
+      const scrollIntoView = vi.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { rerender } = render(
+        <MessageList
+          messages={[makeMessage(1)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      // 初回ロード: 1 回呼ばれる
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+
+      // チャンネル切り替えで messages がリセット
+      rerender(
+        <MessageList messages={[]} loading={false} onLoadMore={vi.fn()} currentUserId={1} />,
+      );
+
+      // 新チャンネルのメッセージが届く
+      rerender(
+        <MessageList
+          messages={[makeMessage(2)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('新着メッセージ到着時のスクロール', () => {
+    it('スクロール位置が最下部付近のとき、新着メッセージ追加後に scrollIntoView が呼ばれる', () => {
+      const scrollIntoView = vi.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { rerender } = render(
+        <MessageList
+          messages={[makeMessage(1)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      // 初回ロード: 1 回
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+
+      // jsdom では scrollHeight / scrollTop / clientHeight がすべて 0 → 差分 0 < 100 → 最下部付近
+      rerender(
+        <MessageList
+          messages={[makeMessage(1), makeMessage(2)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    });
+
+    it('スクロール位置が最下部から離れているとき、新着メッセージ追加後に scrollIntoView は呼ばれない', () => {
+      const scrollIntoView = vi.fn();
+      HTMLElement.prototype.scrollIntoView = scrollIntoView;
+
+      const { rerender, container: renderContainer } = render(
+        <MessageList
+          messages={[makeMessage(1)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      // 初回ロード: 1 回
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+
+      // スクロールコンテナのプロパティを上書きして「上部にいる」状態を再現
+      // scrollHeight(1000) - scrollTop(0) - clientHeight(500) = 500 >= 100 → 最下部でない
+      const scrollContainer = renderContainer.firstChild as HTMLElement;
+      Object.defineProperty(scrollContainer, 'scrollHeight', { value: 1000, configurable: true });
+      Object.defineProperty(scrollContainer, 'scrollTop', { value: 0, configurable: true });
+      Object.defineProperty(scrollContainer, 'clientHeight', { value: 500, configurable: true });
+
+      rerender(
+        <MessageList
+          messages={[makeMessage(1), makeMessage(2)]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+
+      // 初回ロードの 1 回のみ（新着では呼ばれない）
+      expect(scrollIntoView).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/packages/client/src/components/Chat/MessageList.tsx
+++ b/packages/client/src/components/Chat/MessageList.tsx
@@ -17,11 +17,27 @@ export default function MessageList({ messages, loading, onLoadMore, users = [] 
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const hasScrolledToHash = useRef(false);
+  const isInitialLoad = useRef(true);
 
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
+
+    // メッセージが空になったらチャンネル切り替えとみなし、次のロードを初回扱いにする
+    if (messages.length === 0) {
+      isInitialLoad.current = true;
+      return;
+    }
+
+    // 初回ロード時はスクロール位置に関わらず即座に最下部へ移動する
+    if (isInitialLoad.current) {
+      bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+      isInitialLoad.current = false;
+      return;
+    }
+
+    // 以降の更新（新着メッセージ）は最下部付近にいるときのみスクロールする
     const isAtBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
     if (isAtBottom) {
       bottomRef.current?.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
## 概要

Issue #3 の対応。チャット画面表示時に自動で最下部へスクロールし、最新の投稿を表示する。

## 変更内容

**`packages/client/src/components/Chat/MessageList.tsx`**

`isInitialLoad` ref を追加し、スクロール挙動を2パターンに分離:

| タイミング | 変更前 | 変更後 |
|---|---|---|
| チャンネル選択・切り替え時（初回ロード） | スクロール位置が底付近のときのみ移動 | 位置に関わらず即座に最下部へ移動 |
| 新着メッセージ到着時 | 最下部付近ならスクロール | 変更なし |

**`packages/client/src/__tests__/MessageList.test.tsx`**

自動スクロール挙動のテストを4ケース追加:
- 初回ロード時（空→非空）のスクロール
- チャンネル切り替え後のスクロール
- 最下部付近での新着メッセージ時スクロール
- 最下部から離れた位置での新着メッセージ時スクロール抑制

## テスト計画

- [x] `npm run build` 通過
- [x] `npm run test` 通過（88 tests passed）
- [x] MessageList テスト 8/8 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)