### PR TITLE
feat: プライベートチャンネル機能を追加

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -90,6 +90,12 @@ table "channels" {
     type    = integer
     comment = "作成者ユーザーID"
   }
+  column "is_private" {
+    null    = false
+    type    = integer
+    default = 0
+    comment = "プライベートチャンネルフラグ（0: 公開, 1: プライベート）"
+  }
   column "created_at" {
     null    = false
     type    = text

--- a/packages/client/src/__tests__/ChannelList.test.tsx
+++ b/packages/client/src/__tests__/ChannelList.test.tsx
@@ -28,8 +28,15 @@ import { api } from '../api/client';
 const mockList = api.channels.list as ReturnType<typeof vi.fn>;
 const mockCreate = api.channels.create as ReturnType<typeof vi.fn>;
 
-function makeChannel(id: number, name: string): Channel {
-  return { id, name, description: null, createdBy: 1, createdAt: '2024-01-01T00:00:00Z' };
+function makeChannel(id: number, name: string, isPrivate = false): Channel {
+  return {
+    id,
+    name,
+    description: null,
+    createdBy: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    isPrivate,
+  };
 }
 
 beforeEach(() => {
@@ -128,6 +135,31 @@ describe('ChannelList', () => {
       await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => expect(onSelect).toHaveBeenCalledWith(5));
+    });
+  });
+
+  describe('プライベートチャンネルの鍵アイコン表示', () => {
+    it('isPrivate=true のチャンネルに鍵アイコン（LockIcon）が表示される', async () => {
+      mockList.mockResolvedValue({
+        channels: [makeChannel(1, 'secret', true)],
+      });
+
+      render(<ChannelList activeChannelId={null} onSelect={vi.fn()} />);
+      await waitFor(() => screen.getByText('# secret'));
+
+      // aria-label="private channel" で鍵アイコンを識別する
+      expect(screen.getByLabelText('private channel')).toBeInTheDocument();
+    });
+
+    it('isPrivate=false のチャンネルに鍵アイコンは表示されない', async () => {
+      mockList.mockResolvedValue({
+        channels: [makeChannel(1, 'general', false)],
+      });
+
+      render(<ChannelList activeChannelId={null} onSelect={vi.fn()} />);
+      await waitFor(() => screen.getByText('# general'));
+
+      expect(screen.queryByLabelText('private channel')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/client/src/__tests__/CreateChannelDialog.test.tsx
+++ b/packages/client/src/__tests__/CreateChannelDialog.test.tsx
@@ -25,8 +25,15 @@ vi.mock('../api/client', () => ({
 import { api } from '../api/client';
 const mockCreate = api.channels.create as ReturnType<typeof vi.fn>;
 
-function makeChannel(id: number, name: string): Channel {
-  return { id, name, description: null, createdBy: 1, createdAt: '2024-01-01T00:00:00Z' };
+function makeChannel(id: number, name: string, isPrivate = false): Channel {
+  return {
+    id,
+    name,
+    description: null,
+    createdBy: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    isPrivate,
+  };
 }
 
 const defaultProps = {
@@ -72,6 +79,44 @@ describe('CreateChannelDialog', () => {
     });
   });
 
+  describe('プライベートチャンネル', () => {
+    it('プライベートチャンネルのトグルスイッチが表示される', () => {
+      render(<CreateChannelDialog {...defaultProps} />);
+
+      expect(screen.getByLabelText(/private/i)).toBeInTheDocument();
+    });
+
+    it('トグルをオンにすると isPrivate=true で API が呼ばれる', async () => {
+      mockCreate.mockResolvedValue({ channel: { ...makeChannel(1, 'secret'), isPrivate: true } });
+
+      render(<CreateChannelDialog {...defaultProps} />);
+      await userEvent.type(screen.getByLabelText(/channel name/i), 'secret');
+      await userEvent.click(screen.getByLabelText(/private/i));
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() =>
+        expect(mockCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'secret', isPrivate: true }),
+        ),
+      );
+    });
+
+    it('トグルがオフのとき isPrivate=false で API が呼ばれる', async () => {
+      mockCreate.mockResolvedValue({ channel: makeChannel(1, 'public') });
+
+      render(<CreateChannelDialog {...defaultProps} />);
+      await userEvent.type(screen.getByLabelText(/channel name/i), 'public');
+      // トグルはデフォルト OFF のままにする
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() =>
+        expect(mockCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'public', isPrivate: false }),
+        ),
+      );
+    });
+  });
+
   describe('送信フロー', () => {
     it('フォームを送信すると api.channels.create が呼ばれる', async () => {
       mockCreate.mockResolvedValue({ channel: makeChannel(1, 'general') });
@@ -81,9 +126,7 @@ describe('CreateChannelDialog', () => {
       await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
-        expect(mockCreate).toHaveBeenCalledWith(
-          expect.objectContaining({ name: 'general' }),
-        ),
+        expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'general' })),
       );
     });
 

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -32,10 +32,22 @@ export const api = {
   },
   channels: {
     list: () => request<{ channels: Channel[] }>('/channels'),
-    create: (data: { name: string; description?: string }) =>
-      request<{ channel: Channel }>('/channels', { method: 'POST', body: JSON.stringify(data) }),
+    create: (data: { name: string; description?: string; isPrivate?: boolean }) =>
+      request<{ channel: Channel }>('/channels', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: data.name,
+          description: data.description,
+          is_private: data.isPrivate,
+        }),
+      }),
     delete: (id: number) => request<void>(`/channels/${id}`, { method: 'DELETE' }),
     join: (id: number) => request<void>(`/channels/${id}/join`, { method: 'POST' }),
+    addMember: (channelId: number, userId: number) =>
+      request<void>(`/channels/${channelId}/members`, {
+        method: 'POST',
+        body: JSON.stringify({ userId }),
+      }),
   },
   messages: {
     list: (channelId: number, params?: { limit?: number; before?: number }) => {

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -15,6 +15,7 @@ import AddIcon from '@mui/icons-material/Add';
 import SearchIcon from '@mui/icons-material/Search';
 import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
+import LockIcon from '@mui/icons-material/Lock';
 import type { Channel } from '@chat-app/shared';
 import { api } from '../../api/client';
 import CreateChannelDialog from './CreateChannelDialog';
@@ -153,6 +154,12 @@ export default function ChannelList({ activeChannelId, onSelect }: Props) {
                   selected={ch.id === activeChannelId}
                   onClick={() => onSelect(ch.id)}
                 >
+                  {ch.isPrivate && (
+                    <LockIcon
+                      aria-label="private channel"
+                      sx={{ fontSize: 12, mr: 0.5, color: 'text.secondary' }}
+                    />
+                  )}
                   <ListItemText
                     primary={`# ${ch.name}`}
                     primaryTypographyProps={{ fontSize: 14 }}
@@ -190,6 +197,12 @@ export default function ChannelList({ activeChannelId, onSelect }: Props) {
               }
             >
               <ListItemButton selected={ch.id === activeChannelId} onClick={() => onSelect(ch.id)}>
+                {ch.isPrivate && (
+                  <LockIcon
+                    aria-label="private channel"
+                    sx={{ fontSize: 12, mr: 0.5, color: 'text.secondary' }}
+                  />
+                )}
                 <ListItemText primary={`# ${ch.name}`} primaryTypographyProps={{ fontSize: 14 }} />
               </ListItemButton>
             </ListItem>

--- a/packages/client/src/components/Channel/CreateChannelDialog.tsx
+++ b/packages/client/src/components/Channel/CreateChannelDialog.tsx
@@ -1,7 +1,14 @@
 import { useState, FormEvent } from 'react';
 import {
-  Button, Dialog, DialogActions, DialogContent, DialogTitle,
-  TextField, Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+  Alert,
+  FormControlLabel,
+  Switch,
 } from '@mui/material';
 import { api } from '../../api/client';
 import type { Channel } from '@chat-app/shared';
@@ -15,6 +22,7 @@ interface Props {
 export default function CreateChannelDialog({ open, onClose, onCreate }: Props) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [isPrivate, setIsPrivate] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -23,10 +31,15 @@ export default function CreateChannelDialog({ open, onClose, onCreate }: Props) 
     setError('');
     setLoading(true);
     try {
-      const { channel } = await api.channels.create({ name, description: description || undefined });
+      const { channel } = await api.channels.create({
+        name,
+        description: description || undefined,
+        isPrivate,
+      });
       onCreate(channel);
       setName('');
       setDescription('');
+      setIsPrivate(false);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create channel');
@@ -56,6 +69,16 @@ export default function CreateChannelDialog({ open, onClose, onCreate }: Props) 
             fullWidth
             multiline
             rows={2}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={isPrivate}
+                onChange={(e) => setIsPrivate(e.target.checked)}
+                inputProps={{ 'aria-label': 'Private channel' }}
+              />
+            }
+            label="Private"
           />
         </DialogContent>
         <DialogActions>

--- a/packages/server/src/__tests__/channel.test.ts
+++ b/packages/server/src/__tests__/channel.test.ts
@@ -12,7 +12,16 @@
  * beforeAll でテスト用オーナーユーザーを直接 INSERT している。
  */
 
-import { getAllChannels, getChannelById, createChannel, deleteChannel } from '../services/channelService';
+import {
+  getAllChannels,
+  getChannelById,
+  createChannel,
+  deleteChannel,
+  createPrivateChannel,
+  addChannelMember,
+  getChannelsForUser,
+} from '../services/channelService';
+import type { Channel } from '@chat-app/shared';
 import { initializeSchema } from '../db/database';
 import DatabaseLib from 'better-sqlite3';
 
@@ -25,7 +34,8 @@ jest.mock('../db/database', () => {
   const DB = require('better-sqlite3') as typeof import('better-sqlite3');
   const db = new DB(':memory:');
   db.pragma('foreign_keys = ON');
-  const { initializeSchema: init } = jest.requireActual<typeof import('../db/database')>('../db/database');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../db/database')>('../db/database');
   init(db);
   return {
     getDatabase: () => db,
@@ -41,7 +51,9 @@ beforeAll(() => {
   const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
   const db = getDatabase() as InstanceType<typeof DB>;
   const result = db
-    .prepare("INSERT INTO users (username, email, password_hash) VALUES ('owner', 'owner@test.com', 'hash')")
+    .prepare(
+      "INSERT INTO users (username, email, password_hash) VALUES ('owner', 'owner@test.com', 'hash')",
+    )
     .run();
   testUserId = result.lastInsertRowid as number;
 });
@@ -107,6 +119,100 @@ describe('ChannelService', () => {
 
     it('存在しないチャンネルを削除しようとすると 404 を投げる', () => {
       expect(() => deleteChannel(99999, testUserId)).toThrow(
+        expect.objectContaining({ statusCode: 404 }),
+      );
+    });
+  });
+});
+
+describe('PrivateChannel（プライベートチャンネル）', () => {
+  let anotherUserId: number;
+
+  beforeAll(() => {
+    const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+    const db = getDatabase() as ReturnType<typeof DatabaseLib>;
+    const result = db
+      .prepare(
+        "INSERT INTO users (username, email, password_hash) VALUES ('member', 'member@test.com', 'hash')",
+      )
+      .run();
+    anotherUserId = result.lastInsertRowid as number;
+  });
+
+  describe('createPrivateChannel', () => {
+    it('isPrivate=true のプライベートチャンネルを作成でき、作成者が初期メンバーになる', () => {
+      const channel = createPrivateChannel('private-ch', undefined, testUserId, []);
+
+      expect(channel.isPrivate).toBe(true);
+
+      // 作成者が channel_members に追加されていることを DB で確認
+      const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+      const db = getDatabase() as ReturnType<typeof DatabaseLib>;
+      const member = db
+        .prepare('SELECT * FROM channel_members WHERE channel_id = ? AND user_id = ?')
+        .get(channel.id, testUserId);
+      expect(member).toBeDefined();
+    });
+
+    it('指定したメンバーIDも初期メンバーとして追加される', () => {
+      const channel = createPrivateChannel('private-ch2', undefined, testUserId, [anotherUserId]);
+
+      const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+      const db = getDatabase() as ReturnType<typeof DatabaseLib>;
+      const member = db
+        .prepare('SELECT * FROM channel_members WHERE channel_id = ? AND user_id = ?')
+        .get(channel.id, anotherUserId);
+      expect(member).toBeDefined();
+    });
+  });
+
+  describe('getChannelsForUser', () => {
+    it('公開チャンネルは全ユーザーに返る', () => {
+      const pub = createChannel('pub-ch-for-user', undefined, testUserId);
+
+      const channels = getChannelsForUser(anotherUserId);
+      expect(channels.some((c: Channel) => c.id === pub.id)).toBe(true);
+    });
+
+    it('プライベートチャンネルはメンバーのユーザーにのみ返る', () => {
+      const priv = createPrivateChannel('priv-member', undefined, testUserId, [anotherUserId]);
+
+      const channels = getChannelsForUser(anotherUserId);
+      expect(channels.some((c: Channel) => c.id === priv.id)).toBe(true);
+    });
+
+    it('プライベートチャンネルは非メンバーのユーザーには返らない', () => {
+      const priv = createPrivateChannel('priv-no-member', undefined, testUserId, []);
+
+      const channels = getChannelsForUser(anotherUserId);
+      expect(channels.some((c: Channel) => c.id === priv.id)).toBe(false);
+    });
+  });
+
+  describe('addChannelMember', () => {
+    it('チャンネル作成者は他ユーザーをメンバーに追加できる', () => {
+      const priv = createPrivateChannel('priv-add-member', undefined, testUserId, []);
+
+      expect(() => addChannelMember(priv.id, testUserId, anotherUserId)).not.toThrow();
+
+      const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+      const db = getDatabase() as ReturnType<typeof DatabaseLib>;
+      const member = db
+        .prepare('SELECT * FROM channel_members WHERE channel_id = ? AND user_id = ?')
+        .get(priv.id, anotherUserId);
+      expect(member).toBeDefined();
+    });
+
+    it('作成者以外がメンバー追加しようとすると 403 を投げる', () => {
+      const priv = createPrivateChannel('priv-add-forbidden', undefined, testUserId, []);
+
+      expect(() => addChannelMember(priv.id, anotherUserId, anotherUserId)).toThrow(
+        expect.objectContaining({ statusCode: 403 }),
+      );
+    });
+
+    it('存在しないチャンネルへのメンバー追加は 404 を投げる', () => {
+      expect(() => addChannelMember(99999, testUserId, anotherUserId)).toThrow(
         expect.objectContaining({ statusCode: 404 }),
       );
     });

--- a/packages/server/src/__tests__/channelController.test.ts
+++ b/packages/server/src/__tests__/channelController.test.ts
@@ -174,6 +174,201 @@ describe('DELETE /api/channels/:id', () => {
   });
 });
 
+describe('POST /api/channels（プライベートチャンネル作成）', () => {
+  it('正常: is_private=true を指定すると isPrivate=true のチャンネルが作成される', async () => {
+    const { token } = await registerUser('priv_create1', 'priv_create1@example.com');
+
+    const res = await request(app)
+      .post('/api/channels')
+      .set('Cookie', `token=${token}`)
+      .send({ name: 'priv-ch-1', is_private: true });
+
+    expect(res.status).toBe(201);
+    expect(res.body.channel.isPrivate).toBe(true);
+  });
+
+  it('正常: is_private=true で作成者は channel_members に自動追加される', async () => {
+    const { token, userId } = await registerUser('priv_create2', 'priv_create2@example.com');
+
+    const res = await request(app)
+      .post('/api/channels')
+      .set('Cookie', `token=${token}`)
+      .send({ name: 'priv-ch-2', is_private: true });
+
+    expect(res.status).toBe(201);
+    const channelId = (res.body as { channel: { id: number } }).channel.id;
+
+    // メンバー一覧エンドポイントで確認
+    const membersRes = await request(app)
+      .get(`/api/channels/${channelId}/members`)
+      .set('Cookie', `token=${token}`);
+    expect(membersRes.status).toBe(200);
+    expect(
+      (membersRes.body as { members: { id: number }[] }).members.some((m) => m.id === userId),
+    ).toBe(true);
+  });
+
+  it('正常: is_private=true + memberIds を指定すると指定ユーザーもメンバー追加される', async () => {
+    const { token } = await registerUser('priv_create3', 'priv_create3@example.com');
+    const { userId: memberId } = await registerUser('priv_member3', 'priv_member3@example.com');
+
+    const res = await request(app)
+      .post('/api/channels')
+      .set('Cookie', `token=${token}`)
+      .send({ name: 'priv-ch-3', is_private: true, memberIds: [memberId] });
+
+    expect(res.status).toBe(201);
+    const channelId = (res.body as { channel: { id: number } }).channel.id;
+
+    const membersRes = await request(app)
+      .get(`/api/channels/${channelId}/members`)
+      .set('Cookie', `token=${token}`);
+    expect(membersRes.status).toBe(200);
+    expect(
+      (membersRes.body as { members: { id: number }[] }).members.some((m) => m.id === memberId),
+    ).toBe(true);
+  });
+});
+
+describe('GET /api/channels（プライベートチャンネルのフィルタリング）', () => {
+  it('正常: プライベートチャンネルはメンバーのユーザーに返る', async () => {
+    const { token: ownerToken } = await registerUser(
+      'priv_filter_owner1',
+      'priv_filter_owner1@example.com',
+    );
+    const { token: memberToken, userId: memberId } = await registerUser(
+      'priv_filter_member1',
+      'priv_filter_member1@example.com',
+    );
+
+    const createRes = await request(app)
+      .post('/api/channels')
+      .set('Cookie', `token=${ownerToken}`)
+      .send({ name: 'priv-filter-ch-1', is_private: true, memberIds: [memberId] });
+    const channelId = (createRes.body as { channel: { id: number } }).channel.id;
+
+    const res = await request(app).get('/api/channels').set('Cookie', `token=${memberToken}`);
+
+    expect(res.status).toBe(200);
+    expect(
+      (res.body as { channels: { id: number }[] }).channels.some((c) => c.id === channelId),
+    ).toBe(true);
+  });
+
+  it('正常: プライベートチャンネルは非メンバーのユーザーに返らない', async () => {
+    const { token: ownerToken } = await registerUser(
+      'priv_filter_owner2',
+      'priv_filter_owner2@example.com',
+    );
+    const { token: nonMemberToken } = await registerUser(
+      'priv_filter_non2',
+      'priv_filter_non2@example.com',
+    );
+
+    const createRes = await request(app)
+      .post('/api/channels')
+      .set('Cookie', `token=${ownerToken}`)
+      .send({ name: 'priv-filter-ch-2', is_private: true });
+    const channelId = (createRes.body as { channel: { id: number } }).channel.id;
+
+    const res = await request(app).get('/api/channels').set('Cookie', `token=${nonMemberToken}`);
+
+    expect(res.status).toBe(200);
+    expect(
+      (res.body as { channels: { id: number }[] }).channels.some((c) => c.id === channelId),
+    ).toBe(false);
+  });
+
+  it('正常: 公開チャンネルは全ユーザーに返る', async () => {
+    const { token: ownerToken } = await registerUser(
+      'pub_filter_owner1',
+      'pub_filter_owner1@example.com',
+    );
+    const { token: otherToken } = await registerUser(
+      'pub_filter_other1',
+      'pub_filter_other1@example.com',
+    );
+
+    const createRes = await request(app)
+      .post('/api/channels')
+      .set('Cookie', `token=${ownerToken}`)
+      .send({ name: 'pub-filter-ch-1' });
+    const channelId = (createRes.body as { channel: { id: number } }).channel.id;
+
+    const res = await request(app).get('/api/channels').set('Cookie', `token=${otherToken}`);
+
+    expect(res.status).toBe(200);
+    expect(
+      (res.body as { channels: { id: number }[] }).channels.some((c) => c.id === channelId),
+    ).toBe(true);
+  });
+});
+
+describe('POST /api/channels/:id/members（メンバー追加）', () => {
+  it('正常: チャンネル作成者がメンバーを追加すると 204 が返る', async () => {
+    const { token: ownerToken } = await registerUser(
+      'add_member_owner1',
+      'add_member_owner1@example.com',
+    );
+    const { userId: newMemberId } = await registerUser(
+      'add_member_new1',
+      'add_member_new1@example.com',
+    );
+    const channel = await createChannel(ownerToken, 'add-member-ch-1');
+
+    const res = await request(app)
+      .post(`/api/channels/${channel.id}/members`)
+      .set('Cookie', `token=${ownerToken}`)
+      .send({ userId: newMemberId });
+
+    expect(res.status).toBe(204);
+  });
+
+  it('異常: 作成者以外がメンバー追加すると 403 が返る', async () => {
+    const { token: ownerToken } = await registerUser(
+      'add_member_owner2',
+      'add_member_owner2@example.com',
+    );
+    const { token: otherToken } = await registerUser(
+      'add_member_other2',
+      'add_member_other2@example.com',
+    );
+    const { userId: newMemberId } = await registerUser(
+      'add_member_new2',
+      'add_member_new2@example.com',
+    );
+    const channel = await createChannel(ownerToken, 'add-member-ch-2');
+
+    const res = await request(app)
+      .post(`/api/channels/${channel.id}/members`)
+      .set('Cookie', `token=${otherToken}`)
+      .send({ userId: newMemberId });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('異常: 存在しないチャンネルへのメンバー追加は 404 が返る', async () => {
+    const { token } = await registerUser('add_member_owner3', 'add_member_owner3@example.com');
+    const { userId: newMemberId } = await registerUser(
+      'add_member_new3',
+      'add_member_new3@example.com',
+    );
+
+    const res = await request(app)
+      .post('/api/channels/99999/members')
+      .set('Cookie', `token=${token}`)
+      .send({ userId: newMemberId });
+
+    expect(res.status).toBe(404);
+  });
+
+  it('異常: トークンなしで 401 が返る', async () => {
+    const res = await request(app).post('/api/channels/1/members').send({ userId: 1 });
+
+    expect(res.status).toBe(401);
+  });
+});
+
 describe('POST /api/channels/:id/join', () => {
   it('正常: チャンネルに参加すると204が返る', async () => {
     const { token: ownerToken } = await registerUser(

--- a/packages/server/src/controllers/channelController.ts
+++ b/packages/server/src/controllers/channelController.ts
@@ -2,39 +2,91 @@ import { Request, Response, NextFunction } from 'express';
 import * as channelService from '../services/channelService';
 import { AuthenticatedRequest } from '../middleware/auth';
 
-export function getChannels(_req: Request, res: Response, next: NextFunction): void {
+export function getChannels(req: Request, res: Response, next: NextFunction): void {
   try {
-    res.json({ channels: channelService.getAllChannels() });
-  } catch (err) { next(err); }
+    const userId = (req as AuthenticatedRequest).userId;
+    res.json({ channels: channelService.getChannelsForUser(userId) });
+  } catch (err) {
+    next(err);
+  }
 }
 
 export function getChannel(req: Request, res: Response, next: NextFunction): void {
   try {
     const channel = channelService.getChannelById(Number(req.params.id));
-    if (!channel) { res.status(404).json({ error: 'Channel not found' }); return; }
+    if (!channel) {
+      res.status(404).json({ error: 'Channel not found' });
+      return;
+    }
     res.json({ channel });
-  } catch (err) { next(err); }
+  } catch (err) {
+    next(err);
+  }
 }
 
 export function createChannel(req: Request, res: Response, next: NextFunction): void {
   try {
-    const { name, description } = req.body as { name?: string; description?: string };
-    if (!name) { res.status(400).json({ error: 'name is required' }); return; }
-    const channel = channelService.createChannel(name, description, (req as AuthenticatedRequest).userId);
+    const { name, description, is_private, memberIds } = req.body as {
+      name?: string;
+      description?: string;
+      is_private?: boolean;
+      memberIds?: number[];
+    };
+    if (!name) {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+    const userId = (req as AuthenticatedRequest).userId;
+    const channel = is_private
+      ? channelService.createPrivateChannel(name, description, userId, memberIds ?? [])
+      : channelService.createChannel(name, description, userId);
     res.status(201).json({ channel });
-  } catch (err) { next(err); }
+  } catch (err) {
+    next(err);
+  }
 }
 
 export function deleteChannel(req: Request, res: Response, next: NextFunction): void {
   try {
     channelService.deleteChannel(Number(req.params.id), (req as AuthenticatedRequest).userId);
     res.status(204).send();
-  } catch (err) { next(err); }
+  } catch (err) {
+    next(err);
+  }
 }
 
 export function joinChannel(req: Request, res: Response, next: NextFunction): void {
   try {
     channelService.joinChannel(Number(req.params.id), (req as AuthenticatedRequest).userId);
     res.status(204).send();
-  } catch (err) { next(err); }
+  } catch (err) {
+    next(err);
+  }
+}
+
+export function addMember(req: Request, res: Response, next: NextFunction): void {
+  try {
+    const { userId: targetUserId } = req.body as { userId?: number };
+    if (!targetUserId) {
+      res.status(400).json({ error: 'userId is required' });
+      return;
+    }
+    channelService.addChannelMember(
+      Number(req.params.id),
+      (req as AuthenticatedRequest).userId,
+      targetUserId,
+    );
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}
+
+export function getMembers(req: Request, res: Response, next: NextFunction): void {
+  try {
+    const members = channelService.getChannelMembers(Number(req.params.id));
+    res.json({ members });
+  } catch (err) {
+    next(err);
+  }
 }

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -37,6 +37,7 @@ export function initializeSchema(database: Database.Database): void {
       name TEXT NOT NULL UNIQUE,
       description TEXT,
       created_by INTEGER NOT NULL REFERENCES users(id),
+      is_private INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
 
@@ -84,6 +85,12 @@ export function initializeSchema(database: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
   `);
+
+  // 既存 DB に is_private カラムが存在しない場合は追加する
+  const channelCols = database.prepare('PRAGMA table_info(channels)').all() as { name: string }[];
+  if (!channelCols.some((r) => r.name === 'is_private')) {
+    database.exec('ALTER TABLE channels ADD COLUMN is_private INTEGER NOT NULL DEFAULT 0');
+  }
 
   // 既存 DB に display_name・location カラムが存在しない場合は追加する
   for (const col of ['display_name', 'location']) {

--- a/packages/server/src/routes/channels.ts
+++ b/packages/server/src/routes/channels.ts
@@ -130,6 +130,8 @@ router.delete('/:id', authenticateToken, controller.deleteChannel);
  *         description: Joined
  */
 router.post('/:id/join', authenticateToken, controller.joinChannel);
+router.get('/:id/members', authenticateToken, controller.getMembers);
+router.post('/:id/members', authenticateToken, controller.addMember);
 
 /**
  * @swagger

--- a/packages/server/src/services/channelService.ts
+++ b/packages/server/src/services/channelService.ts
@@ -7,6 +7,7 @@ interface ChannelRow {
   name: string;
   description: string | null;
   created_by: number;
+  is_private: number;
   created_at: string;
 }
 
@@ -16,6 +17,7 @@ function toChannel(row: ChannelRow): Channel {
     name: row.name,
     description: row.description,
     createdBy: row.created_by,
+    isPrivate: row.is_private === 1,
     createdAt: row.created_at,
   };
 }
@@ -25,13 +27,33 @@ export function getAllChannels(): Channel[] {
   return (db.prepare('SELECT * FROM channels ORDER BY name').all() as ChannelRow[]).map(toChannel);
 }
 
+export function getChannelsForUser(userId: number): Channel[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(
+      `SELECT c.* FROM channels c
+       WHERE c.is_private = 0
+          OR EXISTS (
+            SELECT 1 FROM channel_members cm
+            WHERE cm.channel_id = c.id AND cm.user_id = ?
+          )
+       ORDER BY c.name`,
+    )
+    .all(userId) as ChannelRow[];
+  return rows.map(toChannel);
+}
+
 export function getChannelById(id: number): Channel | null {
   const db = getDatabase();
   const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(id) as ChannelRow | undefined;
   return row ? toChannel(row) : null;
 }
 
-export function createChannel(name: string, description: string | undefined, createdBy: number): Channel {
+export function createChannel(
+  name: string,
+  description: string | undefined,
+  createdBy: number,
+): Channel {
   const db = getDatabase();
 
   const existing = db.prepare('SELECT id FROM channels WHERE name = ?').get(name);
@@ -42,15 +64,81 @@ export function createChannel(name: string, description: string | undefined, cre
     .run(name, description ?? null, createdBy);
 
   const channelId = result.lastInsertRowid;
-  db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(channelId, createdBy);
+  db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(
+    channelId,
+    createdBy,
+  );
 
   const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as ChannelRow;
   return toChannel(row);
 }
 
+export function createPrivateChannel(
+  name: string,
+  description: string | undefined,
+  createdBy: number,
+  memberIds: number[],
+): Channel {
+  const db = getDatabase();
+
+  const existing = db.prepare('SELECT id FROM channels WHERE name = ?').get(name);
+  if (existing) throw createError('Channel name already taken', 409);
+
+  const result = db
+    .prepare('INSERT INTO channels (name, description, created_by, is_private) VALUES (?, ?, ?, 1)')
+    .run(name, description ?? null, createdBy);
+
+  const channelId = result.lastInsertRowid;
+
+  // 作成者を初期メンバーに追加
+  db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(
+    channelId,
+    createdBy,
+  );
+
+  // 指定メンバーを追加
+  for (const uid of memberIds) {
+    db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(
+      channelId,
+      uid,
+    );
+  }
+
+  const row = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as ChannelRow;
+  return toChannel(row);
+}
+
+export function addChannelMember(channelId: number, requesterId: number, userId: number): void {
+  const db = getDatabase();
+  const channel = db.prepare('SELECT * FROM channels WHERE id = ?').get(channelId) as
+    | ChannelRow
+    | undefined;
+
+  if (!channel) throw createError('Channel not found', 404);
+  if (channel.created_by !== requesterId) throw createError('Forbidden', 403);
+
+  db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(
+    channelId,
+    userId,
+  );
+}
+
+export function getChannelMembers(channelId: number): { id: number; username: string }[] {
+  const db = getDatabase();
+  return db
+    .prepare(
+      `SELECT u.id, u.username FROM users u
+       INNER JOIN channel_members cm ON cm.user_id = u.id
+       WHERE cm.channel_id = ?`,
+    )
+    .all(channelId) as { id: number; username: string }[];
+}
+
 export function deleteChannel(id: number, userId: number): void {
   const db = getDatabase();
-  const channel = db.prepare('SELECT * FROM channels WHERE id = ?').get(id) as ChannelRow | undefined;
+  const channel = db.prepare('SELECT * FROM channels WHERE id = ?').get(id) as
+    | ChannelRow
+    | undefined;
 
   if (!channel) throw createError('Channel not found', 404);
   if (channel.created_by !== userId) throw createError('Forbidden', 403);
@@ -60,5 +148,8 @@ export function deleteChannel(id: number, userId: number): void {
 
 export function joinChannel(channelId: number, userId: number): void {
   const db = getDatabase();
-  db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(channelId, userId);
+  db.prepare('INSERT OR IGNORE INTO channel_members (channel_id, user_id) VALUES (?, ?)').run(
+    channelId,
+    userId,
+  );
 }

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -4,9 +4,11 @@ export interface Channel {
   description: string | null;
   createdBy: number;
   createdAt: string;
+  isPrivate: boolean;
 }
 
 export interface CreateChannelInput {
   name: string;
   description?: string;
+  isPrivate?: boolean;
 }


### PR DESCRIPTION
## Summary

- `Channel` 型に `isPrivate` フィールドを追加（`@chat-app/shared`）
- `channels` テーブルに `is_private INTEGER NOT NULL DEFAULT 0` カラムを追加
- プライベートチャンネルの作成・メンバー管理・フィルタリングをサービス層・コントローラー層に実装
- フロントエンド: `CreateChannelDialog` に Private トグル、`ChannelList` に鍵アイコン表示

## 変更ファイル

| 層 | ファイル | 変更内容 |
|---|---|---|
| 共有型 | `packages/shared/src/types/channel.ts` | `isPrivate: boolean` 追加 |
| DB | `db/schema.hcl`, `packages/server/src/db/database.ts` | `is_private` カラム追加 |
| サービス | `channelService.ts` | `createPrivateChannel`, `getChannelsForUser`, `addChannelMember`, `getChannelMembers` 追加 |
| コントローラー | `channelController.ts` | `getChannels` を `getChannelsForUser` に変更、`addMember`/`getMembers` 追加 |
| ルート | `routes/channels.ts` | `POST/GET /:id/members` 追加 |
| フロントエンド | `CreateChannelDialog.tsx` | Private トグルスイッチ追加 |
| フロントエンド | `ChannelList.tsx` | `LockIcon` 表示 |
| API クライアント | `api/client.ts` | `create` に `isPrivate` オプション追加、`addMember` 追加 |

## Test plan

- [x] `packages/server` テスト全通過（123件）
- [x] `packages/client` テスト全通過（162件）
- [x] `npm run build` 成功

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)