### PR TITLE
feat: ファイルアップロード機能を追加 (#12)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -254,6 +254,57 @@ table "mentions" {
   }
 }
 
+table "message_attachments" {
+  schema  = schema.main
+  comment = "メッセージ添付ファイル"
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+    comment        = "添付ファイルID"
+  }
+  column "message_id" {
+    null    = true
+    type    = integer
+    comment = "メッセージID（NULL = メッセージ投稿前の一時状態）"
+  }
+  column "url" {
+    null    = false
+    type    = text
+    comment = "ファイル公開URL"
+  }
+  column "original_name" {
+    null    = false
+    type    = text
+    comment = "元のファイル名"
+  }
+  column "size" {
+    null    = false
+    type    = integer
+    comment = "ファイルサイズ（バイト）"
+  }
+  column "mime_type" {
+    null    = false
+    type    = text
+    comment = "MIMEタイプ"
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+    comment = "作成日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+}
+
 table "push_subscriptions" {
   schema  = schema.main
   comment = "プッシュ通知サブスクリプション"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3274,7 +3274,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -3296,7 +3295,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3346,7 +3344,6 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -3359,7 +3356,6 @@
       "version": "4.19.8",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
       "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -3382,7 +3378,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -3451,7 +3446,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ms": {
@@ -3460,6 +3454,15 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "25.5.2",
@@ -3486,14 +3489,12 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -3529,7 +3530,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3539,7 +3539,6 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -3551,7 +3550,6 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -4236,6 +4234,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/aproba": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
@@ -4914,8 +4918,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -5235,6 +5249,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/concurrently": {
       "version": "8.2.2",
@@ -9778,6 +9807,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -11637,6 +11685,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -12611,6 +12667,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -13551,6 +13613,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@chat-app/shared": "*",
+        "@types/multer": "^2.1.0",
         "bcrypt": "^5.1.1",
         "better-sqlite3": "^9.4.3",
         "cookie-parser": "^1.4.6",
@@ -13558,6 +13621,7 @@
         "dotenv": "^17.4.1",
         "express": "^4.18.3",
         "jsonwebtoken": "^9.0.2",
+        "multer": "^2.1.1",
         "socket.io": "^4.7.4",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.0",

--- a/packages/client/src/__tests__/MessageItemAttachment.test.tsx
+++ b/packages/client/src/__tests__/MessageItemAttachment.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * components/Chat/MessageItem.tsx の添付ファイル表示機能テスト
+ *
+ * テスト対象: メッセージに添付されたファイルの表示・ダウンロードリンク
+ * 戦略:
+ *   - Socket.IO は SocketContext をモックして注入する
+ *   - RichEditor は jsdom では動作しないためスタブに差し替える
+ *   - Message 型に attachments を含む形でダミーデータを構築する
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message, User } from '@chat-app/shared';
+import MessageItem from '../components/Chat/MessageItem';
+
+vi.mock('../contexts/SocketContext', () => ({
+  useSocket: () => ({ emit: vi.fn(), on: vi.fn(), off: vi.fn() }),
+}));
+
+vi.mock('../components/Chat/RichEditor', () => ({
+  default: ({ onCancel }: { onCancel: () => void }) => (
+    <div data-testid="rich-editor">
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}));
+
+const dummyUsers: User[] = [
+  {
+    id: 1,
+    username: 'alice',
+    email: 'alice@example.com',
+    avatarUrl: null,
+    displayName: null,
+    location: null,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+];
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 1,
+    channelId: 1,
+    userId: 1,
+    username: 'alice',
+    avatarUrl: null,
+    content: JSON.stringify({ ops: [{ insert: 'Hello\n' }] }),
+    isEdited: false,
+    isDeleted: false,
+    createdAt: '2024-06-01T12:00:00Z',
+    updatedAt: '2024-06-01T12:00:00Z',
+    mentions: [],
+    attachments: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('MessageItem - 添付ファイル表示', () => {
+  describe('ファイル名の表示', () => {
+    it('添付ファイルが存在する場合、ファイル名が表示される', () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/doc.pdf',
+                originalName: 'doc.pdf',
+                size: 1024,
+                mimeType: 'application/pdf',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      expect(screen.getByText('doc.pdf')).toBeInTheDocument();
+    });
+
+    it('複数の添付ファイルがある場合、すべてのファイル名が表示される', () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/a.pdf',
+                originalName: 'a.pdf',
+                size: 100,
+                mimeType: 'application/pdf',
+              },
+              {
+                id: 2,
+                url: '/uploads/b.txt',
+                originalName: 'b.txt',
+                size: 200,
+                mimeType: 'text/plain',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      expect(screen.getByText('a.pdf')).toBeInTheDocument();
+      expect(screen.getByText('b.txt')).toBeInTheDocument();
+    });
+
+    it('添付ファイルがない場合、ファイル領域は表示されない', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ attachments: [] })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      expect(screen.queryByTestId('message-attachments')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ダウンロードリンク', () => {
+    it('ファイル名をクリックするとダウンロードリンクが機能する', async () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/file.txt',
+                originalName: 'file.txt',
+                size: 50,
+                mimeType: 'text/plain',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      const link = screen.getByRole('link', { name: /file\.txt/i });
+      expect(link).toBeInTheDocument();
+    });
+
+    it('ダウンロードリンクの href がファイルの URL を指している', () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/report.pdf',
+                originalName: 'report.pdf',
+                size: 2048,
+                mimeType: 'application/pdf',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      const link = screen.getByRole('link', { name: /report\.pdf/i });
+      expect(link).toHaveAttribute('href', '/uploads/report.pdf');
+    });
+
+    it('ダウンロードリンクに download 属性が付与されている', () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/data.csv',
+                originalName: 'data.csv',
+                size: 512,
+                mimeType: 'text/csv',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      const link = screen.getByRole('link', { name: /data\.csv/i });
+      expect(link).toHaveAttribute('download');
+    });
+  });
+
+  describe('ファイルの種類別表示', () => {
+    it('画像ファイルはサムネイル表示される', () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/photo.png',
+                originalName: 'photo.png',
+                size: 4096,
+                mimeType: 'image/png',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      const img = screen.getByRole('img', { name: /photo\.png/i });
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', '/uploads/photo.png');
+    });
+
+    it('非画像ファイルはアイコン＋ファイル名で表示される', () => {
+      render(
+        <MessageItem
+          message={makeMessage({
+            attachments: [
+              {
+                id: 1,
+                url: '/uploads/archive.zip',
+                originalName: 'archive.zip',
+                size: 8192,
+                mimeType: 'application/zip',
+              },
+            ],
+          })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      expect(screen.getByText('archive.zip')).toBeInTheDocument();
+      expect(screen.queryByRole('img', { name: /archive\.zip/i })).not.toBeInTheDocument();
+      expect(screen.getByTestId('file-icon')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/RichEditorFileUpload.test.tsx
+++ b/packages/client/src/__tests__/RichEditorFileUpload.test.tsx
@@ -1,0 +1,311 @@
+/**
+ * components/Chat/RichEditor.tsx のファイルアップロード機能テスト
+ *
+ * テスト対象: ファイル選択ボタン・ドラッグ&ドロップによるファイル添付、添付プレビュー表示
+ * 戦略:
+ *   - react-quill-new は jsdom で動作しないため forwardRef スタブに差し替える
+ *   - API クライアントの files.upload を vi.mock で差し替え、即時 resolve させる
+ *   - userEvent.upload() でファイル選択をシミュレートする
+ *   - ドラッグ&ドロップは fireEvent.dragOver / fireEvent.drop で発火する
+ *   - modules.keyboard.bindings の handler を capturedModules 経由で直接呼び出す
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { User } from '@chat-app/shared';
+import RichEditor from '../components/Chat/RichEditor';
+
+// ─── Quill モックの共有ステート ───────────────────────────────────────────────
+const { mockQuill, capturedModules, mockUpload } = vi.hoisted(() => {
+  const capturedModules = { value: null as Record<string, unknown> | null };
+
+  const mockQuill = {
+    on: vi.fn(),
+    off: vi.fn(),
+    getSelection: vi.fn(() => ({ index: 0, length: 0 })),
+    getText: vi.fn(() => 'hello'),
+    getContents: vi.fn(() => ({ ops: [{ insert: 'hello\n' }] })),
+    deleteText: vi.fn(),
+    insertEmbed: vi.fn(),
+    insertText: vi.fn(),
+    setSelection: vi.fn(),
+    setText: vi.fn(),
+    focus: vi.fn(),
+    root: { getBoundingClientRect: vi.fn(() => new DOMRect()) },
+    getBounds: vi.fn(() => ({ left: 0, bottom: 20 })),
+  };
+
+  const mockUpload = vi.fn();
+
+  return { mockQuill, capturedModules, mockUpload };
+});
+
+vi.mock('react-quill-new', async () => {
+  const React = (await import('react')) as typeof import('react');
+  const MockReactQuill = React.forwardRef(
+    (props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+      capturedModules.value = props.modules as Record<string, unknown>;
+      React.useImperativeHandle(ref, () => ({ getEditor: () => mockQuill }), []);
+      return React.createElement('div', { 'data-testid': 'quill-editor' });
+    },
+  );
+  MockReactQuill.displayName = 'MockReactQuill';
+  return { default: MockReactQuill };
+});
+
+vi.mock('react-quill-new/dist/quill.snow.css', () => ({}));
+vi.mock('../components/Chat/MentionBlot', () => ({}));
+
+vi.mock('../api/client', () => ({
+  api: {
+    files: {
+      upload: mockUpload,
+    },
+  },
+}));
+
+const dummyUsers: User[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpload.mockImplementation((file: File) =>
+    Promise.resolve({
+      id: 1,
+      url: `/uploads/${file.name}`,
+      originalName: file.name,
+      size: file.size,
+    }),
+  );
+});
+
+describe('RichEditor - ファイルアップロード', () => {
+  describe('ファイル選択ボタン', () => {
+    it('ファイル選択ボタンが表示される', () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      expect(screen.getByRole('button', { name: /ファイルを添付/i })).toBeInTheDocument();
+    });
+
+    it('ファイル選択ボタンをクリックするとファイルピッカーが開く', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      const clickSpy = vi.spyOn(fileInput, 'click');
+
+      await userEvent.click(screen.getByRole('button', { name: /ファイルを添付/i }));
+
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('ファイルを選択するとアップロード API が呼ばれる', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await userEvent.upload(fileInput, file);
+
+      await waitFor(() => {
+        expect(mockUpload).toHaveBeenCalledTimes(1);
+        expect(mockUpload).toHaveBeenCalledWith(file);
+      });
+    });
+
+    it('アップロード中はローディング状態を表示する', async () => {
+      let resolve!: (v: unknown) => void;
+      mockUpload.mockReturnValue(new Promise((r) => (resolve = r)));
+
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const file = new File(['hello'], 'loading.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      act(() => {
+        fireEvent.change(fileInput, { target: { files: [file] } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      });
+
+      resolve({ url: '/uploads/loading.txt', originalName: 'loading.txt', size: 5 });
+    });
+
+    it('アップロード完了後にファイル名がプレビューとして表示される', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await userEvent.upload(fileInput, file);
+
+      await waitFor(() => {
+        expect(screen.getByText('test.txt')).toBeInTheDocument();
+      });
+    });
+
+    it('プレビューの削除ボタンをクリックすると添付ファイルが除去される', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const file = new File(['hello'], 'remove.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await userEvent.upload(fileInput, file);
+      await waitFor(() => expect(screen.getByText('remove.txt')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByRole('button', { name: /remove\.txt を削除/i }));
+
+      expect(screen.queryByText('remove.txt')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ドラッグ&ドロップ', () => {
+    it('エディタ領域にファイルをドロップするとアップロード API が呼ばれる', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const dropZone = screen.getByTestId('file-drop-zone');
+      const file = new File(['content'], 'dropped.txt', { type: 'text/plain' });
+
+      fireEvent.dragOver(dropZone, { dataTransfer: { files: [file] } });
+      fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+      await waitFor(() => {
+        expect(mockUpload).toHaveBeenCalledWith(file);
+      });
+    });
+
+    it('ドラッグオーバー中にドロップゾーンのスタイルが変化する', () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const dropZone = screen.getByTestId('file-drop-zone');
+
+      fireEvent.dragOver(dropZone, { dataTransfer: { files: [] } });
+
+      expect(dropZone).toHaveAttribute('data-dragover', 'true');
+
+      fireEvent.dragLeave(dropZone);
+
+      expect(dropZone).not.toHaveAttribute('data-dragover', 'true');
+    });
+
+    it('ドロップ後にファイル名がプレビューとして表示される', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const dropZone = screen.getByTestId('file-drop-zone');
+      const file = new File(['data'], 'dropped.pdf', { type: 'application/pdf' });
+
+      mockUpload.mockResolvedValue({
+        url: '/uploads/dropped.pdf',
+        originalName: 'dropped.pdf',
+        size: 4,
+      });
+
+      fireEvent.drop(dropZone, { dataTransfer: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText('dropped.pdf')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('メッセージ送信との連携', () => {
+    it('送信時に attachmentIds が onSend コールバックに渡される', async () => {
+      mockUpload.mockResolvedValue({
+        url: '/uploads/file.txt',
+        originalName: 'file.txt',
+        size: 5,
+        id: 42,
+      });
+      const onSend = vi.fn();
+
+      render(<RichEditor users={dummyUsers} onSend={onSend} />);
+
+      const file = new File(['hello'], 'file.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await userEvent.upload(fileInput, file);
+      await waitFor(() => expect(screen.getByText('file.txt')).toBeInTheDocument());
+
+      // Enter キーで送信
+      const modules = capturedModules.value as {
+        keyboard: { bindings: { sendOnEnter: { handler: () => boolean } } };
+      };
+      act(() => {
+        modules.keyboard.bindings.sendOnEnter.handler();
+      });
+
+      expect(onSend).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.arrayContaining([42]),
+      );
+    });
+
+    it('送信後に添付ファイルのプレビューがクリアされる', async () => {
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const file = new File(['hello'], 'clear.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await userEvent.upload(fileInput, file);
+      await waitFor(() => expect(screen.getByText('clear.txt')).toBeInTheDocument());
+
+      const modules = capturedModules.value as {
+        keyboard: { bindings: { sendOnEnter: { handler: () => boolean } } };
+      };
+      act(() => {
+        modules.keyboard.bindings.sendOnEnter.handler();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('clear.txt')).not.toBeInTheDocument();
+      });
+    });
+
+    it('テキストなし・添付ファイルのみの場合も送信できる', async () => {
+      mockUpload.mockResolvedValue({
+        url: '/uploads/only.txt',
+        originalName: 'only.txt',
+        size: 3,
+        id: 99,
+      });
+      mockQuill.getText.mockReturnValue(''); // テキストなし
+      const onSend = vi.fn();
+
+      render(<RichEditor users={dummyUsers} onSend={onSend} />);
+
+      const file = new File(['hi'], 'only.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await userEvent.upload(fileInput, file);
+      await waitFor(() => expect(screen.getByText('only.txt')).toBeInTheDocument());
+
+      const modules = capturedModules.value as {
+        keyboard: { bindings: { sendOnEnter: { handler: () => boolean } } };
+      };
+      act(() => {
+        modules.keyboard.bindings.sendOnEnter.handler();
+      });
+
+      expect(onSend).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.arrayContaining([99]),
+      );
+    });
+  });
+
+  describe('異常系', () => {
+    it('アップロード失敗時にエラーメッセージを表示する', async () => {
+      mockUpload.mockRejectedValue(new Error('Upload failed'));
+
+      render(<RichEditor users={dummyUsers} onSend={vi.fn()} />);
+
+      const file = new File(['hello'], 'error.txt', { type: 'text/plain' });
+      const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+
+      await userEvent.upload(fileInput, file);
+
+      await waitFor(() => {
+        expect(screen.getByText(/アップロードに失敗しました/)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { User, Channel, Message, MessageSearchResult } from '@chat-app/shared';
+import type { Attachment, User, Channel, Message, MessageSearchResult } from '@chat-app/shared';
 
 const BASE = '/api';
 
@@ -52,6 +52,21 @@ export const api = {
     delete: (id: number) => request<void>(`/messages/${id}`, { method: 'DELETE' }),
     search: (q: string) =>
       request<{ messages: MessageSearchResult[] }>(`/messages/search?q=${encodeURIComponent(q)}`),
+  },
+  files: {
+    upload: (file: File): Promise<Attachment & { id: number }> => {
+      const form = new FormData();
+      form.append('file', file);
+      return fetch(`${BASE}/files/upload`, {
+        method: 'POST',
+        credentials: 'include',
+        body: form,
+      }).then(async (res) => {
+        const body = (await res.json()) as unknown;
+        if (!res.ok) throw new Error((body as { error?: string }).error ?? 'Upload failed');
+        return body as Attachment & { id: number };
+      });
+    },
   },
   push: {
     vapidKey: () => request<{ publicKey: string }>('/push/vapid-key'),

--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -140,17 +140,14 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
   const author = users.find((u) => u.id === message.userId);
   const displayName = author?.displayName || message.username;
 
-  const handleEdit = (content: string, mentionedUserIds: number[]) => {
-    socket?.emit('edit_message', { messageId: message.id, content, mentionedUserIds });
+  const handleEditSend = (content: string, mentionedUserIds: number[], attachmentIds: number[]) => {
+    socket?.emit('edit_message', {
+      messageId: message.id,
+      content,
+      mentionedUserIds,
+      attachmentIds,
+    });
     setEditing(false);
-  };
-
-  const handleEditSend = (
-    content: string,
-    mentionedUserIds: number[],
-    _attachmentIds: number[],
-  ) => {
-    handleEdit(content, mentionedUserIds);
   };
 
   const handleDelete = () => {
@@ -304,6 +301,7 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
               onSend={handleEditSend}
               onCancel={() => setEditing(false)}
               initialContent={message.content}
+              initialAttachments={message.attachments ?? []}
             />
           </Box>
         ) : (

--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
-import { Box, Avatar, Typography, IconButton, Tooltip, Popover, Paper } from '@mui/material';
+import { Box, Avatar, Typography, IconButton, Tooltip, Popover, Paper, Link } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
 import CloseIcon from '@mui/icons-material/Close';
 import LinkIcon from '@mui/icons-material/Link';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
+import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import type { Message, User } from '@chat-app/shared';
 import { useSocket } from '../../contexts/SocketContext';
 import RichEditor from './RichEditor';
@@ -142,6 +143,14 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
   const handleEdit = (content: string, mentionedUserIds: number[]) => {
     socket?.emit('edit_message', { messageId: message.id, content, mentionedUserIds });
     setEditing(false);
+  };
+
+  const handleEditSend = (
+    content: string,
+    mentionedUserIds: number[],
+    _attachmentIds: number[],
+  ) => {
+    handleEdit(content, mentionedUserIds);
   };
 
   const handleDelete = () => {
@@ -292,7 +301,7 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
           <Box sx={{ mt: 0.5, width: '100%' }}>
             <RichEditor
               users={users}
-              onSend={handleEdit}
+              onSend={handleEditSend}
               onCancel={() => setEditing(false)}
               initialContent={message.content}
             />
@@ -324,6 +333,52 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
               }}
             >
               {renderContent(message.content)}
+
+              {/* 添付ファイル */}
+              {message.attachments && message.attachments.length > 0 && (
+                <Box
+                  data-testid="message-attachments"
+                  sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}
+                >
+                  {message.attachments.map((attachment) => {
+                    const isImage = attachment.mimeType.startsWith('image/');
+                    return isImage ? (
+                      <Link
+                        key={attachment.id}
+                        href={attachment.url}
+                        download={attachment.originalName}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={attachment.originalName}
+                      >
+                        <Box
+                          component="img"
+                          src={attachment.url}
+                          alt={attachment.originalName}
+                          sx={{
+                            maxWidth: '100%',
+                            maxHeight: 200,
+                            borderRadius: 1,
+                            display: 'block',
+                          }}
+                        />
+                      </Link>
+                    ) : (
+                      <Link
+                        key={attachment.id}
+                        href={attachment.url}
+                        download={attachment.originalName}
+                        underline="hover"
+                        sx={{ display: 'flex', alignItems: 'center', gap: 0.5, fontSize: '0.8rem' }}
+                        aria-label={attachment.originalName}
+                      >
+                        <InsertDriveFileIcon fontSize="small" data-testid="file-icon" />
+                        <Typography variant="caption">{attachment.originalName}</Typography>
+                      </Link>
+                    );
+                  })}
+                </Box>
+              )}
             </Box>
 
             {/* アクションボタン（バブルのすぐ隣） */}

--- a/packages/client/src/components/Chat/RichEditor.tsx
+++ b/packages/client/src/components/Chat/RichEditor.tsx
@@ -4,6 +4,7 @@ import ReactQuill from 'react-quill-new';
 import 'react-quill-new/dist/quill.snow.css';
 import {
   Box,
+  CircularProgress,
   ClickAwayListener,
   IconButton,
   List,
@@ -13,10 +14,14 @@ import {
   Paper,
   Popper,
   Tooltip,
+  Typography,
 } from '@mui/material';
+import AttachFileIcon from '@mui/icons-material/AttachFile';
+import CloseIcon from '@mui/icons-material/Close';
 import EmojiEmotionsIcon from '@mui/icons-material/EmojiEmotions';
-import type { User } from '@chat-app/shared';
+import type { Attachment, User } from '@chat-app/shared';
 import type { MentionData } from './MentionBlot';
+import { api } from '../../api/client';
 
 const COMMON_EMOJIS = [
   '😀',
@@ -91,9 +96,13 @@ interface VirtualElement {
   getBoundingClientRect: () => DOMRect;
 }
 
+interface PendingAttachment extends Attachment {
+  id: number;
+}
+
 interface Props {
   users: User[];
-  onSend: (content: string, mentionedUserIds: number[]) => void;
+  onSend: (content: string, mentionedUserIds: number[], attachmentIds: number[]) => void;
   onCancel?: () => void;
   initialContent?: string;
   disabled?: boolean;
@@ -103,6 +112,13 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
   const quillRef = useRef<ReactQuill>(null);
   const [mentionState, setMentionState] = useState<MentionState | null>(null);
   const [emojiAnchor, setEmojiAnchor] = useState<HTMLElement | null>(null);
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const attachmentsRef = useRef(attachments);
+  attachmentsRef.current = attachments;
 
   // Refs so stable `modules` closure always reads fresh values
   const usersRef = useRef(users);
@@ -158,12 +174,27 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
     setEmojiAnchor(null);
   }, []);
 
+  // --- Upload file ---
+  const uploadFile = useCallback(async (file: File) => {
+    setUploading(true);
+    setUploadError(null);
+    try {
+      const result = await api.files.upload(file);
+      setAttachments((prev) => [...prev, result]);
+    } catch {
+      setUploadError('アップロードに失敗しました');
+    } finally {
+      setUploading(false);
+    }
+  }, []);
+
   // --- Send message ---
   const doSend = useCallback(() => {
     const quill = quillRef.current?.getEditor();
     if (!quill) return;
     const text = quill.getText().trim();
-    if (!text) return;
+    const currentAttachments = attachmentsRef.current;
+    if (!text && currentAttachments.length === 0) return;
 
     const delta = quill.getContents();
     const ops = (delta.ops ?? []) as DeltaOp[];
@@ -175,9 +206,11 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
       ),
     ];
 
-    onSendRef.current(JSON.stringify(delta), mentionedIds);
+    const attachmentIds = currentAttachments.map((a) => a.id);
+    onSendRef.current(JSON.stringify(delta), mentionedIds, attachmentIds);
     quill.setText('');
     quill.focus();
+    setAttachments([]);
   }, []);
   const doSendRef = useRef(doSend);
   doSendRef.current = doSend;
@@ -300,7 +333,6 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
       quill.off('text-change', detectDeferred);
       quill.off('selection-change', handleSelectionChange);
     };
-     
   }, []); // run once after mount
 
   // --- Popper virtual anchor at the cursor position ---
@@ -339,16 +371,32 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
 
   return (
     <Box
+      data-testid="file-drop-zone"
+      data-dragover={dragOver ? 'true' : undefined}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setDragOver(true);
+      }}
+      onDragLeave={() => setDragOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragOver(false);
+        const files = Array.from(e.dataTransfer.files);
+        files.forEach((f) => void uploadFile(f));
+      }}
       sx={{
         position: 'relative',
         opacity: disabled ? 0.6 : 1,
         pointerEvents: disabled ? 'none' : 'auto',
+        outline: dragOver ? '2px dashed' : 'none',
+        outlineColor: 'primary.main',
+        borderRadius: 1,
         '& .ql-editor': {
           minHeight: 60,
           maxHeight: 200,
           overflowY: 'auto',
           fontSize: '0.875rem',
-          paddingRight: '36px', // room for emoji button
+          paddingRight: '72px', // room for emoji + attach buttons
         },
         '& .ql-editor.ql-blank::before': { fontStyle: 'normal', color: '#aaa' },
         '& .ql-mention': {
@@ -362,6 +410,19 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
         },
       }}
     >
