### PR TITLE
feat: リアクション機能の実装 (#29)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -361,5 +361,56 @@ table "push_subscriptions" {
   }
 }
 
+table "message_reactions" {
+  schema  = schema.main
+  comment = "メッセージリアクション"
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+    comment        = "リアクションID"
+  }
+  column "message_id" {
+    null    = false
+    type    = integer
+    comment = "メッセージID"
+  }
+  column "user_id" {
+    null    = false
+    type    = integer
+    comment = "リアクションしたユーザーID"
+  }
+  column "emoji" {
+    null    = false
+    type    = text
+    comment = "絵文字（Unicode文字）"
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+    comment = "作成日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  index "message_reactions_unique" {
+    unique  = true
+    columns = [column.message_id, column.user_id, column.emoji]
+  }
+  foreign_key "0" {
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "1" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+}
+
 schema "main" {
 }

--- a/packages/client/src/__tests__/MessageItem.test.tsx
+++ b/packages/client/src/__tests__/MessageItem.test.tsx
@@ -63,6 +63,7 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
     createdAt: '2024-06-01T12:00:00Z',
     updatedAt: '2024-06-01T12:00:00Z',
     mentions: [],
+    reactions: [],
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/MessageItemAttachment.test.tsx
+++ b/packages/client/src/__tests__/MessageItemAttachment.test.tsx
@@ -51,6 +51,7 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
     updatedAt: '2024-06-01T12:00:00Z',
     mentions: [],
     attachments: [],
+    reactions: [],
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/MessageItemReaction.test.tsx
+++ b/packages/client/src/__tests__/MessageItemReaction.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * MessageItem - リアクション機能のユニットテスト
+ *
+ * テスト対象: packages/client/src/components/Chat/MessageItem.tsx
+ * - リアクションバッジの表示
+ * - 絵文字ピッカーの表示・非表示
+ * - リアクションのトグル（追加・取り消し）
+ * - reaction_updated Socket イベントの受信による表示更新
+ *
+ * 戦略:
+ *   - Socket.IO は SocketContext をモックして注入する
+ *   - RichEditor は jsdom では動作しないためスタブに差し替える
+ *   - userEvent でホバー・クリックをシミュレートする
+ */
+
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Message, Reaction, User } from '@chat-app/shared';
+import MessageItem from '../components/Chat/MessageItem';
+
+// Socket.IO モック（on でハンドラを保持できるようにする）
+const socketHandlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+const mockSocket = {
+  emit: vi.fn(),
+  on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+    socketHandlers[event] = socketHandlers[event] ?? [];
+    socketHandlers[event].push(handler);
+  }),
+  off: vi.fn(),
+};
+
+vi.mock('../contexts/SocketContext', () => ({
+  useSocket: () => mockSocket,
+}));
+
+vi.mock('../components/Chat/RichEditor', () => ({
+  default: ({ onCancel }: { onCancel: () => void; onSend: (c: string, m: number[]) => void }) => (
+    <div data-testid="rich-editor">
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}));
+
+const dummyUsers: User[] = [
+  {
+    id: 1,
+    username: 'alice',
+    email: 'alice@example.com',
+    avatarUrl: null,
+    displayName: null,
+    location: null,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    username: 'bob',
+    email: 'bob@example.com',
+    avatarUrl: null,
+    displayName: null,
+    location: null,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+];
+
+function makeReaction(overrides: Partial<Reaction> = {}): Reaction {
+  return {
+    emoji: '👍',
+    count: 1,
+    userIds: [1],
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 1,
+    channelId: 1,
+    userId: 1,
+    username: 'alice',
+    avatarUrl: null,
+    content: JSON.stringify({ ops: [{ insert: 'Hello world\n' }] }),
+    isEdited: false,
+    isDeleted: false,
+    createdAt: '2024-06-01T12:00:00Z',
+    updatedAt: '2024-06-01T12:00:00Z',
+    mentions: [],
+    reactions: [],
+    ...overrides,
+  };
+}
+
+function emitSocketEvent(event: string, payload: unknown) {
+  socketHandlers[event]?.forEach((handler) => handler(payload));
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // ハンドラ登録テーブルをリセット
+  Object.keys(socketHandlers).forEach((k) => delete socketHandlers[k]);
+  // on の実装を再設定（resetAllMocks で消えるため）
+  mockSocket.on.mockImplementation((event: string, handler: (...args: unknown[]) => void) => {
+    socketHandlers[event] = socketHandlers[event] ?? [];
+    socketHandlers[event].push(handler);
+  });
+});
+
+describe('MessageItem - リアクション機能', () => {
+  describe('リアクションバッジの表示', () => {
+    it('reactions が空配列のときバッジが表示されない', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ reactions: [] })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      // リアクションバッジ用のコンテナが存在しないか、中身が空であること
+      expect(screen.queryByTestId('reaction-badge')).not.toBeInTheDocument();
+    });
+
+    it('reactions に絵文字がある場合、その絵文字とカウントを表示する', () => {
+      const reactions = [makeReaction({ emoji: '👍', count: 3, userIds: [1, 2, 3] })];
+      render(
+        <MessageItem message={makeMessage({ reactions })} currentUserId={1} users={dummyUsers} />,
+      );
+
+      expect(screen.getByText('👍')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('自分がリアクション済みのバッジはスタイルで強調される（data属性で判定）', () => {
+      // currentUserId=1 が userIds に含まれる → 自分がリアクション済み
+      const reactions = [makeReaction({ emoji: '❤️', count: 1, userIds: [1] })];
+      render(
+        <MessageItem message={makeMessage({ reactions })} currentUserId={1} users={dummyUsers} />,
+      );
+
+      // 実装側は data-reacted="true" を付与して強調を表現する
+      const badge = screen.getByTestId('reaction-badge');
+      expect(badge).toHaveAttribute('data-reacted', 'true');
+    });
+
+    it('バッジホバー時に誰がリアクションしたかのツールチップが表示される', async () => {
+      const reactions = [makeReaction({ emoji: '🎉', count: 1, userIds: [2] })];
+      render(
+        <MessageItem message={makeMessage({ reactions })} currentUserId={1} users={dummyUsers} />,
+      );
+
+      await userEvent.hover(screen.getByTestId('reaction-badge'));
+
+      await waitFor(() => {
+        // ユーザー名 "bob"（userId=2）がツールチップに表示される
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('絵文字ピッカー', () => {
+    it('メッセージホバー時にアクションバーに絵文字ピッカー起動ボタンが DOM 上に存在する', () => {
+      render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
+
+      // opacity:0 で非表示だが DOM には存在する設計
+      expect(screen.getByRole('button', { name: /リアクションを追加/i })).toBeInTheDocument();
+    });
+
+    it('絵文字ピッカー起動ボタンをクリックするとピッカーが表示される', async () => {
+      render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+
+      expect(screen.getByTestId('emoji-picker')).toBeInTheDocument();
+    });
+
+    it('絵文字ピッカーに固定の絵文字リストが表示される', async () => {
+      render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+
+      // 固定絵文字セットの一部が表示されていること
+      expect(screen.getByRole('button', { name: '👍' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '❤️' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '🎉' })).toBeInTheDocument();
+    });
+
+    it('ピッカー外をクリックするとピッカーが閉じる', async () => {
+      render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+      expect(screen.getByTestId('emoji-picker')).toBeInTheDocument();
+
+      // ピッカー外をクリックして閉じる
+      await userEvent.click(document.body);
+
+      expect(screen.queryByTestId('emoji-picker')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('リアクションのトグル', () => {
+    it('絵文字ピッカーで絵文字を選択すると socket.emit("add_reaction") が呼ばれる', async () => {
+      render(
+        <MessageItem message={makeMessage({ id: 42 })} currentUserId={1} users={dummyUsers} />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+      await userEvent.click(screen.getByRole('button', { name: '👍' }));
+
+      expect(mockSocket.emit).toHaveBeenCalledWith('add_reaction', {
+        messageId: 42,
+        emoji: '👍',
+      });
+    });
+
+    it('自分がリアクション済みのバッジをクリックすると socket.emit("remove_reaction") が呼ばれる', async () => {
+      // currentUserId=1 が userIds に含まれる → 自分がリアクション済み
+      const reactions = [makeReaction({ emoji: '🔥', count: 1, userIds: [1] })];
+      render(
+        <MessageItem
+          message={makeMessage({ id: 10, reactions })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('reaction-badge'));
+
+      expect(mockSocket.emit).toHaveBeenCalledWith('remove_reaction', {
+        messageId: 10,
+        emoji: '🔥',
+      });
+    });
+
+    it('自分がリアクションしていないバッジをクリックすると socket.emit("add_reaction") が呼ばれる', async () => {
+      // currentUserId=1 が userIds に含まれない → 未リアクション
+      const reactions = [makeReaction({ emoji: '😂', count: 1, userIds: [2] })];
+      render(
+        <MessageItem
+          message={makeMessage({ id: 20, reactions })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('reaction-badge'));
+
+      expect(mockSocket.emit).toHaveBeenCalledWith('add_reaction', {
+        messageId: 20,
+        emoji: '😂',
+      });
+    });
+  });
+
+  describe('reaction_updated Socket イベント', () => {
+    it('reaction_updated イベントを受信すると対象メッセージのリアクションが更新される', async () => {
+      render(
+        <MessageItem
+          message={makeMessage({ id: 1, reactions: [] })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      // 初期状態ではバッジなし
+      expect(screen.queryByTestId('reaction-badge')).not.toBeInTheDocument();
+
+      // reaction_updated イベントを発火
+      act(() => {
+        emitSocketEvent('reaction_updated', {
+          messageId: 1,
+          channelId: 1,
+          reactions: [{ emoji: '👍', count: 1, userIds: [2] }],
+        });
+      });
+
+      // バッジが表示される
+      await waitFor(() => {
+        expect(screen.getByText('👍')).toBeInTheDocument();
+      });
+    });
+
+    it('別メッセージの reaction_updated イベントは自分のリアクション表示に影響しない', async () => {
+      render(
+        <MessageItem
+          message={makeMessage({ id: 1, reactions: [] })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+
+      // 別メッセージID=99 の reaction_updated を発火
+      act(() => {
+        emitSocketEvent('reaction_updated', {
+          messageId: 99,
+          channelId: 1,
+          reactions: [{ emoji: '🚀', count: 1, userIds: [2] }],
+        });
+      });
+
+      // 自分のメッセージ（id=1）には影響しない
+      expect(screen.queryByText('🚀')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/MessageList.test.tsx
+++ b/packages/client/src/__tests__/MessageList.test.tsx
@@ -48,6 +48,7 @@ function makeMessage(id: number): Message {
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
     mentions: [],
+    reactions: [],
   };
 }
 

--- a/packages/client/src/__tests__/SearchResults.test.tsx
+++ b/packages/client/src/__tests__/SearchResults.test.tsx
@@ -28,6 +28,7 @@ function makeResult(overrides: Partial<MessageSearchResult> = {}): MessageSearch
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
     mentions: [],
+    reactions: [],
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/useMessages.test.tsx
+++ b/packages/client/src/__tests__/useMessages.test.tsx
@@ -65,6 +65,7 @@ function makeMessage(id: number, channelId = 1): Message {
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
     mentions: [],
+    reactions: [],
   };
 }
 
@@ -104,10 +105,10 @@ describe('useMessages', () => {
       mockUseSocket.mockReturnValue(socket);
       mockList.mockResolvedValue({ messages: [makeMessage(1, 1)] });
 
-      const { result, rerender } = renderHook(
-        ({ ch }: { ch: number }) => useMessages(ch),
-        { wrapper, initialProps: { ch: 1 } },
-      );
+      const { result, rerender } = renderHook(({ ch }: { ch: number }) => useMessages(ch), {
+        wrapper,
+        initialProps: { ch: 1 },
+      });
       await waitFor(() => expect(result.current.messages).toHaveLength(1));
 
       // チャンネルを切り替える
@@ -136,10 +137,10 @@ describe('useMessages', () => {
       mockUseSocket.mockReturnValue(socket);
       mockList.mockResolvedValue({ messages: [] });
 
-      const { rerender } = renderHook(
-        ({ ch }: { ch: number }) => useMessages(ch),
-        { wrapper, initialProps: { ch: 3 } },
-      );
+      const { rerender } = renderHook(({ ch }: { ch: number }) => useMessages(ch), {
+        wrapper,
+        initialProps: { ch: 3 },
+      });
       await waitFor(() => expect(socket.emit).toHaveBeenCalledWith('join_channel', 3));
 
       rerender({ ch: 4 });
@@ -243,7 +244,9 @@ describe('useMessages', () => {
       await waitFor(() => expect(result.current.messages).toHaveLength(2));
 
       mockList.mockResolvedValue({ messages: [makeMessage(8), makeMessage(9)] });
-      act(() => { result.current.loadMore(); });
+      act(() => {
+        result.current.loadMore();
+      });
 
       await waitFor(() => expect(result.current.messages).toHaveLength(4));
       // 古いメッセージが先頭に来ること

--- a/packages/client/src/components/Chat/EmojiPicker.tsx
+++ b/packages/client/src/components/Chat/EmojiPicker.tsx
@@ -1,0 +1,73 @@
+import { Box, ClickAwayListener, Paper, Popper } from '@mui/material';
+
+const EMOJI_LIST = [
+  '👍',
+  '👎',
+  '❤️',
+  '😂',
+  '😮',
+  '😢',
+  '🎉',
+  '🔥',
+  '👀',
+  '✅',
+  '❌',
+  '🚀',
+  '💯',
+  '🙏',
+  '😍',
+  '🤔',
+  '👏',
+  '💪',
+  '🫡',
+  '⭐',
+];
+
+interface Props {
+  anchorEl: HTMLElement | null;
+  onSelect: (emoji: string) => void;
+  onClose: () => void;
+}
+
+export default function EmojiPicker({ anchorEl, onSelect, onClose }: Props) {
+  return (
+    <Popper
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      placement="top-start"
+      sx={{ zIndex: 1300 }}
+    >
+      <ClickAwayListener onClickAway={onClose}>
+        <Paper
+          data-testid="emoji-picker"
+          elevation={3}
+          sx={{ p: 0.5, display: 'flex', flexWrap: 'wrap', gap: 0.25, maxWidth: 200 }}
+        >
+          {EMOJI_LIST.map((emoji) => (
+            <Box
+              key={emoji}
+              component="button"
+              aria-label={emoji}
+              onClick={() => {
+                onSelect(emoji);
+                onClose();
+              }}
+              sx={{
+                border: 'none',
+                background: 'none',
+                cursor: 'pointer',
+                fontSize: '1.2rem',
+                p: 0.5,
+                borderRadius: 1,
+                lineHeight: 1,
+                '&:hover': { bgcolor: 'action.hover' },
+              }}
+            >
+              {emoji}
+            </Box>
+          ))}
+        </Paper>
+      </ClickAwayListener>
+    </Popper>
+  );
+}

--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Box, Avatar, Typography, IconButton, Tooltip, Popover, Paper, Link } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -7,9 +7,12 @@ import RestoreIcon from '@mui/icons-material/Restore';
 import LinkIcon from '@mui/icons-material/Link';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
-import type { Message, User } from '@chat-app/shared';
+import EmojiEmotionsIcon from '@mui/icons-material/EmojiEmotions';
+import type { Message, Reaction, User } from '@chat-app/shared';
 import { useSocket } from '../../contexts/SocketContext';
 import RichEditor from './RichEditor';
+import EmojiPicker from './EmojiPicker';
+import ReactionBadge from './ReactionBadge';
 import { getAvatarColor } from '../../utils/avatarColor';
 
 interface Props {
@@ -134,8 +137,23 @@ function renderContent(content: string): React.ReactNode {
 export default function MessageItem({ message, currentUserId, users }: Props) {
   const [editing, setEditing] = useState(false);
   const [profileAnchor, setProfileAnchor] = useState<HTMLElement | null>(null);
+  const [emojiAnchor, setEmojiAnchor] = useState<HTMLElement | null>(null);
+  const [reactions, setReactions] = useState<Reaction[]>(message.reactions ?? []);
   const socket = useSocket();
   const isOwn = message.userId === currentUserId;
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = (data: { messageId: number; channelId: number; reactions: Reaction[] }) => {
+      if (data.messageId === message.id) {
+        setReactions(data.reactions);
+      }
+    };
+    socket.on('reaction_updated', handler);
+    return () => {
+      socket.off('reaction_updated', handler);
+    };
+  }, [socket, message.id]);
 
   // 投稿者の User 情報を users 配列から取得
   const author = users.find((u) => u.id === message.userId);
@@ -162,6 +180,17 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
   const handleCopyLink = () => {
     const url = `${window.location.origin}${window.location.pathname}?channel=${message.channelId}#message-${message.id}`;
     navigator.clipboard.writeText(url);
+  };
+
+  const handleReactionClick = (emoji: string) => {
+    const alreadyReacted = reactions
+      .find((r) => r.emoji === emoji)
+      ?.userIds.includes(currentUserId);
+    if (alreadyReacted) {
+      socket?.emit('remove_reaction', { messageId: message.id, emoji });
+    } else {
+      socket?.emit('add_reaction', { messageId: message.id, emoji });
+    }
   };
 
   if (message.isDeleted) {
@@ -397,7 +426,31 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
                   })}
                 </Box>
               )}
+
+              {/* リアクションバッジ */}
+              {reactions.length > 0 && (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}>
+                  {reactions.map((reaction) => (
+                    <ReactionBadge
+                      key={reaction.emoji}
+                      reaction={reaction}
+                      currentUserId={currentUserId}
+                      users={users}
+                      onClick={handleReactionClick}
+                    />
+                  ))}
+                </Box>
+              )}
             </Box>
+
+            {/* 絵文字ピッカー（Popper なので DOM 位置は任意） */}
+            <EmojiPicker
+              anchorEl={emojiAnchor}
+              onSelect={(emoji) => {
+                socket?.emit('add_reaction', { messageId: message.id, emoji });
+              }}
+              onClose={() => setEmojiAnchor(null)}
+            />
 
             {/* アクションボタン（バブルのすぐ隣） */}
             <Box
@@ -411,6 +464,15 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
                 flexShrink: 0,
               }}
             >
+              <Tooltip title="リアクションを追加">
+                <IconButton
+                  size="small"
+                  aria-label="リアクションを追加"
+                  onClick={(e) => setEmojiAnchor(e.currentTarget)}
+                >
+                  <EmojiEmotionsIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
               <Tooltip title="リンクをコピー">
                 <IconButton size="small" aria-label="リンクをコピー" onClick={handleCopyLink}>
                   <LinkIcon fontSize="small" />

--- a/packages/client/src/components/Chat/ReactionBadge.tsx
+++ b/packages/client/src/components/Chat/ReactionBadge.tsx
@@ -1,0 +1,52 @@
+import { Box, Tooltip } from '@mui/material';
+import type { Reaction, User } from '@chat-app/shared';
+
+interface Props {
+  reaction: Reaction;
+  currentUserId: number;
+  users: User[];
+  onClick: (emoji: string) => void;
+}
+
+export default function ReactionBadge({ reaction, currentUserId, users, onClick }: Props) {
+  const reacted = reaction.userIds.includes(currentUserId);
+
+  const tooltipNames = reaction.userIds
+    .map(
+      (id) =>
+        users.find((u) => u.id === id)?.displayName ??
+        users.find((u) => u.id === id)?.username ??
+        `User ${id}`,
+    )
+    .join(', ');
+
+  return (
+    <Tooltip title={tooltipNames} arrow>
+      <Box
+        component="button"
+        data-testid="reaction-badge"
+        data-reacted={reacted ? 'true' : 'false'}
+        onClick={() => onClick(reaction.emoji)}
+        sx={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 0.5,
+          border: '1px solid',
+          borderColor: reacted ? 'primary.main' : 'divider',
+          bgcolor: reacted ? 'primary.50' : 'background.paper',
+          borderRadius: 3,
+          px: 0.75,
+          py: 0.25,
+          cursor: 'pointer',
+          fontSize: '0.8rem',
+          lineHeight: 1.4,
+          fontWeight: reacted ? 600 : 400,
+          '&:hover': { bgcolor: reacted ? 'primary.100' : 'action.hover' },
+        }}
+      >
+        <span>{reaction.emoji}</span>
+        <span>{reaction.count}</span>
+      </Box>
+    </Tooltip>
+  );
+}

--- a/packages/server/src/__tests__/unit/messageReaction.test.ts
+++ b/packages/server/src/__tests__/unit/messageReaction.test.ts
@@ -1,0 +1,202 @@
+/**
+ * MessageService - リアクション機能のユニットテスト
+ *
+ * テスト対象: packages/server/src/services/messageService.ts
+ * - addReaction: リアクション追加
+ * - removeReaction: リアクション削除
+ * - getReactions: リアクション取得
+ * - getChannelMessages: reactionsフィールドが含まれること
+ *
+ * DB 戦略: better-sqlite3 のインメモリ DB を使用。
+ * メッセージは users と channels への外部キーを持つため、
+ * beforeAll でテスト用ユーザー・チャンネル・メッセージを直接 INSERT している。
+ */
+
+import {
+  addReaction,
+  removeReaction,
+  getReactions,
+  createMessage,
+  getChannelMessages,
+} from '../../services/messageService';
+import { initializeSchema } from '../../db/database';
+import DatabaseLib from 'better-sqlite3';
+
+let userId1: number;
+let userId2: number;
+let channelId: number;
+
+jest.mock('../../db/database', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DB = require('better-sqlite3') as typeof import('better-sqlite3');
+  const db = new DB(':memory:');
+  db.pragma('foreign_keys = ON');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../../db/database')>('../../db/database');
+  init(db);
+  return {
+    getDatabase: () => db,
+    initializeSchema: init,
+    closeDatabase: jest.fn(),
+  };
+});
+
+beforeAll(() => {
+  const DB = DatabaseLib;
+  const { getDatabase } = jest.requireMock<typeof import('../../db/database')>('../../db/database');
+  const db = getDatabase() as InstanceType<typeof DB>;
+
+  const r1 = db
+    .prepare("INSERT INTO users (username, email, password_hash) VALUES ('user1', 'u1@t.com', 'h')")
+    .run();
+  userId1 = r1.lastInsertRowid as number;
+
+  const r2 = db
+    .prepare("INSERT INTO users (username, email, password_hash) VALUES ('user2', 'u2@t.com', 'h')")
+    .run();
+  userId2 = r2.lastInsertRowid as number;
+
+  const rc = db
+    .prepare("INSERT INTO channels (name, created_by) VALUES ('test-channel', ?)")
+    .run(userId1);
+  channelId = rc.lastInsertRowid as number;
+});
+
+const sampleContent = JSON.stringify({ ops: [{ insert: 'Hello\n' }] });
+
+describe('MessageService - リアクション機能', () => {
+  describe('addReaction', () => {
+    it('指定した絵文字のリアクションを追加できる', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      const reactions = addReaction(msg.id, userId1, '👍');
+
+      expect(reactions.some((r) => r.emoji === '👍')).toBe(true);
+    });
+
+    it('追加後に返される Reaction[] にその絵文字・count・userIds が含まれる', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      const reactions = addReaction(msg.id, userId1, '❤️');
+
+      const reaction = reactions.find((r) => r.emoji === '❤️');
+      expect(reaction).toBeDefined();
+      expect(reaction!.count).toBe(1);
+      expect(reaction!.userIds).toContain(userId1);
+    });
+
+    it('同じユーザーが同じ絵文字を二重に追加しても重複しない（UNIQUE制約）', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '🎉');
+      const reactions = addReaction(msg.id, userId1, '🎉');
+
+      const reaction = reactions.find((r) => r.emoji === '🎉');
+      expect(reaction!.count).toBe(1);
+      expect(reaction!.userIds.filter((id) => id === userId1).length).toBe(1);
+    });
+
+    it('複数ユーザーが同じ絵文字をリアクションすると count が増える', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '🔥');
+      const reactions = addReaction(msg.id, userId2, '🔥');
+
+      const reaction = reactions.find((r) => r.emoji === '🔥');
+      expect(reaction!.count).toBe(2);
+      expect(reaction!.userIds).toContain(userId1);
+      expect(reaction!.userIds).toContain(userId2);
+    });
+
+    it('存在しないメッセージにリアクションしようとするとエラーになる', () => {
+      expect(() => addReaction(99999, userId1, '👍')).toThrow();
+    });
+  });
+
+  describe('removeReaction', () => {
+    it('追加済みのリアクションを削除できる', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '👀');
+      const reactions = removeReaction(msg.id, userId1, '👀');
+
+      const reaction = reactions.find((r) => r.emoji === '👀');
+      expect(reaction).toBeUndefined();
+    });
+
+    it('削除後の Reaction[] にそのユーザーの userId が含まれない', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '🚀');
+      addReaction(msg.id, userId2, '🚀');
+      const reactions = removeReaction(msg.id, userId1, '🚀');
+
+      const reaction = reactions.find((r) => r.emoji === '🚀');
+      expect(reaction).toBeDefined();
+      expect(reaction!.userIds).not.toContain(userId1);
+      expect(reaction!.userIds).toContain(userId2);
+    });
+
+    it('存在しないリアクションを削除しようとしてもエラーにならない', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      expect(() => removeReaction(msg.id, userId1, '❌')).not.toThrow();
+    });
+  });
+
+  describe('getReactions', () => {
+    it('メッセージにリアクションがない場合は空配列を返す', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      const reactions = getReactions(msg.id);
+
+      expect(reactions).toEqual([]);
+    });
+
+    it('emoji ごとにグループ化して Reaction[] を返す', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '👍');
+      addReaction(msg.id, userId2, '👍');
+      addReaction(msg.id, userId1, '❤️');
+
+      const reactions = getReactions(msg.id);
+
+      expect(reactions.length).toBe(2);
+      expect(reactions.map((r) => r.emoji)).toContain('👍');
+      expect(reactions.map((r) => r.emoji)).toContain('❤️');
+    });
+
+    it('各 Reaction に emoji・count・userIds が含まれる', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '💯');
+
+      const reactions = getReactions(msg.id);
+      const reaction = reactions.find((r) => r.emoji === '💯');
+
+      expect(reaction).toBeDefined();
+      expect(typeof reaction!.emoji).toBe('string');
+      expect(typeof reaction!.count).toBe('number');
+      expect(Array.isArray(reaction!.userIds)).toBe(true);
+    });
+  });
+
+  describe('getChannelMessages - reactions フィールドの付与', () => {
+    it('取得したメッセージに reactions フィールドが含まれる', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+      addReaction(msg.id, userId1, '⭐');
+
+      const messages = getChannelMessages(channelId);
+      const found = messages.find((m) => m.id === msg.id);
+
+      expect(found).toBeDefined();
+      expect(Array.isArray(found!.reactions)).toBe(true);
+      expect(found!.reactions.some((r) => r.emoji === '⭐')).toBe(true);
+    });
+
+    it('リアクションがないメッセージの reactions は空配列になる', () => {
+      const msg = createMessage(channelId, userId1, sampleContent);
+
+      const messages = getChannelMessages(channelId);
+      const found = messages.find((m) => m.id === msg.id);
+
+      expect(found).toBeDefined();
+      expect(found!.reactions).toEqual([]);
+    });
+  });
+});
+
+// initializeSchema は jest.requireActual 経由でのみ使用しているため、
+// TypeScript の未使用インポートエラーを抑制するための参照
+void initializeSchema;

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -84,6 +84,15 @@ export function initializeSchema(database: Database.Database): void {
       auth TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
+
+    CREATE TABLE IF NOT EXISTS message_reactions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      emoji TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      UNIQUE (message_id, user_id, emoji)
+    );
   `);
 
   // 既存 DB に is_private カラムが存在しない場合は追加する

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -1,5 +1,5 @@
 import { getDatabase } from '../db/database';
-import { Attachment, Message, MessageSearchResult } from '@chat-app/shared';
+import { Attachment, Message, MessageSearchResult, Reaction } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
 
 interface MessageRow {
@@ -21,6 +21,26 @@ const MESSAGE_SELECT = `
   FROM messages m
   JOIN users u ON m.user_id = u.id
 `;
+
+function getReactionsForMessage(messageId: number): Reaction[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare('SELECT emoji, user_id FROM message_reactions WHERE message_id = ? ORDER BY emoji')
+    .all(messageId) as { emoji: string; user_id: number }[];
+
+  const map = new Map<string, number[]>();
+  for (const row of rows) {
+    const userIds = map.get(row.emoji) ?? [];
+    userIds.push(row.user_id);
+    map.set(row.emoji, userIds);
+  }
+
+  return Array.from(map.entries()).map(([emoji, userIds]) => ({
+    emoji,
+    count: userIds.length,
+    userIds,
+  }));
+}
 
 function getMentions(messageId: number): number[] {
   const db = getDatabase();
@@ -66,6 +86,7 @@ function toMessage(row: MessageRow): Message {
     updatedAt: row.updated_at,
     mentions: getMentions(row.id),
     attachments: getAttachments(row.id),
+    reactions: getReactionsForMessage(row.id),
   };
 }
 
@@ -221,4 +242,31 @@ export function getMessageById(messageId: number): Message | null {
     | MessageRow
     | undefined;
   return row ? toMessage(row) : null;
+}
+
+export function getReactions(messageId: number): Reaction[] {
+  return getReactionsForMessage(messageId);
+}
+
+export function addReaction(messageId: number, userId: number, emoji: string): Reaction[] {
+  const db = getDatabase();
+
+  const message = db.prepare('SELECT id FROM messages WHERE id = ?').get(messageId);
+  if (!message) throw createError('Message not found', 404);
+
+  db.prepare(
+    'INSERT OR IGNORE INTO message_reactions (message_id, user_id, emoji) VALUES (?, ?, ?)',
+  ).run(messageId, userId, emoji);
+
+  return getReactionsForMessage(messageId);
+}
+
+export function removeReaction(messageId: number, userId: number, emoji: string): Reaction[] {
+  const db = getDatabase();
+
+  db.prepare(
+    'DELETE FROM message_reactions WHERE message_id = ? AND user_id = ? AND emoji = ?',
+  ).run(messageId, userId, emoji);
+
+  return getReactionsForMessage(messageId);
 }

--- a/packages/server/src/socket/handler.ts
+++ b/packages/server/src/socket/handler.ts
@@ -125,5 +125,37 @@ export function setupSocketHandlers(io: ChatServer): void {
     socket.on('typing_stop', (channelId) => {
       socket.to(`channel:${channelId}`).emit('user_stopped_typing', { userId, channelId });
     });
+
+    socket.on('add_reaction', (data) => {
+      try {
+        const message = messageService.getMessageById(data.messageId);
+        if (!message) return;
+
+        const reactions = messageService.addReaction(data.messageId, userId, data.emoji);
+        io.to(`channel:${message.channelId}`).emit('reaction_updated', {
+          messageId: data.messageId,
+          channelId: message.channelId,
+          reactions,
+        });
+      } catch {
+        socket.emit('error', 'Failed to add reaction');
+      }
+    });
+
+    socket.on('remove_reaction', (data) => {
+      try {
+        const message = messageService.getMessageById(data.messageId);
+        if (!message) return;
+
+        const reactions = messageService.removeReaction(data.messageId, userId, data.emoji);
+        io.to(`channel:${message.channelId}`).emit('reaction_updated', {
+          messageId: data.messageId,
+          channelId: message.channelId,
+          reactions,
+        });
+      } catch {
+        socket.emit('error', 'Failed to remove reaction');
+      }
+    });
   });
 }

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -1,3 +1,9 @@
+export interface Reaction {
+  emoji: string;
+  count: number;
+  userIds: number[];
+}
+
 export interface Attachment {
   id: number;
   url: string;
@@ -19,6 +25,7 @@ export interface Message {
   updatedAt: string;
   mentions: number[];
   attachments?: Attachment[];
+  reactions: Reaction[];
 }
 
 export interface MessageSearchResult extends Message {

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -1,4 +1,4 @@
-import type { Message } from './message';
+import type { Message, Reaction } from './message';
 
 export interface ServerToClientEvents {
   new_message: (message: Message) => void;
@@ -8,6 +8,7 @@ export interface ServerToClientEvents {
   user_typing: (data: { userId: number; username: string; channelId: number }) => void;
   user_stopped_typing: (data: { userId: number; channelId: number }) => void;
   error: (message: string) => void;
+  reaction_updated: (data: { messageId: number; channelId: number; reactions: Reaction[] }) => void;
 }
 
 export interface ClientToServerEvents {
@@ -29,6 +30,8 @@ export interface ClientToServerEvents {
   restore_message: (messageId: number) => void;
   typing_start: (channelId: number) => void;
   typing_stop: (channelId: number) => void;
+  add_reaction: (data: { messageId: number; emoji: string }) => void;
+  remove_reaction: (data: { messageId: number; emoji: string }) => void;
 }
 
 export interface InterServerEvents {}


### PR DESCRIPTION
## 概要

メッセージに絵文字リアクションを付与・取り消しできる機能を実装。同じ絵文字に複数ユーザーが反応でき、カウント表示する。

## 変更内容

- **DBスキーマ**: `message_reactions` テーブルを追加（`db/schema.hcl`・`database.ts`）
- **共有型**: `Reaction` インターフェース追加、`Message` に `reactions` フィールド追加、Socket型に `add_reaction`・`remove_reaction`・`reaction_updated` イベント追加
- **バックエンド**: `messageService.ts` に `addReaction`・`removeReaction`・`getReactions` 追加。`toMessage()` が `reactions` を返すよう変更。`handler.ts` に Socket イベントハンドラ追加
- **フロントエンド**: `EmojiPicker.tsx`（新規）・`ReactionBadge.tsx`（新規）を追加。`MessageItem.tsx` にピッカー起動ボタン・バッジ表示・`reaction_updated` Socket リスナーを追加

## 影響範囲

- `packages/shared/src/types/message.ts` — `Reaction` 型追加・`Message.reactions` 追加（既存テストの `makeMessage` に `reactions: []` 追加が必要 → 対応済み）
- `packages/shared/src/types/socket.ts` — 新規Socketイベント3件追加
- `packages/server/src/services/messageService.ts` — `toMessage()` の返り値が変わるため、既存のメッセージ取得レスポンスに `reactions` が付加される
- `packages/server/src/socket/handler.ts` — 新規Socketイベントハンドラ2件追加
- `packages/client/src/components/Chat/MessageItem.tsx` — ホバーアクションバー・バブル内部を変更
- 既存テスト5ファイル — `makeMessage` に `reactions: []` を追加（型変更への対応。テストの意図・アサーションは変更なし）

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（191件）
- [x] バックエンドユニットテストがすべてパスする（179件）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #29

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した