+      {/* 隠しファイル入力 */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          files.forEach((f) => void uploadFile(f));
+          e.target.value = '';
+        }}
+      />
+
       <ReactQuill
         ref={quillRef}
         theme="snow"
@@ -370,6 +431,64 @@ export default function RichEditor({ users, onSend, onCancel, initialContent, di
         placeholder="メッセージを入力… (@ でメンション、Enter で送信、Shift+Enter で改行)"
         readOnly={disabled}
       />
+
+      {/* 添付ファイルプレビュー */}
+      {attachments.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, px: 1, pt: 0.5 }}>
+          {attachments.map((a) => (
+            <Box
+              key={a.id}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.25,
+                bgcolor: 'grey.100',
+                borderRadius: 2,
+                px: 1,
+                py: 0.25,
+              }}
+            >
+              <Typography variant="caption">{a.originalName}</Typography>
+              <IconButton
+                size="small"
+                aria-label={`${a.originalName} を削除`}
+                onClick={() => setAttachments((prev) => prev.filter((x) => x.id !== a.id))}
+                sx={{ p: 0.1 }}
+              >
+                <CloseIcon sx={{ fontSize: '0.8rem' }} />
+              </IconButton>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {/* アップロードエラー */}
+      {uploadError && (
+        <Typography variant="caption" color="error" sx={{ px: 1 }}>
+          {uploadError}
+        </Typography>
+      )}
+
+      {/* ファイル添付ボタン — エディタ右下に絶対配置（絵文字の左） */}
+      <Box sx={{ position: 'absolute', bottom: 6, right: 34, zIndex: 10 }}>
+        {uploading ? (
+          <CircularProgress size={18} sx={{ color: 'text.secondary' }} role="progressbar" />
+        ) : (
+          <Tooltip title="ファイルを添付">
+            <IconButton
+              size="small"
+              aria-label="ファイルを添付"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                fileInputRef.current?.click();
+              }}
+              sx={{ p: 0.25 }}
+            >
+              <AttachFileIcon fontSize="small" sx={{ color: 'text.secondary' }} />
+            </IconButton>
+          </Tooltip>
+        )}
+      </Box>
 
       {/* 絵文字ボタン — エディタ右下に絶対配置 */}
       <Box sx={{ position: 'absolute', bottom: 6, right: 6, zIndex: 10 }}>

--- a/packages/client/src/components/Chat/RichEditor.tsx
+++ b/packages/client/src/components/Chat/RichEditor.tsx
@@ -105,14 +105,24 @@ interface Props {
   onSend: (content: string, mentionedUserIds: number[], attachmentIds: number[]) => void;
   onCancel?: () => void;
   initialContent?: string;
+  initialAttachments?: Attachment[];
   disabled?: boolean;
 }
 
-export default function RichEditor({ users, onSend, onCancel, initialContent, disabled }: Props) {
+export default function RichEditor({
+  users,
+  onSend,
+  onCancel,
+  initialContent,
+  initialAttachments,
+  disabled,
+}: Props) {
   const quillRef = useRef<ReactQuill>(null);
   const [mentionState, setMentionState] = useState<MentionState | null>(null);
   const [emojiAnchor, setEmojiAnchor] = useState<HTMLElement | null>(null);
-  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const [attachments, setAttachments] = useState<PendingAttachment[]>(
+    (initialAttachments ?? []) as PendingAttachment[],
+  );
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -47,9 +47,14 @@ export default function ChatPage({ users }: Props) {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  const handleSend = (content: string, mentionedUserIds: number[]) => {
+  const handleSend = (content: string, mentionedUserIds: number[], attachmentIds: number[]) => {
     if (!activeChannelId || !socket) return;
-    socket.emit('send_message', { channelId: activeChannelId, content, mentionedUserIds });
+    socket.emit('send_message', {
+      channelId: activeChannelId,
+      content,
+      mentionedUserIds,
+      attachmentIds,
+    });
   };
 
   // 検索結果から投稿へ移動

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@chat-app/shared": "*",
+    "@types/multer": "^2.1.0",
     "bcrypt": "^5.1.1",
     "better-sqlite3": "^9.4.3",
     "cookie-parser": "^1.4.6",
@@ -18,6 +19,7 @@
     "dotenv": "^17.4.1",
     "express": "^4.18.3",
     "jsonwebtoken": "^9.0.2",
+    "multer": "^2.1.1",
     "socket.io": "^4.7.4",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.0",

--- a/packages/server/src/__tests__/fileStorage.test.ts
+++ b/packages/server/src/__tests__/fileStorage.test.ts
@@ -1,0 +1,166 @@
+/**
+ * services/fileStorageService.ts + POST /api/files/upload のテスト
+ *
+ * テスト対象: ファイルアップロード保存機能 / アップロードエンドポイント
+ * 戦略:
+ *   - jest.mock('fs') で fs を差し替え、実際のディスク書き込みを防ぐ
+ *   - supertest で POST /api/files/upload の統合テストを行う
+ *   - DB は better-sqlite3 インメモリを使用する
+ *   - multer によるマルチパートパースを supertest の .attach() でテストする
+ */
+
+jest.mock('../db/database', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const Db = require('better-sqlite3') as typeof import('better-sqlite3');
+  const db = new Db(':memory:');
+  db.pragma('foreign_keys = ON');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../db/database')>('../db/database');
+  init(db);
+  return { getDatabase: () => db, initializeSchema: init, closeDatabase: jest.fn() };
+});
+
+jest.mock('fs', () => {
+  const actual = jest.requireActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    mkdirSync: jest.fn(),
+    writeFileSync: jest.fn(),
+    existsSync: jest.fn().mockImplementation((p: unknown) => {
+      if (typeof p === 'string' && p.includes('uploads')) return false;
+      return actual.existsSync(p as import('fs').PathLike);
+    }),
+  };
+});
+
+import * as fs from 'fs';
+import path from 'path';
+import request from 'supertest';
+import { saveFile } from '../services/fileStorageService';
+import { createApp } from '../app';
+import { register } from '../services/authService';
+import { generateToken } from '../middleware/auth';
+
+describe('FileStorageService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockImplementation((p: unknown) => {
+      const actual = jest.requireActual<typeof import('fs')>('fs');
+      if (typeof p === 'string' && p.includes('uploads')) return false;
+      return actual.existsSync(p as import('fs').PathLike);
+    });
+  });
+
+  describe('saveFile', () => {
+    it('バイナリデータを uploads/ ディレクトリに保存できる', () => {
+      const buffer = Buffer.from('hello world');
+      saveFile(buffer, 'hello.txt', 'text/plain');
+
+      expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+      const [filePath] = (fs.writeFileSync as jest.Mock).mock.calls[0] as [string, Buffer];
+      expect(filePath).toContain(path.join('uploads'));
+    });
+
+    it('保存されたファイルの公開 URL を返す', () => {
+      const buffer = Buffer.from('dummy');
+      const result = saveFile(buffer, 'test.pdf', 'application/pdf');
+
+      expect(result.url).toMatch(/^\/uploads\//);
+    });
+
+    it('uploads/ ディレクトリが存在しない場合は自動作成する', () => {
+      (fs.existsSync as jest.Mock).mockReturnValue(false);
+
+      const buffer = Buffer.from('data');
+      saveFile(buffer, 'file.txt', 'text/plain');
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining('uploads'), {
+        recursive: true,
+      });
+    });
+
+    it('元のファイル名・拡張子を含むファイル名で保存する', () => {
+      const buffer = Buffer.from('content');
+      saveFile(buffer, 'document.pdf', 'application/pdf');
+
+      const [filePath] = (fs.writeFileSync as jest.Mock).mock.calls[0] as [string, Buffer];
+      expect(filePath).toMatch(/document.*\.pdf$/);
+    });
+  });
+});
+
+describe('POST /api/files/upload', () => {
+  let app: ReturnType<typeof createApp>;
+  let token: string;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (fs.existsSync as jest.Mock).mockImplementation((p: unknown) => {
+      const actual = jest.requireActual<typeof import('fs')>('fs');
+      if (typeof p === 'string' && p.includes('uploads')) return false;
+      return actual.existsSync(p as import('fs').PathLike);
+    });
+    app = createApp();
+    const user = await register(
+      `fileuser_${Date.now()}`,
+      `fileuser_${Date.now()}@example.com`,
+      'password123',
+    );
+    token = generateToken(user.id, user.username);
+  });
+
+  describe('正常系', () => {
+    it('認証済みユーザーがファイルをアップロードすると 200 と { url, originalName, size } を返す', async () => {
+      const buffer = Buffer.from('test file content');
+
+      const res = await request(app)
+        .post('/api/files/upload')
+        .set('Cookie', `token=${token}`)
+        .attach('file', buffer, 'test.txt');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        url: expect.stringMatching(/^\/uploads\//),
+        originalName: 'test.txt',
+        size: expect.any(Number),
+      });
+    });
+
+    it('画像・テキスト・PDF など複数の MIME タイプのファイルをアップロードできる', async () => {
+      const cases = [
+        { name: 'image.png', mime: 'image/png' },
+        { name: 'doc.pdf', mime: 'application/pdf' },
+        { name: 'note.txt', mime: 'text/plain' },
+      ];
+
+      for (const { name } of cases) {
+        const res = await request(app)
+          .post('/api/files/upload')
+          .set('Cookie', `token=${token}`)
+          .attach('file', Buffer.from('data'), name);
+
+        expect(res.status).toBe(200);
+        expect(res.body.originalName).toBe(name);
+      }
+    });
+  });
+
+  describe('異常系', () => {
+    it('未認証のリクエストは 401 を返す', async () => {
+      const res = await request(app)
+        .post('/api/files/upload')
+        .attach('file', Buffer.from('data'), 'test.txt');
+
+      expect(res.status).toBe(401);
+    });
+
+    it('ファイルが添付されていない場合は 400 を返す', async () => {
+      const res = await request(app)
+        .post('/api/files/upload')
+        .set('Cookie', `token=${token}`)
+        .send();
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -6,6 +6,7 @@ import authRoutes from './routes/auth';
 import channelRoutes from './routes/channels';
 import messageRoutes from './routes/messages';
 import pushRoutes from './routes/push';
+import fileRoutes from './routes/files';
 import { errorHandler } from './middleware/errorHandler';
 import { setupSwagger } from './swagger/setup';
 
@@ -31,6 +32,7 @@ export function createApp() {
   app.use('/api/channels', channelRoutes);
   app.use('/api/messages', messageRoutes);
   app.use('/api/push', pushRoutes);
+  app.use('/api/files', fileRoutes);
 
   app.use(errorHandler);
 

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -65,6 +65,16 @@ export function initializeSchema(database: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
+    CREATE TABLE IF NOT EXISTS message_attachments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE,
+      url TEXT NOT NULL,
+      original_name TEXT NOT NULL,
+      size INTEGER NOT NULL,
+      mime_type TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
     CREATE TABLE IF NOT EXISTS push_subscriptions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -94,6 +94,32 @@ export function initializeSchema(database: Database.Database): void {
       database.exec(`ALTER TABLE users ADD COLUMN ${col} TEXT`);
     }
   }
+
+  // message_attachments.message_id が NOT NULL 制約付きで作られていた場合は再作成する
+  // （SQLite は ALTER COLUMN をサポートしないためテーブルを作り直す）
+  const attachmentCols = database.prepare('PRAGMA table_info(message_attachments)').all() as {
+    name: string;
+    notnull: number;
+  }[];
+  const messageIdCol = attachmentCols.find((c) => c.name === 'message_id');
+  if (messageIdCol && messageIdCol.notnull === 1) {
+    database.exec(`
+      PRAGMA foreign_keys = OFF;
+      CREATE TABLE message_attachments_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE,
+        url TEXT NOT NULL,
+        original_name TEXT NOT NULL,
+        size INTEGER NOT NULL,
+        mime_type TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO message_attachments_new SELECT * FROM message_attachments;
+      DROP TABLE message_attachments;
+      ALTER TABLE message_attachments_new RENAME TO message_attachments;
+      PRAGMA foreign_keys = ON;
+    `);
+  }
 }
 
 export function closeDatabase(): void {

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { authenticateToken } from '../middleware/auth';
+import { saveFile } from '../services/fileStorageService';
+import { getDatabase } from '../db/database';
+import { createError } from '../middleware/errorHandler';
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+/**
+ * POST /api/files/upload
+ * ファイルをアップロードし、メタデータを DB に保存して URL を返す。
+ */
+router.post('/upload', authenticateToken, upload.single('file'), (req, res, next) => {
+  try {
+    if (!req.file) {
+      throw createError('ファイルが指定されていません', 400);
+    }
+
+    const { originalname, mimetype, buffer } = req.file;
+    const saved = saveFile(buffer, originalname, mimetype);
+
+    const db = getDatabase();
+    const result = db
+      .prepare(
+        'INSERT INTO message_attachments (message_id, url, original_name, size, mime_type) VALUES (NULL, ?, ?, ?, ?)',
+      )
+      .run(saved.url, saved.originalName, saved.size, mimetype);
+
+    res.json({
+      id: result.lastInsertRowid,
+      url: saved.url,
+      originalName: saved.originalName,
+      size: saved.size,
+      mimeType: mimetype,
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/packages/server/src/services/fileStorageService.ts
+++ b/packages/server/src/services/fileStorageService.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
+
+export interface SavedFile {
+  url: string;
+  originalName: string;
+  size: number;
+}
+
+/**
+ * バイナリデータを uploads/ ディレクトリに保存し公開 URL を返す。
+ */
+export function saveFile(buffer: Buffer, originalName: string, _mimeType: string): SavedFile {
+  if (!fs.existsSync(UPLOAD_DIR)) {
+    fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+  }
+
+  const ext = path.extname(originalName);
+  const basename = path.basename(originalName, ext);
+  const filename = `${basename}_${Date.now()}${ext}`;
+  const filePath = path.join(UPLOAD_DIR, filename);
+
+  fs.writeFileSync(filePath, buffer);
+
+  return {
+    url: `/uploads/${filename}`,
+    originalName,
+    size: buffer.length,
+  };
+}

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -1,5 +1,5 @@
 import { getDatabase } from '../db/database';
-import { Message, MessageSearchResult } from '@chat-app/shared';
+import { Attachment, Message, MessageSearchResult } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
 
 interface MessageRow {
@@ -30,6 +30,28 @@ function getMentions(messageId: number): number[] {
   return rows.map((r) => r.mentioned_user_id);
 }
 
+function getAttachments(messageId: number): Attachment[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      'SELECT id, url, original_name, size, mime_type FROM message_attachments WHERE message_id = ?',
+    )
+    .all(messageId) as {
+    id: number;
+    url: string;
+    original_name: string;
+    size: number;
+    mime_type: string;
+  }[];
+  return rows.map((r) => ({
+    id: r.id,
+    url: r.url,
+    originalName: r.original_name,
+    size: r.size,
+    mimeType: r.mime_type,
+  }));
+}
+
 function toMessage(row: MessageRow): Message {
   return {
     id: row.id,
@@ -43,6 +65,7 @@ function toMessage(row: MessageRow): Message {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     mentions: getMentions(row.id),
+    attachments: getAttachments(row.id),
   };
 }
 
@@ -69,6 +92,7 @@ export function createMessage(
   userId: number,
   content: string,
   mentionedUserIds: number[] = [],
+  attachmentIds: number[] = [],
 ): Message {
   const db = getDatabase();
 
@@ -83,6 +107,13 @@ export function createMessage(
       'INSERT OR IGNORE INTO mentions (message_id, mentioned_user_id) VALUES (?, ?)',
     );
     for (const uid of mentionedUserIds) insertMention.run(messageId, uid);
+  }
+
+  if (attachmentIds.length > 0) {
+    const updateAttachment = db.prepare(
+      'UPDATE message_attachments SET message_id = ? WHERE id = ?',
+    );
+    for (const aid of attachmentIds) updateAttachment.run(messageId, aid);
   }
 
   const row = db.prepare(MESSAGE_SELECT + ' WHERE m.id = ?').get(messageId) as MessageRow;

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -125,6 +125,7 @@ export function editMessage(
   userId: number,
   content: string,
   mentionedUserIds: number[] = [],
+  attachmentIds: number[] = [],
 ): Message {
   const db = getDatabase();
 
@@ -145,6 +146,17 @@ export function editMessage(
       'INSERT OR IGNORE INTO mentions (message_id, mentioned_user_id) VALUES (?, ?)',
     );
     for (const uid of mentionedUserIds) insertMention.run(messageId, uid);
+  }
+
+  // 既存添付を一旦すべて切り離し、今回指定されたIDのみ紐付ける
+  db.prepare('UPDATE message_attachments SET message_id = NULL WHERE message_id = ?').run(
+    messageId,
+  );
+  if (attachmentIds.length > 0) {
+    const updateAttachment = db.prepare(
+      'UPDATE message_attachments SET message_id = ? WHERE id = ?',
+    );
+    for (const aid of attachmentIds) updateAttachment.run(messageId, aid);
   }
 
   const row = db.prepare(MESSAGE_SELECT + ' WHERE m.id = ?').get(messageId) as MessageRow;

--- a/packages/server/src/socket/handler.ts
+++ b/packages/server/src/socket/handler.ts
@@ -86,6 +86,7 @@ export function setupSocketHandlers(io: ChatServer): void {
           userId,
           data.content,
           data.mentionedUserIds,
+          data.attachmentIds,
         );
         io.to(`channel:${message.channelId}`).emit('message_edited', message);
       } catch {

--- a/packages/server/src/socket/handler.ts
+++ b/packages/server/src/socket/handler.ts
@@ -11,7 +11,12 @@ import {
 
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-please-change-in-production';
 
-type ChatServer = SocketServer<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>;
+type ChatServer = SocketServer<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  InterServerEvents,
+  SocketData
+>;
 
 export function setupSocketHandlers(io: ChatServer): void {
   // Auth middleware: verify JWT from cookie or auth header
@@ -20,7 +25,10 @@ export function setupSocketHandlers(io: ChatServer): void {
     const tokenMatch = cookieHeader.match(/(?:^|;\s*)token=([^;]+)/);
     const token = tokenMatch?.[1] ?? (socket.handshake.auth as { token?: string }).token;
 
-    if (!token) { next(new Error('Unauthorized')); return; }
+    if (!token) {
+      next(new Error('Unauthorized'));
+      return;
+    }
 
     try {
       const payload = jwt.verify(token, JWT_SECRET) as { userId: number; username: string };
@@ -50,6 +58,7 @@ export function setupSocketHandlers(io: ChatServer): void {
           userId,
           data.content,
           data.mentionedUserIds,
+          (data as { attachmentIds?: number[] }).attachmentIds,
         );
 
         io.to(`channel:${data.channelId}`).emit('new_message', message);

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -1,3 +1,11 @@
+export interface Attachment {
+  id: number;
+  url: string;
+  originalName: string;
+  size: number;
+  mimeType: string;
+}
+
 export interface Message {
   id: number;
   channelId: number;
@@ -10,6 +18,7 @@ export interface Message {
   createdAt: string;
   updatedAt: string;
   mentions: number[];
+  attachments?: Attachment[];
 }
 
 export interface MessageSearchResult extends Message {
@@ -20,6 +29,7 @@ export interface SendMessageInput {
   channelId: number;
   content: string;
   mentionedUserIds?: number[];
+  attachmentIds?: number[];
 }
 
 export interface EditMessageInput {

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -18,7 +18,12 @@ export interface ClientToServerEvents {
     mentionedUserIds?: number[];
     attachmentIds?: number[];
   }) => void;
-  edit_message: (data: { messageId: number; content: string; mentionedUserIds?: number[] }) => void;
+  edit_message: (data: {
+    messageId: number;
+    content: string;
+    mentionedUserIds?: number[];
+    attachmentIds?: number[];
+  }) => void;
   delete_message: (messageId: number) => void;
   typing_start: (channelId: number) => void;
   typing_stop: (channelId: number) => void;

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -12,7 +12,12 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
   join_channel: (channelId: number) => void;
   leave_channel: (channelId: number) => void;
-  send_message: (data: { channelId: number; content: string; mentionedUserIds?: number[] }) => void;
+  send_message: (data: {
+    channelId: number;
+    content: string;
+    mentionedUserIds?: number[];
+    attachmentIds?: number[];
+  }) => void;
   edit_message: (data: { messageId: number; content: string; mentionedUserIds?: number[] }) => void;
   delete_message: (messageId: number) => void;
   typing_start: (channelId: number) => void;


### PR DESCRIPTION
## Summary

- チャット入力エリアへのドラッグ&ドロップとファイル選択ボタンでファイルを添付可能
- `POST /api/files/upload` エンドポイントでサーバーの `uploads/` ディレクトリに保存（アバターと同じストレージ方式）
- `message_attachments` テーブルでメッセージとファイルを紐付け（アップロード時は `message_id = NULL`、送信時に紐付け）
- 投稿メッセージに添付ファイルを表示：画像はサムネイル、非画像はアイコン＋ファイル名でダウンロードリンクを提供

## Test plan

- [x] `npm run build` 通過
- [x] `npm run test` 通過（サーバー 103件、クライアント 143件）
- [x] `fileStorage.test.ts`：saveFile サービス + アップロードエンドポイントの統合テスト
- [x] `RichEditorFileUpload.test.tsx`：ファイル選択・D&D・プレビュー・送信連携テスト
- [x] `MessageItemAttachment.test.tsx`：添付ファイル表示・ダウンロードリンクテスト

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)