### PR TITLE
feat: 管理者機能を実装

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -103,9 +103,9 @@ table "channels" {
     comment = "チャンネル説明"
   }
   column "created_by" {
-    null    = false
+    null    = true
     type    = integer
-    comment = "作成者ユーザーID"
+    comment = "作成者ユーザーID（ユーザー削除時に NULL になる）"
   }
   column "is_private" {
     null    = false
@@ -126,7 +126,7 @@ table "channels" {
     columns     = [column.created_by]
     ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
-    on_delete   = NO_ACTION
+    on_delete   = SET_NULL
   }
   index "channels_name" {
     unique  = true
@@ -185,9 +185,9 @@ table "messages" {
     comment = "チャンネルID"
   }
   column "user_id" {
-    null    = false
+    null    = true
     type    = integer
-    comment = "投稿者ユーザーID"
+    comment = "投稿者ユーザーID（ユーザー削除時に NULL になる）"
   }
   column "content" {
     null    = false
@@ -225,7 +225,7 @@ table "messages" {
     columns     = [column.user_id]
     ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
-    on_delete   = NO_ACTION
+    on_delete   = SET_NULL
   }
   foreign_key "1" {
     columns     = [column.channel_id]

--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -53,6 +53,23 @@ table "users" {
     type    = text
     comment = "所在地"
   }
+  column "role" {
+    null    = false
+    type    = text
+    default = "user"
+    comment = "ロール（user / admin）"
+  }
+  column "is_active" {
+    null    = false
+    type    = integer
+    default = 1
+    comment = "アカウント有効フラグ（0: 停止中, 1: 有効）"
+  }
+  column "last_login_at" {
+    null    = true
+    type    = text
+    comment = "最終ログイン日時"
+  }
   primary_key {
     columns = [column.id]
   }

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -8,6 +8,7 @@ import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ChatPage from './pages/ChatPage';
 import ProfilePage from './pages/ProfilePage';
+import AdminPage from './pages/AdminPage';
 import { api } from './api/client';
 import type { User } from '@chat-app/shared';
 
@@ -80,6 +81,14 @@ function AppRoutes() {
         element={
           <RequireAuth>
             <ProfilePage />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/admin"
+        element={
+          <RequireAuth>
+            <AdminPage />
           </RequireAuth>
         }
       />

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -168,11 +168,12 @@ describe('AdminPage: ユーザー管理タブ', () => {
     expect(mockedApi.admin.updateUserRole).toHaveBeenCalledWith(2, 'admin');
   });
 
-  it('停止ボタンを押すと updateUserStatus が呼ばれる', async () => {
+  it('停止ボタンを押すと updateUserStatus が bob (id=2) を対象に呼ばれる', async () => {
     await openUsersTab();
+    // alice は自分自身のため停止ボタンが最初に出るのは bob (id=2)
     const suspendButtons = screen.getAllByRole('button', { name: '停止' });
     await userEvent.click(suspendButtons[0]);
-    expect(mockedApi.admin.updateUserStatus).toHaveBeenCalledWith(expect.any(Number), false);
+    expect(mockedApi.admin.updateUserStatus).toHaveBeenCalledWith(2, false);
   });
 
   it('削除ボタンを押すと確認ダイアログが表示される', async () => {
@@ -229,5 +230,45 @@ describe('AdminPage: チャンネル管理タブ', () => {
     const confirmButtons = screen.getAllByRole('button', { name: '削除' });
     await userEvent.click(confirmButtons[confirmButtons.length - 1]);
     expect(mockedApi.admin.deleteChannel).toHaveBeenCalled();
+  });
+});
+
+describe('AdminPage: エラーハンドリング', () => {
+  it('getStats が reject するとエラーメッセージが表示される', async () => {
+    mockedApi.admin.getStats.mockRejectedValue(new Error('サーバーエラー'));
+    // ErrorBoundary がエラーをキャッチするため console.error を抑制
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await renderAdminPage();
+    expect(screen.getByText(/エラーが発生しました/)).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it('updateUserRole が reject してもユーザーリストの状態は変化しない', async () => {
+    mockedApi.admin.updateUserRole.mockRejectedValue(new Error('権限エラー'));
+    await renderAdminPage();
+    await userEvent.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
+    await act(async () => {});
+    await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
+
+    // bob のロール変更を試みる（API は reject）
+    const roleButtons = screen.getAllByRole('button', { name: 'admin に変更' });
+    await userEvent.click(roleButtons[0]);
+
+    // setUsers が呼ばれないため bob のロールは 'user' のまま
+    await waitFor(() => {
+      const chips = screen.getAllByText('user');
+      // bob と carol の user ロールチップが残っていること
+      expect(chips.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+
+describe('AdminPage: 非管理者アクセス', () => {
+  it('非管理者ユーザーはトップページにリダイレクトされる', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 2, username: 'bob', role: 'user', isActive: true },
+    });
+    await renderAdminPage();
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
   });
 });

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * AdminPage のテスト
+ *
+ * テスト対象: packages/client/src/pages/AdminPage.tsx
+ * 戦略: vi.mock('../api/client') でAPIをモック化し、
+ * 統計・ユーザー管理・チャンネル管理の各タブの動作を検証する。
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import AdminPage from '../pages/AdminPage';
+import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockAdminUsers: AdminUser[] = [
+  {
+    id: 1,
+    username: 'alice',
+    email: 'alice@example.com',
+    role: 'admin',
+    isActive: true,
+    lastLoginAt: '2025-01-10T00:00:00Z',
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    username: 'bob',
+    email: 'bob@example.com',
+    role: 'user',
+    isActive: true,
+    lastLoginAt: '2025-01-09T00:00:00Z',
+    createdAt: '2024-01-02T00:00:00Z',
+  },
+  {
+    id: 3,
+    username: 'carol',
+    email: 'carol@example.com',
+    role: 'user',
+    isActive: false,
+    lastLoginAt: null,
+    createdAt: '2024-01-03T00:00:00Z',
+  },
+];
+
+const mockAdminChannels: AdminChannel[] = [
+  {
+    id: 1,
+    name: 'general',
+    description: null,
+    isPrivate: false,
+    memberCount: 3,
+    createdAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    name: 'secret',
+    description: 'private channel',
+    isPrivate: true,
+    memberCount: 1,
+    createdAt: '2024-01-02T00:00:00Z',
+  },
+];
+
+const mockStats: AdminStats = {
+  totalUsers: 42,
+  totalChannels: 12,
+  totalMessages: 1840,
+  activeUsersLast24h: 5,
+  activeUsersLast7d: 20,
+};
+
+vi.mock('../api/client', () => ({
+  api: {
+    admin: {
+      getStats: vi.fn(),
+      getUsers: vi.fn(),
+      getChannels: vi.fn(),
+      updateUserRole: vi.fn(),
+      updateUserStatus: vi.fn(),
+      deleteUser: vi.fn(),
+      deleteChannel: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+import { api } from '../api/client';
+import { useAuth } from '../contexts/AuthContext';
+
+const mockedApi = api as unknown as {
+  admin: {
+    getStats: ReturnType<typeof vi.fn>;
+    getUsers: ReturnType<typeof vi.fn>;
+    getChannels: ReturnType<typeof vi.fn>;
+    updateUserRole: ReturnType<typeof vi.fn>;
+    updateUserStatus: ReturnType<typeof vi.fn>;
+    deleteUser: ReturnType<typeof vi.fn>;
+    deleteChannel: ReturnType<typeof vi.fn>;
+  };
+};
+const mockedUseAuth = useAuth as ReturnType<typeof vi.fn>;
+
+/** use() + Suspense をフラッシュするため await act でラップする */
+async function renderAdminPage() {
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <AdminPage />
+      </MemoryRouter>,
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseAuth.mockReturnValue({
+    user: { id: 1, username: 'alice', role: 'admin', isActive: true },
+  });
+  mockedApi.admin.getStats.mockResolvedValue(mockStats);
+  mockedApi.admin.getUsers.mockResolvedValue({ users: mockAdminUsers });
+  mockedApi.admin.getChannels.mockResolvedValue({ channels: mockAdminChannels });
+  mockedApi.admin.updateUserRole.mockResolvedValue({ success: true });
+  mockedApi.admin.updateUserStatus.mockResolvedValue({ success: true });
+  mockedApi.admin.deleteUser.mockResolvedValue(undefined);
+  mockedApi.admin.deleteChannel.mockResolvedValue(undefined);
+});
+
+describe('AdminPage: 統計タブ', () => {
+  it('統計カード（ユーザー数・チャンネル数・総メッセージ数）が表示される', async () => {
+    await renderAdminPage();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('1,840')).toBeInTheDocument();
+  });
+});
+
+describe('AdminPage: ユーザー管理タブ', () => {
+  async function openUsersTab() {
+    await renderAdminPage();
+    await userEvent.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
+    await act(async () => {});
+    await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
+  }
+
+  it('ユーザー一覧テーブルが表示される', async () => {
+    await openUsersTab();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByText('carol')).toBeInTheDocument();
+  });
+
+  it('ロール変更ボタンを押すと updateUserRole が呼ばれる', async () => {
+    await openUsersTab();
+    // bob (id=2, role='user') の「admin に変更」ボタン
+    const roleButtons = screen.getAllByRole('button', { name: 'admin に変更' });
+    await userEvent.click(roleButtons[0]);
+    expect(mockedApi.admin.updateUserRole).toHaveBeenCalledWith(2, 'admin');
+  });
+
+  it('停止ボタンを押すと updateUserStatus が呼ばれる', async () => {
+    await openUsersTab();
+    const suspendButtons = screen.getAllByRole('button', { name: '停止' });
+    await userEvent.click(suspendButtons[0]);
+    expect(mockedApi.admin.updateUserStatus).toHaveBeenCalledWith(expect.any(Number), false);
+  });
+
+  it('削除ボタンを押すと確認ダイアログが表示される', async () => {
+    await openUsersTab();
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    await userEvent.click(deleteButtons[0]);
+    expect(screen.getByText('ユーザーを削除しますか？')).toBeInTheDocument();
+  });
+
+  it('確認ダイアログで「削除」を押すと deleteUser が呼ばれる', async () => {
+    await openUsersTab();
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    await userEvent.click(deleteButtons[0]);
+    // ダイアログ内の「削除」ボタンをクリック
+    const confirmButtons = screen.getAllByRole('button', { name: '削除' });
+    await userEvent.click(confirmButtons[confirmButtons.length - 1]);
+    expect(mockedApi.admin.deleteUser).toHaveBeenCalled();
+  });
+
+  it('自分自身（alice, id=1）の行にはロール変更・削除ボタンが非表示', async () => {
+    await openUsersTab();
+    // alice 行のセルを探す（1行目 = alice）
+    const rows = screen.getAllByRole('row');
+    const aliceRow = rows.find((r) => r.textContent?.includes('alice'));
+    expect(aliceRow).toBeDefined();
+    // alice 行内に「admin に変更」「user に変更」「削除」ボタンがないこと
+    const buttonsInRow = aliceRow!.querySelectorAll('button');
+    const labels = Array.from(buttonsInRow).map((b) => b.textContent);
+    expect(labels).not.toContain('admin に変更');
+    expect(labels).not.toContain('user に変更');
+    expect(labels).not.toContain('削除');
+  });
+});
+
+describe('AdminPage: チャンネル管理タブ', () => {
+  async function openChannelsTab() {
+    await renderAdminPage();
+    await userEvent.click(screen.getByRole('tab', { name: 'チャンネル管理' }));
+    await act(async () => {});
+    await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
+  }
+
+  it('チャンネル一覧テーブルが表示される', async () => {
+    await openChannelsTab();
+    expect(screen.getByText('general')).toBeInTheDocument();
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+
+  it('削除ボタンを押すと確認ダイアログ → deleteChannel が呼ばれる', async () => {
+    await openChannelsTab();
+    const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+    await userEvent.click(deleteButtons[0]);
+    expect(screen.getByText('チャンネルを削除しますか？')).toBeInTheDocument();
+    const confirmButtons = screen.getAllByRole('button', { name: '削除' });
+    await userEvent.click(confirmButtons[confirmButtons.length - 1]);
+    expect(mockedApi.admin.deleteChannel).toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/__tests__/AuthContext.test.tsx
+++ b/packages/client/src/__tests__/AuthContext.test.tsx
@@ -45,6 +45,8 @@ const dummyUser: User = {
   displayName: null,
   location: null,
   createdAt: '2024-01-01T00:00:00Z',
+  role: 'user',
+  isActive: true,
 };
 
 beforeEach(() => {

--- a/packages/client/src/__tests__/ChannelList.test.tsx
+++ b/packages/client/src/__tests__/ChannelList.test.tsx
@@ -43,6 +43,17 @@ vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => mockSocket,
 }));
 
+// AuthContext をモック（ChannelList が useAuth でロールを参照するため）
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 1, role: 'user', isActive: true } }),
+}));
+
+// react-router-dom の useNavigate をモック
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
 import { api } from '../api/client';
 const mockChannels = api.channels as unknown as {
   list: ReturnType<typeof vi.fn>;

--- a/packages/client/src/__tests__/MessageItemAttachment.test.tsx
+++ b/packages/client/src/__tests__/MessageItemAttachment.test.tsx
@@ -34,6 +34,8 @@ const dummyUsers: User[] = [
     displayName: null,
     location: null,
     createdAt: '2024-01-01T00:00:00Z',
+    role: 'user',
+    isActive: true,
   },
 ];
 

--- a/packages/client/src/__tests__/RichEditor.test.tsx
+++ b/packages/client/src/__tests__/RichEditor.test.tsx
@@ -87,6 +87,8 @@ const dummyUsers: User[] = [
     displayName: null,
     location: null,
     createdAt: '2024-01-01T00:00:00Z',
+    role: 'user',
+    isActive: true,
   },
   {
     id: 2,
@@ -96,6 +98,8 @@ const dummyUsers: User[] = [
     displayName: null,
     location: null,
     createdAt: '2024-01-01T00:00:00Z',
+    role: 'user',
+    isActive: true,
   },
   {
     id: 3,
@@ -105,6 +109,8 @@ const dummyUsers: User[] = [
     displayName: null,
     location: null,
     createdAt: '2024-01-01T00:00:00Z',
+    role: 'user',
+    isActive: true,
   },
 ];
 

--- a/packages/client/src/__tests__/__fixtures__/users.ts
+++ b/packages/client/src/__tests__/__fixtures__/users.ts
@@ -13,6 +13,8 @@ export const dummyUsers: User[] = [
     displayName: null,
     location: null,
     createdAt: '2024-01-01T00:00:00Z',
+    role: 'user',
+    isActive: true,
   },
   {
     id: 2,
@@ -22,5 +24,7 @@ export const dummyUsers: User[] = [
     displayName: null,
     location: null,
     createdAt: '2024-01-01T00:00:00Z',
+    role: 'user',
+    isActive: true,
   },
 ];

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -1,4 +1,5 @@
 import type { Attachment, User, Channel, Message, MessageSearchResult } from '@chat-app/shared';
+import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
 
 const BASE = '/api';
 
@@ -97,5 +98,22 @@ export const api = {
       request<void>('/push/subscribe', { method: 'POST', body: JSON.stringify(sub) }),
     unsubscribe: (endpoint: string) =>
       request<void>('/push/unsubscribe', { method: 'DELETE', body: JSON.stringify({ endpoint }) }),
+  },
+  admin: {
+    getUsers: () => request<{ users: AdminUser[] }>('/admin/users'),
+    updateUserRole: (id: number, role: 'user' | 'admin') =>
+      request<{ success: boolean }>(`/admin/users/${id}/role`, {
+        method: 'PATCH',
+        body: JSON.stringify({ role }),
+      }),
+    updateUserStatus: (id: number, isActive: boolean) =>
+      request<{ success: boolean }>(`/admin/users/${id}/status`, {
+        method: 'PATCH',
+        body: JSON.stringify({ isActive }),
+      }),
+    deleteUser: (id: number) => request<void>(`/admin/users/${id}`, { method: 'DELETE' }),
+    getChannels: () => request<{ channels: AdminChannel[] }>('/admin/channels'),
+    deleteChannel: (id: number) => request<void>(`/admin/channels/${id}`, { method: 'DELETE' }),
+    getStats: () => request<AdminStats>('/admin/stats'),
   },
 };

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -19,9 +19,12 @@ import PushPinIcon from '@mui/icons-material/PushPin';
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined';
 import LockIcon from '@mui/icons-material/Lock';
 import GroupAddIcon from '@mui/icons-material/GroupAdd';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import type { Channel, Message } from '@chat-app/shared';
 import { api } from '../../api/client';
 import { useSocket } from '../../contexts/SocketContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 import CreateChannelDialog from './CreateChannelDialog';
 import ChannelMembersDialog from './ChannelMembersDialog';
 
@@ -61,6 +64,8 @@ function ChannelListContent({
   const [pinnedIds, setPinnedIds] = useState<number[]>(loadPins);
   const [hoveredId, setHoveredId] = useState<number | null>(null);
   const socket = useSocket();
+  const { user } = useAuth();
+  const navigate = useNavigate();
 
   // 非アクティブチャンネルの new_message を受信して unreadCount をインクリメント
   useEffect(() => {
@@ -285,6 +290,18 @@ function ChannelListContent({
           ))}
         </List>
       </Box>
+
+      {user?.role === 'admin' && (
+        <>
+          <Divider sx={{ mt: 1 }} />
+          <List dense disablePadding>
+            <ListItemButton onClick={() => navigate('/admin')}>
+              <AdminPanelSettingsIcon sx={{ fontSize: 16, mr: 1, color: 'text.secondary' }} />
+              <ListItemText primary="管理画面" primaryTypographyProps={{ fontSize: 14 }} />
+            </ListItemButton>
+          </List>
+        </>
+      )}
 
       <CreateChannelDialog
         open={dialogOpen}

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,0 +1,305 @@
+import { useState, useMemo, use, Suspense } from 'react';
+import {
+  Box,
+  Tab,
+  Tabs,
+  Typography,
+  Card,
+  CardContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Button,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+} from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { api } from '../api/client';
+import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
+
+// ─── 統計タブ ────────────────────────────────────────────────
+function StatsContent({ statsPromise }: { statsPromise: Promise<AdminStats> }) {
+  const stats = use(statsPromise);
+  const cards: { label: string; value: number }[] = [
+    { label: 'ユーザー数', value: stats.totalUsers },
+    { label: 'チャンネル数', value: stats.totalChannels },
+    { label: '総メッセージ数', value: stats.totalMessages },
+    { label: '24h アクティブ', value: stats.activeUsersLast24h },
+    { label: '7日 アクティブ', value: stats.activeUsersLast7d },
+  ];
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', p: 2 }}>
+      {cards.map(({ label, value }) => (
+        <Card key={label} sx={{ minWidth: 160 }}>
+          <CardContent>
+            <Typography variant="h4" fontWeight="bold">
+              {value.toLocaleString()}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {label}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}
+
+// ─── ユーザー管理タブ ─────────────────────────────────────────
+function UsersContent({
+  usersPromise,
+  currentUserId,
+}: {
+  usersPromise: Promise<{ users: AdminUser[] }>;
+  currentUserId: number;
+}) {
+  const { users: initial } = use(usersPromise);
+  const [users, setUsers] = useState<AdminUser[]>(initial);
+  const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
+
+  const handleRoleToggle = async (user: AdminUser) => {
+    const newRole = user.role === 'admin' ? 'user' : 'admin';
+    await api.admin.updateUserRole(user.id, newRole);
+    setUsers((prev) => prev.map((u) => (u.id === user.id ? { ...u, role: newRole } : u)));
+  };
+
+  const handleStatusToggle = async (user: AdminUser) => {
+    const newActive = !user.isActive;
+    await api.admin.updateUserStatus(user.id, newActive);
+    setUsers((prev) => prev.map((u) => (u.id === user.id ? { ...u, isActive: newActive } : u)));
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await api.admin.deleteUser(deleteTarget.id);
+    setUsers((prev) => prev.filter((u) => u.id !== deleteTarget.id));
+    setDeleteTarget(null);
+  };
+
+  return (
+    <>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>ユーザー名</TableCell>
+            <TableCell>メール</TableCell>
+            <TableCell>ロール</TableCell>
+            <TableCell>状態</TableCell>
+            <TableCell>最終ログイン</TableCell>
+            <TableCell>操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {users.map((user) => {
+            const isSelf = user.id === currentUserId;
+            return (
+              <TableRow key={user.id}>
+                <TableCell>{user.username}</TableCell>
+                <TableCell>{user.email}</TableCell>
+                <TableCell>
+                  <Chip
+                    label={user.role}
+                    color={user.role === 'admin' ? 'primary' : 'default'}
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell>
+                  <Chip
+                    label={user.isActive ? '有効' : '停止中'}
+                    color={user.isActive ? 'success' : 'error'}
+                    size="small"
+                  />
+                </TableCell>
+                <TableCell>
+                  {user.lastLoginAt ? new Date(user.lastLoginAt).toLocaleDateString('ja-JP') : '—'}
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', gap: 1 }}>
+                    {!isSelf && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        onClick={() => void handleRoleToggle(user)}
+                      >
+                        {user.role === 'admin' ? 'user に変更' : 'admin に変更'}
+                      </Button>
+                    )}
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color={user.isActive ? 'warning' : 'success'}
+                      onClick={() => void handleStatusToggle(user)}
+                    >
+                      {user.isActive ? '停止' : '復活'}
+                    </Button>
+                    {!isSelf && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color="error"
+                        onClick={() => setDeleteTarget(user)}
+                      >
+                        削除
+                      </Button>
+                    )}
+                  </Box>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+
+      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>ユーザーを削除しますか？</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {deleteTarget?.username} を削除します。この操作は取り消せません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>キャンセル</Button>
+          <Button color="error" onClick={() => void handleDelete()}>
+            削除
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+// ─── チャンネル管理タブ ───────────────────────────────────────
+function ChannelsContent({
+  channelsPromise,
+}: {
+  channelsPromise: Promise<{ channels: AdminChannel[] }>;
+}) {
+  const { channels: initial } = use(channelsPromise);
+  const [channels, setChannels] = useState<AdminChannel[]>(initial);
+  const [deleteTarget, setDeleteTarget] = useState<AdminChannel | null>(null);
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    await api.admin.deleteChannel(deleteTarget.id);
+    setChannels((prev) => prev.filter((c) => c.id !== deleteTarget.id));
+    setDeleteTarget(null);
+  };
+
+  return (
+    <>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>チャンネル名</TableCell>
+            <TableCell>説明</TableCell>
+            <TableCell>種別</TableCell>
+            <TableCell>メンバー数</TableCell>
+            <TableCell>操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {channels.map((ch) => (
+            <TableRow key={ch.id}>
+              <TableCell>{ch.name}</TableCell>
+              <TableCell>{ch.description ?? '—'}</TableCell>
+              <TableCell>
+                <Chip
+                  label={ch.isPrivate ? 'プライベート' : '公開'}
+                  size="small"
+                  color={ch.isPrivate ? 'warning' : 'default'}
+                />
+              </TableCell>
+              <TableCell>{ch.memberCount}</TableCell>
+              <TableCell>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  color="error"
+                  onClick={() => setDeleteTarget(ch)}
+                >
+                  削除
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
+        <DialogTitle>チャンネルを削除しますか？</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            #{deleteTarget?.name} を削除します。この操作は取り消せません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteTarget(null)}>キャンセル</Button>
+          <Button color="error" onClick={() => void handleDelete()}>
+            削除
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}
+
+// ─── メインコンポーネント ─────────────────────────────────────
+export default function AdminPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [tab, setTab] = useState(0);
+
+  // admin 以外はトップにリダイレクト
+  if (!user || user.role !== 'admin') {
+    navigate('/', { replace: true });
+    return null;
+  }
+
+  const statsPromise = useMemo(() => api.admin.getStats(), []);
+  const usersPromise = useMemo(() => api.admin.getUsers(), []);
+  const channelsPromise = useMemo(() => api.admin.getChannels(), []);
+
+  const fallback = (
+    <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+      <CircularProgress />
+    </Box>
+  );
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography variant="h5" fontWeight="bold" mb={2}>
+        管理画面
+      </Typography>
+
+      <Tabs value={tab} onChange={(_, v: number) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label="統計" />
+        <Tab label="ユーザー管理" />
+        <Tab label="チャンネル管理" />
+      </Tabs>
+
+      {tab === 0 && (
+        <Suspense fallback={fallback}>
+          <StatsContent statsPromise={statsPromise} />
+        </Suspense>
+      )}
+      {tab === 1 && (
+        <Suspense fallback={fallback}>
+          <UsersContent usersPromise={usersPromise} currentUserId={user.id} />
+        </Suspense>
+      )}
+      {tab === 2 && (
+        <Suspense fallback={fallback}>
+          <ChannelsContent channelsPromise={channelsPromise} />
+        </Suspense>
+      )}
+    </Box>
+  );
+}

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, use, Suspense } from 'react';
+import { useState, useMemo, use, Suspense, Component, ReactNode } from 'react';
 import {
   Box,
   Tab,
@@ -67,8 +67,12 @@ function UsersContent({
 
   const handleRoleToggle = async (user: AdminUser) => {
     const newRole = user.role === 'admin' ? 'user' : 'admin';
-    await api.admin.updateUserRole(user.id, newRole);
-    setUsers((prev) => prev.map((u) => (u.id === user.id ? { ...u, role: newRole } : u)));
+    try {
+      await api.admin.updateUserRole(user.id, newRole);
+      setUsers((prev) => prev.map((u) => (u.id === user.id ? { ...u, role: newRole } : u)));
+    } catch {
+      // API エラー時は状態を変更しない
+    }
   };
 
   const handleStatusToggle = async (user: AdminUser) => {
@@ -132,14 +136,16 @@ function UsersContent({
                         {user.role === 'admin' ? 'user に変更' : 'admin に変更'}
                       </Button>
                     )}
-                    <Button
-                      size="small"
-                      variant="outlined"
-                      color={user.isActive ? 'warning' : 'success'}
-                      onClick={() => void handleStatusToggle(user)}
-                    >
-                      {user.isActive ? '停止' : '復活'}
-                    </Button>
+                    {!isSelf && (
+                      <Button
+                        size="small"
+                        variant="outlined"
+                        color={user.isActive ? 'warning' : 'success'}
+                        onClick={() => void handleStatusToggle(user)}
+                      >
+                        {user.isActive ? '停止' : '復活'}
+                      </Button>
+                    )}
                     {!isSelf && (
                       <Button
                         size="small"
@@ -251,6 +257,35 @@ function ChannelsContent({
   );
 }
 
+// ─── ErrorBoundary ───────────────────────────────────────────
+interface ErrorBoundaryState {
+  hasError: boolean;
+  message: string;
+}
+
+class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false, message: '' };
+  }
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    const message = error instanceof Error ? error.message : 'エラーが発生しました';
+    return { hasError: true, message };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box sx={{ p: 2, color: 'error.main' }}>
+          <Typography>エラーが発生しました: {this.state.message}</Typography>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 // ─── メインコンポーネント ─────────────────────────────────────
 export default function AdminPage() {
   const { user } = useAuth();
@@ -286,19 +321,25 @@ export default function AdminPage() {
       </Tabs>
 
       {tab === 0 && (
-        <Suspense fallback={fallback}>
-          <StatsContent statsPromise={statsPromise} />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={fallback}>
+            <StatsContent statsPromise={statsPromise} />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {tab === 1 && (
-        <Suspense fallback={fallback}>
-          <UsersContent usersPromise={usersPromise} currentUserId={user.id} />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={fallback}>
+            <UsersContent usersPromise={usersPromise} currentUserId={user.id} />
+          </Suspense>
+        </ErrorBoundary>
       )}
       {tab === 2 && (
-        <Suspense fallback={fallback}>
-          <ChannelsContent channelsPromise={channelsPromise} />
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={fallback}>
+            <ChannelsContent channelsPromise={channelsPromise} />
+          </Suspense>
+        </ErrorBoundary>
       )}
     </Box>
   );

--- a/packages/client/src/types/admin.ts
+++ b/packages/client/src/types/admin.ts
@@ -1,0 +1,26 @@
+export interface AdminUser {
+  id: number;
+  username: string;
+  email: string;
+  role: 'user' | 'admin';
+  isActive: boolean;
+  lastLoginAt: string | null;
+  createdAt: string;
+}
+
+export interface AdminChannel {
+  id: number;
+  name: string;
+  description: string | null;
+  isPrivate: boolean;
+  memberCount: number;
+  createdAt: string;
+}
+
+export interface AdminStats {
+  totalUsers: number;
+  totalChannels: number;
+  totalMessages: number;
+  activeUsersLast24h: number;
+  activeUsersLast7d: number;
+}

--- a/packages/server/src/__tests__/integration/adminController.test.ts
+++ b/packages/server/src/__tests__/integration/adminController.test.ts
@@ -1,0 +1,345 @@
+/**
+ * adminController のHTTPレベルテスト
+ *
+ * テスト対象: packages/server/src/controllers/adminController.ts
+ * 戦略: supertest でHTTPリクエストを発行し、管理者APIの認可・動作を検証する。
+ * DB は better-sqlite3 のインメモリ DB を使用。
+ */
+
+import request from 'supertest';
+import { createApp } from '../../app';
+import { registerUser } from '../__fixtures__/testHelpers';
+import { getDatabase } from '../../db/database';
+
+jest.mock('../../db/database', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DatabaseLib = require('better-sqlite3') as typeof import('better-sqlite3');
+  const db = new DatabaseLib(':memory:');
+  db.pragma('foreign_keys = ON');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../../db/database')>('../../db/database');
+  init(db);
+  return {
+    getDatabase: () => db,
+    initializeSchema: init,
+    closeDatabase: jest.fn(),
+  };
+});
+
+const app = createApp();
+
+/** DB でユーザーを admin に昇格するヘルパー */
+function makeAdmin(userId: number): void {
+  getDatabase().prepare("UPDATE users SET role = 'admin' WHERE id = ?").run(userId);
+}
+
+describe('GET /api/admin/users', () => {
+  it('正常: admin がリクエストすると全ユーザー一覧を返す', async () => {
+    const { token, userId } = await registerUser(app, 'adm_list', 'adm_list@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/users').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.users)).toBe(true);
+    expect(res.body.users[0]).toHaveProperty('role');
+    expect(res.body.users[0]).toHaveProperty('isActive');
+  });
+
+  it('異常: 非ログインは 401', async () => {
+    const res = await request(app).get('/api/admin/users');
+    expect(res.status).toBe(401);
+  });
+
+  it('異常: 一般ユーザーは 403', async () => {
+    const { token } = await registerUser(app, 'adm_user403', 'adm_user403@example.com');
+    const res = await request(app).get('/api/admin/users').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('PATCH /api/admin/users/:id/role', () => {
+  it('正常: admin が他ユーザーのロールを変更できる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_role1', 'adm_role1@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(
+      app,
+      'adm_role_tgt',
+      'adm_role_tgt@example.com',
+    );
+
+    const res = await request(app)
+      .patch(`/api/admin/users/${targetId}/role`)
+      .set('Cookie', `token=${token}`)
+      .send({ role: 'admin' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('異常: admin が自分自身のロールを変更しようとすると 400', async () => {
+    const { token, userId } = await registerUser(app, 'adm_role_self', 'adm_role_self@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app)
+      .patch(`/api/admin/users/${userId}/role`)
+      .set('Cookie', `token=${token}`)
+      .send({ role: 'user' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('異常: 無効なロール値は 400', async () => {
+    const { token, userId } = await registerUser(app, 'adm_role_bad', 'adm_role_bad@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(
+      app,
+      'adm_role_tgt2',
+      'adm_role_tgt2@example.com',
+    );
+
+    const res = await request(app)
+      .patch(`/api/admin/users/${targetId}/role`)
+      .set('Cookie', `token=${token}`)
+      .send({ role: 'superuser' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('異常: 存在しないユーザーIDは 404', async () => {
+    const { token, userId } = await registerUser(app, 'adm_role_404', 'adm_role_404@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app)
+      .patch('/api/admin/users/99999/role')
+      .set('Cookie', `token=${token}`)
+      .send({ role: 'user' });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PATCH /api/admin/users/:id/status', () => {
+  it('正常: admin がユーザーを停止できる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_status1', 'adm_status1@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(
+      app,
+      'adm_status_tgt',
+      'adm_status_tgt@example.com',
+    );
+
+    const res = await request(app)
+      .patch(`/api/admin/users/${targetId}/status`)
+      .set('Cookie', `token=${token}`)
+      .send({ isActive: false });
+
+    expect(res.status).toBe(200);
+    const row = getDatabase().prepare('SELECT is_active FROM users WHERE id = ?').get(targetId) as {
+      is_active: number;
+    };
+    expect(row.is_active).toBe(0);
+  });
+
+  it('正常: admin が停止中ユーザーを復活できる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_status2', 'adm_status2@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(
+      app,
+      'adm_status_tgt2',
+      'adm_status_tgt2@example.com',
+    );
+
+    await request(app)
+      .patch(`/api/admin/users/${targetId}/status`)
+      .set('Cookie', `token=${token}`)
+      .send({ isActive: false });
+
+    const res = await request(app)
+      .patch(`/api/admin/users/${targetId}/status`)
+      .set('Cookie', `token=${token}`)
+      .send({ isActive: true });
+
+    expect(res.status).toBe(200);
+    const row = getDatabase().prepare('SELECT is_active FROM users WHERE id = ?').get(targetId) as {
+      is_active: number;
+    };
+    expect(row.is_active).toBe(1);
+  });
+
+  it('異常: 停止中ユーザーはログインで 403 が返る', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'adm_suspend_adm',
+      'adm_suspend_adm@example.com',
+    );
+    makeAdmin(userId);
+    await registerUser(app, 'adm_suspended', 'adm_suspended@example.com');
+    const suspendedRow = getDatabase()
+      .prepare('SELECT id FROM users WHERE username = ?')
+      .get('adm_suspended') as { id: number };
+
+    await request(app)
+      .patch(`/api/admin/users/${suspendedRow.id}/status`)
+      .set('Cookie', `token=${token}`)
+      .send({ isActive: false });
+
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'adm_suspended@example.com', password: 'password123' });
+
+    expect(loginRes.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/admin/users/:id', () => {
+  it('正常: admin が別ユーザーを削除できる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_del1', 'adm_del1@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(app, 'adm_del_tgt', 'adm_del_tgt@example.com');
+
+    const res = await request(app)
+      .delete(`/api/admin/users/${targetId}`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(204);
+    const row = getDatabase().prepare('SELECT id FROM users WHERE id = ?').get(targetId);
+    expect(row).toBeUndefined();
+  });
+
+  it('異常: admin が自分自身を削除しようとすると 400', async () => {
+    const { token, userId } = await registerUser(app, 'adm_del_self', 'adm_del_self@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app)
+      .delete(`/api/admin/users/${userId}`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/admin/channels', () => {
+  it('正常: admin が全チャンネル（プライベート含む）を取得できる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_ch1', 'adm_ch1@example.com');
+    makeAdmin(userId);
+
+    // プライベートチャンネルを作成
+    getDatabase()
+      .prepare("INSERT INTO channels (name, created_by, is_private) VALUES ('priv-test-ch', ?, 1)")
+      .run(userId);
+
+    const res = await request(app).get('/api/admin/channels').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.channels)).toBe(true);
+    const found = (res.body.channels as { name: string; isPrivate: boolean }[]).find(
+      (c) => c.name === 'priv-test-ch',
+    );
+    expect(found?.isPrivate).toBe(true);
+  });
+
+  it('異常: 一般ユーザーは 403', async () => {
+    const { token } = await registerUser(app, 'adm_ch_user', 'adm_ch_user@example.com');
+    const res = await request(app).get('/api/admin/channels').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('DELETE /api/admin/channels/:id', () => {
+  it('正常: admin が任意のチャンネルを強制削除できる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_chd1', 'adm_chd1@example.com');
+    makeAdmin(userId);
+
+    const result = getDatabase()
+      .prepare("INSERT INTO channels (name, created_by) VALUES ('adm-force-del', ?)")
+      .run(userId);
+    const chId = result.lastInsertRowid as number;
+
+    const res = await request(app)
+      .delete(`/api/admin/channels/${chId}`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(204);
+  });
+
+  it('異常: 存在しないチャンネルIDは 404', async () => {
+    const { token, userId } = await registerUser(app, 'adm_chd2', 'adm_chd2@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app)
+      .delete('/api/admin/channels/99999')
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/admin/stats', () => {
+  it('正常: 統計情報を返す（totalUsers/totalChannels/totalMessages/activeUsersLast24h/activeUsersLast7d）', async () => {
+    const { token, userId } = await registerUser(app, 'adm_stats1', 'adm_stats1@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/stats').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.totalUsers).toBe('number');
+    expect(typeof res.body.totalChannels).toBe('number');
+    expect(typeof res.body.totalMessages).toBe('number');
+    expect(typeof res.body.activeUsersLast24h).toBe('number');
+    expect(typeof res.body.activeUsersLast7d).toBe('number');
+  });
+
+  it('異常: 一般ユーザーは 403', async () => {
+    const { token } = await registerUser(app, 'adm_stats_user', 'adm_stats_user@example.com');
+    const res = await request(app).get('/api/admin/stats').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('register: 初回ユーザーが自動で admin になる', () => {
+  it('DBにユーザーが0人の時、最初に登録したユーザーのroleがadminになる', async () => {
+    // このテストスイートは独立したDBを使うため、現在のユーザー数を基準に確認する
+    const countBefore = (
+      getDatabase().prepare('SELECT COUNT(*) as cnt FROM users').get() as { cnt: number }
+    ).cnt;
+
+    // 別のDBインスタンスで確認するため、DB直接参照で role を確認
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({
+        username: 'first_user_chk',
+        email: 'first_user_chk@example.com',
+        password: 'password123',
+      });
+
+    expect(res.status).toBe(201);
+    const row = getDatabase()
+      .prepare('SELECT role FROM users WHERE username = ?')
+      .get('first_user_chk') as { role: string } | undefined;
+
+    // countBefore === 0 のときだけ admin になる
+    if (countBefore === 0) {
+      expect(row?.role).toBe('admin');
+    } else {
+      expect(row?.role).toBe('user');
+    }
+  });
+
+  it('2人目以降に登録したユーザーのroleはuserになる', async () => {
+    // 1人目が既に存在する前提（他テストが先行する）
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({
+        username: 'second_user_chk',
+        email: 'second_user_chk@example.com',
+        password: 'password123',
+      });
+
+    expect(res.status).toBe(201);
+    const row = getDatabase()
+      .prepare('SELECT role FROM users WHERE username = ?')
+      .get('second_user_chk') as { role: string } | undefined;
+    expect(row?.role).toBe('user');
+  });
+});

--- a/packages/server/src/__tests__/integration/adminController.test.ts
+++ b/packages/server/src/__tests__/integration/adminController.test.ts
@@ -217,6 +217,15 @@ describe('DELETE /api/admin/users/:id', () => {
 
     expect(res.status).toBe(400);
   });
+
+  it('異常: 存在しないユーザーIDは 404', async () => {
+    const { token, userId } = await registerUser(app, 'adm_del_404', 'adm_del_404@example.com');
+    makeAdmin(userId);
+
+    const res = await request(app).delete('/api/admin/users/99999').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(404);
+  });
 });
 
 describe('GET /api/admin/channels', () => {
@@ -297,49 +306,5 @@ describe('GET /api/admin/stats', () => {
   });
 });
 
-describe('register: 初回ユーザーが自動で admin になる', () => {
-  it('DBにユーザーが0人の時、最初に登録したユーザーのroleがadminになる', async () => {
-    // このテストスイートは独立したDBを使うため、現在のユーザー数を基準に確認する
-    const countBefore = (
-      getDatabase().prepare('SELECT COUNT(*) as cnt FROM users').get() as { cnt: number }
-    ).cnt;
-
-    // 別のDBインスタンスで確認するため、DB直接参照で role を確認
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({
-        username: 'first_user_chk',
-        email: 'first_user_chk@example.com',
-        password: 'password123',
-      });
-
-    expect(res.status).toBe(201);
-    const row = getDatabase()
-      .prepare('SELECT role FROM users WHERE username = ?')
-      .get('first_user_chk') as { role: string } | undefined;
-
-    // countBefore === 0 のときだけ admin になる
-    if (countBefore === 0) {
-      expect(row?.role).toBe('admin');
-    } else {
-      expect(row?.role).toBe('user');
-    }
-  });
-
-  it('2人目以降に登録したユーザーのroleはuserになる', async () => {
-    // 1人目が既に存在する前提（他テストが先行する）
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({
-        username: 'second_user_chk',
-        email: 'second_user_chk@example.com',
-        password: 'password123',
-      });
-
-    expect(res.status).toBe(201);
-    const row = getDatabase()
-      .prepare('SELECT role FROM users WHERE username = ?')
-      .get('second_user_chk') as { role: string } | undefined;
-    expect(row?.role).toBe('user');
-  });
-});
+// 初回ユーザー自動 admin 昇格のテストは registerAdmin.test.ts に移動済み
+// （DB を他スイートと共有すると countBefore > 0 になり仕様を検証できないため独立ファイルで管理）

--- a/packages/server/src/__tests__/integration/adminController.test.ts
+++ b/packages/server/src/__tests__/integration/adminController.test.ts
@@ -226,6 +226,63 @@ describe('DELETE /api/admin/users/:id', () => {
 
     expect(res.status).toBe(404);
   });
+
+  it('正常: ユーザー削除後もそのユーザーのメッセージは残り user_id が NULL になる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_del_msg', 'adm_del_msg@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(
+      app,
+      'adm_del_msg_tgt',
+      'adm_del_msg_tgt@example.com',
+    );
+
+    // チャンネル作成とメッセージ投稿
+    const chResult = getDatabase()
+      .prepare("INSERT INTO channels (name, created_by) VALUES ('del-msg-ch-int', ?)")
+      .run(userId);
+    const chId = chResult.lastInsertRowid as number;
+    const msgResult = getDatabase()
+      .prepare('INSERT INTO messages (channel_id, user_id, content) VALUES (?, ?, ?)')
+      .run(chId, targetId, 'test message');
+    const msgId = msgResult.lastInsertRowid as number;
+
+    const res = await request(app)
+      .delete(`/api/admin/users/${targetId}`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(204);
+    const msg = getDatabase().prepare('SELECT user_id FROM messages WHERE id = ?').get(msgId) as
+      | { user_id: number | null }
+      | undefined;
+    expect(msg).toBeDefined();
+    expect(msg!.user_id).toBeNull();
+  });
+
+  it('正常: ユーザー削除後もそのユーザーが作成したチャンネルは残り created_by が NULL になる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_del_ch', 'adm_del_ch@example.com');
+    makeAdmin(userId);
+    const { userId: targetId } = await registerUser(
+      app,
+      'adm_del_ch_tgt',
+      'adm_del_ch_tgt@example.com',
+    );
+
+    const chResult = getDatabase()
+      .prepare("INSERT INTO channels (name, created_by) VALUES ('del-ch-int', ?)")
+      .run(targetId);
+    const chId = chResult.lastInsertRowid as number;
+
+    const res = await request(app)
+      .delete(`/api/admin/users/${targetId}`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(204);
+    const ch = getDatabase().prepare('SELECT created_by FROM channels WHERE id = ?').get(chId) as
+      | { created_by: number | null }
+      | undefined;
+    expect(ch).toBeDefined();
+    expect(ch!.created_by).toBeNull();
+  });
 });
 
 describe('GET /api/admin/channels', () => {

--- a/packages/server/src/__tests__/integration/registerAdmin.test.ts
+++ b/packages/server/src/__tests__/integration/registerAdmin.test.ts
@@ -1,0 +1,69 @@
+/**
+ * 初回ユーザー自動 admin 昇格の統合テスト
+ *
+ * テスト対象: packages/server/src/services/authService.ts register()
+ * 戦略: このファイル専用のインメモリ DB を使い、ユーザー 0 人の状態から
+ * 登録を行うことで「最初のユーザーが admin になる」仕様を確定的に検証する。
+ * 他テストスイートと DB を共有すると countBefore > 0 になり検証できないため分離している。
+ *
+ * DB をファクトリ内で生成するのは jest.mock がホイスティングされるため。
+ * let/const は TDZ（一時的デッドゾーン）があり、ホイスティングされたファクトリから
+ * 代入できないため var を使う（var はホイスティング後も undefined で初期化済み扱いになる）。
+ */
+
+import request from 'supertest';
+import type Database from 'better-sqlite3';
+import { createApp } from '../../app';
+
+// jest.mock ファクトリがホイスティングされるため var で宣言（TDZ 回避）
+ 
+var isolatedDb: Database.Database;
+
+jest.mock('../../db/database', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DatabaseLib = require('better-sqlite3') as typeof import('better-sqlite3');
+  isolatedDb = new DatabaseLib(':memory:');
+  isolatedDb.pragma('foreign_keys = ON');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../../db/database')>('../../db/database');
+  init(isolatedDb);
+  return {
+    getDatabase: () => isolatedDb,
+    initializeSchema: init,
+    closeDatabase: jest.fn(),
+  };
+});
+
+const app = createApp();
+
+describe('register: 初回ユーザーが自動で admin になる', () => {
+  it('DBにユーザーが0人の時、最初に登録したユーザーのroleがadminになる', async () => {
+    // このファイル専用 DB はテスト開始時点でユーザーが 0 人であることを確認
+    const count = (isolatedDb.prepare('SELECT COUNT(*) as cnt FROM users').get() as { cnt: number })
+      .cnt;
+    expect(count).toBe(0);
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ username: 'first_admin', email: 'first_admin@example.com', password: 'password123' });
+
+    expect(res.status).toBe(201);
+    const row = isolatedDb
+      .prepare('SELECT role FROM users WHERE username = ?')
+      .get('first_admin') as { role: string } | undefined;
+    expect(row?.role).toBe('admin');
+  });
+
+  it('2人目以降に登録したユーザーのroleはuserになる', async () => {
+    // 前テストで first_admin が登録済み → 2人目は user になる
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ username: 'second_user', email: 'second_user@example.com', password: 'password123' });
+
+    expect(res.status).toBe(201);
+    const row = isolatedDb
+      .prepare('SELECT role FROM users WHERE username = ?')
+      .get('second_user') as { role: string } | undefined;
+    expect(row?.role).toBe('user');
+  });
+});

--- a/packages/server/src/__tests__/unit/admin.test.ts
+++ b/packages/server/src/__tests__/unit/admin.test.ts
@@ -1,0 +1,180 @@
+/**
+ * adminService のユニットテスト
+ *
+ * テスト対象: packages/server/src/services/adminService.ts
+ * - getAdminUsers: 全ユーザー一覧（role/is_active/last_login_at 含む）
+ * - updateUserRole: ロール変更（自分自身は変更不可）
+ * - updateUserStatus: アカウント停止・復活
+ * - deleteUser: ユーザー削除
+ * - getAdminChannels: 全チャンネル（プライベート含む・メンバー数含む）
+ * - deleteChannel: 管理者権限での強制削除
+ * - getStats: システム統計
+ *
+ * DB 戦略: better-sqlite3 のインメモリ DB を使用
+ */
+
+import {
+  getAdminUsers,
+  updateUserRole,
+  updateUserStatus,
+  deleteUser,
+  getAdminChannels,
+  deleteChannel,
+  getStats,
+} from '../../services/adminService';
+import { getDatabase } from '../../db/database';
+
+jest.mock('../../db/database', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DatabaseLib = require('better-sqlite3') as typeof import('better-sqlite3');
+  const db = new DatabaseLib(':memory:');
+  db.pragma('foreign_keys = ON');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../../db/database')>('../../db/database');
+  init(db);
+  return {
+    getDatabase: () => db,
+    initializeSchema: init,
+    closeDatabase: jest.fn(),
+  };
+});
+
+// テスト用ユーザーを DB に直接 INSERT するヘルパー
+function insertUser(username: string, email: string, role: 'user' | 'admin' = 'user'): number {
+  const db = getDatabase();
+  const result = db
+    .prepare("INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, 'hash', ?)")
+    .run(username, email, role);
+  return result.lastInsertRowid as number;
+}
+
+function insertChannel(name: string, createdBy: number, isPrivate = false): number {
+  const db = getDatabase();
+  const result = db
+    .prepare('INSERT INTO channels (name, created_by, is_private) VALUES (?, ?, ?)')
+    .run(name, createdBy, isPrivate ? 1 : 0);
+  return result.lastInsertRowid as number;
+}
+
+function insertMessage(channelId: number, userId: number): number {
+  const db = getDatabase();
+  const result = db
+    .prepare('INSERT INTO messages (channel_id, user_id, content) VALUES (?, ?, ?)')
+    .run(channelId, userId, 'test');
+  return result.lastInsertRowid as number;
+}
+
+describe('getAdminUsers', () => {
+  it('全ユーザーを role / is_active / last_login_at を含めて返す', () => {
+    const id = insertUser('admin_test_user', 'atu@example.com', 'admin');
+    const users = getAdminUsers();
+    const found = users.find((u) => u.id === id);
+    expect(found).toBeDefined();
+    expect(found?.role).toBe('admin');
+    expect(found?.isActive).toBe(true);
+    expect(found).toHaveProperty('lastLoginAt');
+  });
+});
+
+describe('updateUserRole', () => {
+  it('対象ユーザーのロールを変更できる', () => {
+    const adminId = insertUser('role_admin', 'radmin@example.com', 'admin');
+    const targetId = insertUser('role_target', 'rtarget@example.com', 'user');
+    updateUserRole(targetId, 'admin', adminId);
+    const users = getAdminUsers();
+    expect(users.find((u) => u.id === targetId)?.role).toBe('admin');
+  });
+
+  it('自分自身のロールを変更しようとすると例外を投げる', () => {
+    const adminId = insertUser('role_self', 'rself@example.com', 'admin');
+    expect(() => updateUserRole(adminId, 'user', adminId)).toThrow();
+  });
+
+  it('存在しないユーザーIDを指定すると例外を投げる', () => {
+    const adminId = insertUser('role_admin2', 'radmin2@example.com', 'admin');
+    expect(() => updateUserRole(99999, 'user', adminId)).toThrow();
+  });
+});
+
+describe('updateUserStatus', () => {
+  it('ユーザーを停止 (is_active = 0) できる', () => {
+    const id = insertUser('status_user1', 'su1@example.com');
+    updateUserStatus(id, false);
+    const users = getAdminUsers();
+    expect(users.find((u) => u.id === id)?.isActive).toBe(false);
+  });
+
+  it('停止中ユーザーを復活 (is_active = 1) できる', () => {
+    const id = insertUser('status_user2', 'su2@example.com');
+    updateUserStatus(id, false);
+    updateUserStatus(id, true);
+    const users = getAdminUsers();
+    expect(users.find((u) => u.id === id)?.isActive).toBe(true);
+  });
+});
+
+describe('deleteUser', () => {
+  it('ユーザーをDBから削除できる', () => {
+    const adminId = insertUser('del_admin', 'dadmin@example.com', 'admin');
+    const targetId = insertUser('del_target', 'dtarget@example.com');
+    deleteUser(targetId, adminId);
+    const users = getAdminUsers();
+    expect(users.find((u) => u.id === targetId)).toBeUndefined();
+  });
+
+  it('自分自身を削除しようとすると例外を投げる', () => {
+    const adminId = insertUser('del_self', 'dself@example.com', 'admin');
+    expect(() => deleteUser(adminId, adminId)).toThrow();
+  });
+});
+
+describe('getAdminChannels', () => {
+  it('プライベートチャンネルを含む全チャンネルを memberCount 付きで返す', () => {
+    const userId = insertUser('ch_admin', 'chadmin@example.com', 'admin');
+    const pubId = insertChannel('admin-pub-ch', userId, false);
+    const privId = insertChannel('admin-priv-ch', userId, true);
+
+    // pubId にメンバーを追加してカウントを確認
+    getDatabase()
+      .prepare('INSERT INTO channel_members (channel_id, user_id) VALUES (?, ?)')
+      .run(pubId, userId);
+
+    const channels = getAdminChannels();
+    const pub = channels.find((c) => c.id === pubId);
+    const priv = channels.find((c) => c.id === privId);
+
+    expect(pub).toBeDefined();
+    expect(pub?.memberCount).toBe(1);
+    expect(priv).toBeDefined();
+    expect(priv?.isPrivate).toBe(true);
+  });
+});
+
+describe('deleteChannel', () => {
+  it('任意のチャンネルを削除できる', () => {
+    const userId = insertUser('delch_admin', 'delchadmin@example.com', 'admin');
+    const chId = insertChannel('admin-delete-ch', userId);
+    deleteChannel(chId);
+    expect(getAdminChannels().find((c) => c.id === chId)).toBeUndefined();
+  });
+
+  it('存在しないチャンネルIDは例外を投げる', () => {
+    expect(() => deleteChannel(99999)).toThrow();
+  });
+});
+
+describe('getStats', () => {
+  it('totalUsers/totalChannels/totalMessages/activeUsersLast24h/activeUsersLast7d を返す', () => {
+    const before = getStats();
+    // メッセージを追加して totalMessages が増加することを確認
+    const userId = insertUser('stats_user', 'stats@example.com');
+    const chId = insertChannel('stats-ch', userId);
+    insertMessage(chId, userId);
+    const after = getStats();
+    expect(after.totalUsers).toBeGreaterThanOrEqual(before.totalUsers);
+    expect(after.totalChannels).toBeGreaterThanOrEqual(before.totalChannels);
+    expect(after.totalMessages).toBe(before.totalMessages + 1);
+    expect(typeof after.activeUsersLast24h).toBe('number');
+    expect(typeof after.activeUsersLast7d).toBe('number');
+  });
+});

--- a/packages/server/src/__tests__/unit/admin.test.ts
+++ b/packages/server/src/__tests__/unit/admin.test.ts
@@ -130,6 +130,37 @@ describe('deleteUser', () => {
     const adminId = insertUser('del_self', 'dself@example.com', 'admin');
     expect(() => deleteUser(adminId, adminId)).toThrow();
   });
+
+  it('削除後もそのユーザーのメッセージは残り user_id が NULL になる', () => {
+    const adminId = insertUser('del_msg_admin', 'del_msg_admin@example.com', 'admin');
+    const targetId = insertUser('del_msg_target', 'del_msg_target@example.com');
+    const chId = insertChannel('del-msg-ch', adminId);
+    insertMessage(chId, targetId);
+
+    deleteUser(targetId, adminId);
+
+    const db = getDatabase();
+    const msgs = db.prepare('SELECT user_id FROM messages WHERE channel_id = ?').all(chId) as {
+      user_id: number | null;
+    }[];
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].user_id).toBeNull();
+  });
+
+  it('削除後もそのユーザーが作成したチャンネルは残り created_by が NULL になる', () => {
+    const adminId = insertUser('del_ch_admin', 'del_ch_admin@example.com', 'admin');
+    const targetId = insertUser('del_ch_target', 'del_ch_target@example.com');
+    const chId = insertChannel('del-ch-owned', targetId);
+
+    deleteUser(targetId, adminId);
+
+    const db = getDatabase();
+    const row = db.prepare('SELECT created_by FROM channels WHERE id = ?').get(chId) as
+      | { created_by: number | null }
+      | undefined;
+    expect(row).toBeDefined();
+    expect(row!.created_by).toBeNull();
+  });
 });
 
 describe('getAdminChannels', () => {

--- a/packages/server/src/__tests__/unit/admin.test.ts
+++ b/packages/server/src/__tests__/unit/admin.test.ts
@@ -111,6 +111,10 @@ describe('updateUserStatus', () => {
     const users = getAdminUsers();
     expect(users.find((u) => u.id === id)?.isActive).toBe(true);
   });
+
+  it('存在しないユーザーIDを指定すると例外を投げる', () => {
+    expect(() => updateUserStatus(99999, false)).toThrow();
+  });
 });
 
 describe('deleteUser', () => {
@@ -164,7 +168,7 @@ describe('deleteChannel', () => {
 });
 
 describe('getStats', () => {
-  it('totalUsers/totalChannels/totalMessages/activeUsersLast24h/activeUsersLast7d を返す', () => {
+  it('totalUsers/totalChannels/totalMessages が正しくカウントされる', () => {
     const before = getStats();
     // メッセージを追加して totalMessages が増加することを確認
     const userId = insertUser('stats_user', 'stats@example.com');
@@ -174,7 +178,36 @@ describe('getStats', () => {
     expect(after.totalUsers).toBeGreaterThanOrEqual(before.totalUsers);
     expect(after.totalChannels).toBeGreaterThanOrEqual(before.totalChannels);
     expect(after.totalMessages).toBe(before.totalMessages + 1);
-    expect(typeof after.activeUsersLast24h).toBe('number');
-    expect(typeof after.activeUsersLast7d).toBe('number');
+  });
+
+  it('last_login_at が現在時刻のユーザーは activeUsersLast24h / activeUsersLast7d の両方に含まれる', () => {
+    const before = getStats();
+    const id = insertUser('active_now', 'active_now@example.com');
+    getDatabase().prepare("UPDATE users SET last_login_at = datetime('now') WHERE id = ?").run(id);
+    const after = getStats();
+    expect(after.activeUsersLast24h).toBe(before.activeUsersLast24h + 1);
+    expect(after.activeUsersLast7d).toBe(before.activeUsersLast7d + 1);
+  });
+
+  it('last_login_at が 8 日前のユーザーは activeUsersLast24h / activeUsersLast7d のどちらにも含まれない', () => {
+    const before = getStats();
+    const id = insertUser('inactive_8d', 'inactive_8d@example.com');
+    getDatabase()
+      .prepare("UPDATE users SET last_login_at = datetime('now', '-8 days') WHERE id = ?")
+      .run(id);
+    const after = getStats();
+    expect(after.activeUsersLast24h).toBe(before.activeUsersLast24h);
+    expect(after.activeUsersLast7d).toBe(before.activeUsersLast7d);
+  });
+
+  it('last_login_at が 6 日前のユーザーは activeUsersLast7d にのみ含まれる', () => {
+    const before = getStats();
+    const id = insertUser('active_6d', 'active_6d@example.com');
+    getDatabase()
+      .prepare("UPDATE users SET last_login_at = datetime('now', '-6 days') WHERE id = ?")
+      .run(id);
+    const after = getStats();
+    expect(after.activeUsersLast24h).toBe(before.activeUsersLast24h);
+    expect(after.activeUsersLast7d).toBe(before.activeUsersLast7d + 1);
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -7,6 +7,7 @@ import channelRoutes from './routes/channels';
 import messageRoutes from './routes/messages';
 import pushRoutes from './routes/push';
 import fileRoutes from './routes/files';
+import adminRoutes from './routes/admin';
 import { errorHandler } from './middleware/errorHandler';
 import { setupSwagger } from './swagger/setup';
 
@@ -33,6 +34,7 @@ export function createApp() {
   app.use('/api/messages', messageRoutes);
   app.use('/api/push', pushRoutes);
   app.use('/api/files', fileRoutes);
+  app.use('/api/admin', adminRoutes);
 
   app.use(errorHandler);
 

--- a/packages/server/src/controllers/adminController.ts
+++ b/packages/server/src/controllers/adminController.ts
@@ -1,0 +1,51 @@
+import { Response } from 'express';
+import { AuthenticatedRequest } from '../middleware/auth';
+import * as adminService from '../services/adminService';
+import { createError } from '../middleware/errorHandler';
+
+export function getUsers(req: AuthenticatedRequest, res: Response): void {
+  const users = adminService.getAdminUsers();
+  res.json({ users });
+}
+
+export function updateUserRole(req: AuthenticatedRequest, res: Response): void {
+  const targetId = Number(req.params.id);
+  const { role } = req.body as { role?: unknown };
+  if (role !== 'user' && role !== 'admin') {
+    throw createError('Invalid role', 400);
+  }
+  adminService.updateUserRole(targetId, role, req.userId);
+  res.json({ success: true });
+}
+
+export function updateUserStatus(req: AuthenticatedRequest, res: Response): void {
+  const targetId = Number(req.params.id);
+  const { isActive } = req.body as { isActive?: unknown };
+  if (typeof isActive !== 'boolean') {
+    throw createError('isActive must be a boolean', 400);
+  }
+  adminService.updateUserStatus(targetId, isActive);
+  res.json({ success: true });
+}
+
+export function deleteUser(req: AuthenticatedRequest, res: Response): void {
+  const targetId = Number(req.params.id);
+  adminService.deleteUser(targetId, req.userId);
+  res.status(204).end();
+}
+
+export function getChannels(req: AuthenticatedRequest, res: Response): void {
+  const channels = adminService.getAdminChannels();
+  res.json({ channels });
+}
+
+export function deleteChannel(req: AuthenticatedRequest, res: Response): void {
+  const channelId = Number(req.params.id);
+  adminService.deleteChannel(channelId);
+  res.status(204).end();
+}
+
+export function getStats(req: AuthenticatedRequest, res: Response): void {
+  const stats = adminService.getStats();
+  res.json(stats);
+}

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -39,7 +39,7 @@ export function initializeSchema(database: Database.Database): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       name TEXT NOT NULL UNIQUE,
       description TEXT,
-      created_by INTEGER NOT NULL REFERENCES users(id),
+      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
       is_private INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -54,7 +54,7 @@ export function initializeSchema(database: Database.Database): void {
     CREATE TABLE IF NOT EXISTS messages (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       channel_id INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
-      user_id INTEGER NOT NULL REFERENCES users(id),
+      user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
       content TEXT NOT NULL,
       is_edited INTEGER NOT NULL DEFAULT 0,
       is_deleted INTEGER NOT NULL DEFAULT 0,
@@ -128,6 +128,56 @@ export function initializeSchema(database: Database.Database): void {
   }
   if (!userCols().some((r) => r.name === 'last_login_at')) {
     database.exec(`ALTER TABLE users ADD COLUMN last_login_at TEXT`);
+  }
+
+  // channels.created_by が NOT NULL で作られていた場合は nullable + ON DELETE SET NULL に再作成する
+  const channelColsAll = database.prepare('PRAGMA table_info(channels)').all() as {
+    name: string;
+    notnull: number;
+  }[];
+  const createdByCol = channelColsAll.find((c) => c.name === 'created_by');
+  if (createdByCol && createdByCol.notnull === 1) {
+    database.exec(`
+      PRAGMA foreign_keys = OFF;
+      CREATE TABLE channels_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL UNIQUE,
+        description TEXT,
+        created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+        is_private INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO channels_new SELECT * FROM channels;
+      DROP TABLE channels;
+      ALTER TABLE channels_new RENAME TO channels;
+      PRAGMA foreign_keys = ON;
+    `);
+  }
+
+  // messages.user_id が NOT NULL で作られていた場合は nullable + ON DELETE SET NULL に再作成する
+  const messageColsAll = database.prepare('PRAGMA table_info(messages)').all() as {
+    name: string;
+    notnull: number;
+  }[];
+  const messageUserIdCol = messageColsAll.find((c) => c.name === 'user_id');
+  if (messageUserIdCol && messageUserIdCol.notnull === 1) {
+    database.exec(`
+      PRAGMA foreign_keys = OFF;
+      CREATE TABLE messages_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel_id INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+        user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+        content TEXT NOT NULL,
+        is_edited INTEGER NOT NULL DEFAULT 0,
+        is_deleted INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO messages_new SELECT * FROM messages;
+      DROP TABLE messages;
+      ALTER TABLE messages_new RENAME TO messages;
+      PRAGMA foreign_keys = ON;
+    `);
   }
 
   // message_attachments.message_id が NOT NULL 制約付きで作られていた場合は再作成する

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -28,6 +28,9 @@ export function initializeSchema(database: Database.Database): void {
       avatar_url TEXT,
       display_name TEXT,
       location TEXT,
+      role TEXT NOT NULL DEFAULT 'user',
+      is_active INTEGER NOT NULL DEFAULT 1,
+      last_login_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
@@ -109,14 +112,22 @@ export function initializeSchema(database: Database.Database): void {
     database.exec('ALTER TABLE channels ADD COLUMN is_private INTEGER NOT NULL DEFAULT 0');
   }
 
-  // 既存 DB に display_name・location カラムが存在しない場合は追加する
+  // 既存 DB に display_name・location・role・is_active・last_login_at カラムが存在しない場合は追加する
+  const userCols = () => database.prepare(`PRAGMA table_info(users)`).all() as { name: string }[];
+
   for (const col of ['display_name', 'location']) {
-    const exists = (database.prepare(`PRAGMA table_info(users)`).all() as { name: string }[]).some(
-      (r) => r.name === col,
-    );
-    if (!exists) {
+    if (!userCols().some((r) => r.name === col)) {
       database.exec(`ALTER TABLE users ADD COLUMN ${col} TEXT`);
     }
+  }
+  if (!userCols().some((r) => r.name === 'role')) {
+    database.exec(`ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'`);
+  }
+  if (!userCols().some((r) => r.name === 'is_active')) {
+    database.exec(`ALTER TABLE users ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1`);
+  }
+  if (!userCols().some((r) => r.name === 'last_login_at')) {
+    database.exec(`ALTER TABLE users ADD COLUMN last_login_at TEXT`);
   }
 
   // message_attachments.message_id が NOT NULL 制約付きで作られていた場合は再作成する

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { getDatabase } from '../db/database';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-please-change-in-production';
 
@@ -28,4 +29,17 @@ export function authenticateToken(req: Request, res: Response, next: NextFunctio
 
 export function generateToken(userId: number, username: string): string {
   return jwt.sign({ userId, username }, JWT_SECRET, { expiresIn: '7d' });
+}
+
+/** authenticateToken の後に使う管理者専用ミドルウェア */
+export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
+  const userId = (req as AuthenticatedRequest).userId;
+  const row = getDatabase().prepare('SELECT role FROM users WHERE id = ?').get(userId) as
+    | { role: string }
+    | undefined;
+  if (row?.role !== 'admin') {
+    res.status(403).json({ error: 'Forbidden' });
+    return;
+  }
+  next();
 }

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -1,0 +1,38 @@
+import { Router } from 'express';
+import { authenticateToken, requireAdmin, AuthenticatedRequest } from '../middleware/auth';
+import * as controller from '../controllers/adminController';
+
+const router = Router();
+
+// すべての管理者ルートに認証 + 管理者チェックを適用
+router.use(authenticateToken);
+router.use(requireAdmin);
+
+// ユーザー管理
+router.get('/users', (req, res) =>
+  controller.getUsers(req as unknown as AuthenticatedRequest, res),
+);
+router.patch('/users/:id/role', (req, res) =>
+  controller.updateUserRole(req as unknown as AuthenticatedRequest, res),
+);
+router.patch('/users/:id/status', (req, res) =>
+  controller.updateUserStatus(req as unknown as AuthenticatedRequest, res),
+);
+router.delete('/users/:id', (req, res) =>
+  controller.deleteUser(req as unknown as AuthenticatedRequest, res),
+);
+
+// チャンネル管理
+router.get('/channels', (req, res) =>
+  controller.getChannels(req as unknown as AuthenticatedRequest, res),
+);
+router.delete('/channels/:id', (req, res) =>
+  controller.deleteChannel(req as unknown as AuthenticatedRequest, res),
+);
+
+// 統計
+router.get('/stats', (req, res) =>
+  controller.getStats(req as unknown as AuthenticatedRequest, res),
+);
+
+export default router;

--- a/packages/server/src/services/adminService.ts
+++ b/packages/server/src/services/adminService.ts
@@ -1,0 +1,149 @@
+import { getDatabase } from '../db/database';
+import { createError } from '../middleware/errorHandler';
+
+export interface AdminUser {
+  id: number;
+  username: string;
+  email: string;
+  role: 'user' | 'admin';
+  isActive: boolean;
+  lastLoginAt: string | null;
+  createdAt: string;
+}
+
+export interface AdminChannel {
+  id: number;
+  name: string;
+  description: string | null;
+  isPrivate: boolean;
+  memberCount: number;
+  createdAt: string;
+}
+
+export interface AdminStats {
+  totalUsers: number;
+  totalChannels: number;
+  totalMessages: number;
+  activeUsersLast24h: number;
+  activeUsersLast7d: number;
+}
+
+interface AdminUserRow {
+  id: number;
+  username: string;
+  email: string;
+  role: 'user' | 'admin';
+  is_active: number;
+  last_login_at: string | null;
+  created_at: string;
+}
+
+interface AdminChannelRow {
+  id: number;
+  name: string;
+  description: string | null;
+  is_private: number;
+  member_count: number;
+  created_at: string;
+}
+
+export function getAdminUsers(): AdminUser[] {
+  const rows = getDatabase()
+    .prepare(
+      `SELECT id, username, email, role, is_active, last_login_at, created_at
+       FROM users ORDER BY created_at ASC`,
+    )
+    .all() as AdminUserRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    username: r.username,
+    email: r.email,
+    role: r.role,
+    isActive: r.is_active === 1,
+    lastLoginAt: r.last_login_at,
+    createdAt: r.created_at,
+  }));
+}
+
+export function updateUserRole(
+  targetId: number,
+  role: 'user' | 'admin',
+  requesterId: number,
+): void {
+  if (targetId === requesterId) throw createError('Cannot change your own role', 400);
+  const db = getDatabase();
+  const user = db.prepare('SELECT id FROM users WHERE id = ?').get(targetId);
+  if (!user) throw createError('User not found', 404);
+  db.prepare('UPDATE users SET role = ? WHERE id = ?').run(role, targetId);
+}
+
+export function updateUserStatus(targetId: number, isActive: boolean): void {
+  const db = getDatabase();
+  const user = db.prepare('SELECT id FROM users WHERE id = ?').get(targetId);
+  if (!user) throw createError('User not found', 404);
+  db.prepare('UPDATE users SET is_active = ? WHERE id = ?').run(isActive ? 1 : 0, targetId);
+}
+
+export function deleteUser(targetId: number, requesterId: number): void {
+  if (targetId === requesterId) throw createError('Cannot delete yourself', 400);
+  const db = getDatabase();
+  const user = db.prepare('SELECT id FROM users WHERE id = ?').get(targetId);
+  if (!user) throw createError('User not found', 404);
+  db.prepare('DELETE FROM users WHERE id = ?').run(targetId);
+}
+
+export function getAdminChannels(): AdminChannel[] {
+  const rows = getDatabase()
+    .prepare(
+      `SELECT c.id, c.name, c.description, c.is_private, c.created_at,
+              COUNT(cm.user_id) AS member_count
+       FROM channels c
+       LEFT JOIN channel_members cm ON cm.channel_id = c.id
+       GROUP BY c.id
+       ORDER BY c.created_at ASC`,
+    )
+    .all() as AdminChannelRow[];
+  return rows.map((r) => ({
+    id: r.id,
+    name: r.name,
+    description: r.description,
+    isPrivate: r.is_private === 1,
+    memberCount: r.member_count,
+    createdAt: r.created_at,
+  }));
+}
+
+export function deleteChannel(channelId: number): void {
+  const db = getDatabase();
+  const channel = db.prepare('SELECT id FROM channels WHERE id = ?').get(channelId);
+  if (!channel) throw createError('Channel not found', 404);
+  db.prepare('DELETE FROM channels WHERE id = ?').run(channelId);
+}
+
+export function getStats(): AdminStats {
+  const db = getDatabase();
+  const totalUsers = (db.prepare('SELECT COUNT(*) as cnt FROM users').get() as { cnt: number }).cnt;
+  const totalChannels = (
+    db.prepare('SELECT COUNT(*) as cnt FROM channels').get() as { cnt: number }
+  ).cnt;
+  const totalMessages = (
+    db.prepare('SELECT COUNT(*) as cnt FROM messages WHERE is_deleted = 0').get() as { cnt: number }
+  ).cnt;
+  const activeUsersLast24h = (
+    db
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM users
+         WHERE last_login_at >= datetime('now', '-24 hours')`,
+      )
+      .get() as { cnt: number }
+  ).cnt;
+  const activeUsersLast7d = (
+    db
+      .prepare(
+        `SELECT COUNT(*) as cnt FROM users
+         WHERE last_login_at >= datetime('now', '-7 days')`,
+      )
+      .get() as { cnt: number }
+  ).cnt;
+  return { totalUsers, totalChannels, totalMessages, activeUsersLast24h, activeUsersLast7d };
+}

--- a/packages/server/src/services/authService.ts
+++ b/packages/server/src/services/authService.ts
@@ -12,6 +12,9 @@ interface UserRow {
   avatar_url: string | null;
   display_name: string | null;
   location: string | null;
+  role: 'user' | 'admin';
+  is_active: number;
+  last_login_at: string | null;
   created_at: string;
 }
 
@@ -24,6 +27,8 @@ function toUser(row: UserRow): User {
     displayName: row.display_name,
     location: row.location,
     createdAt: row.created_at,
+    role: row.role,
+    isActive: row.is_active === 1,
   };
 }
 
@@ -36,9 +41,14 @@ export async function register(username: string, email: string, password: string
   if (existing) throw createError('Username or email already taken', 409);
 
   const passwordHash = await bcrypt.hash(password, 12);
+
+  // 最初のユーザーは自動で admin にする
+  const userCount = (db.prepare('SELECT COUNT(*) as cnt FROM users').get() as { cnt: number }).cnt;
+  const role = userCount === 0 ? 'admin' : 'user';
+
   const result = db
-    .prepare('INSERT INTO users (username, email, password_hash) VALUES (?, ?, ?)')
-    .run(username, email, passwordHash);
+    .prepare('INSERT INTO users (username, email, password_hash, role) VALUES (?, ?, ?, ?)')
+    .run(username, email, passwordHash, role);
 
   const row = db.prepare('SELECT * FROM users WHERE id = ?').get(result.lastInsertRowid) as UserRow;
   return toUser(row);
@@ -53,7 +63,11 @@ export async function login(email: string, password: string): Promise<User> {
   const valid = await bcrypt.compare(password, row.password_hash);
   if (!valid) throw createError('Invalid credentials', 401);
 
-  return toUser(row);
+  if (row.is_active === 0) throw createError('Account is suspended', 403);
+
+  db.prepare("UPDATE users SET last_login_at = datetime('now') WHERE id = ?").run(row.id);
+
+  return toUser({ ...row, last_login_at: new Date().toISOString() });
 }
 
 export function getUserById(id: number): User | null {

--- a/packages/server/src/services/channelService.ts
+++ b/packages/server/src/services/channelService.ts
@@ -6,7 +6,7 @@ interface ChannelRow {
   id: number;
   name: string;
   description: string | null;
-  created_by: number;
+  created_by: number | null;
   is_private: number;
   created_at: string;
 }

--- a/packages/server/src/services/channelService.ts
+++ b/packages/server/src/services/channelService.ts
@@ -159,6 +159,8 @@ interface UserRow {
   avatar_url: string | null;
   display_name: string | null;
   location: string | null;
+  role: 'user' | 'admin';
+  is_active: number;
   created_at: string;
 }
 
@@ -171,6 +173,8 @@ function toUser(row: UserRow): User {
     displayName: row.display_name,
     location: row.location,
     createdAt: row.created_at,
+    role: row.role,
+    isActive: row.is_active === 1,
   };
 }
 

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -5,8 +5,8 @@ import { createError } from '../middleware/errorHandler';
 interface MessageRow {
   id: number;
   channel_id: number;
-  user_id: number;
-  username: string;
+  user_id: number | null;
+  username: string | null;
   avatar_url: string | null;
   content: string;
   is_edited: number;
@@ -19,7 +19,7 @@ const MESSAGE_SELECT = `
   SELECT m.id, m.channel_id, m.user_id, u.username, u.avatar_url,
          m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at
   FROM messages m
-  JOIN users u ON m.user_id = u.id
+  LEFT JOIN users u ON m.user_id = u.id
 `;
 
 function getReactionsForMessage(messageId: number): Reaction[] {
@@ -77,7 +77,7 @@ function toMessage(row: MessageRow): Message {
     id: row.id,
     channelId: row.channel_id,
     userId: row.user_id,
-    username: row.username,
+    username: row.username ?? '削除済みユーザー',
     avatarUrl: row.avatar_url,
     content: row.content,
     isEdited: row.is_edited === 1,
@@ -225,7 +225,7 @@ export function searchMessages(query: string): MessageSearchResult[] {
               m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at,
               c.name AS channel_name
        FROM messages m
-       JOIN users u ON m.user_id = u.id
+       LEFT JOIN users u ON m.user_id = u.id
        JOIN channels c ON m.channel_id = c.id
        WHERE m.is_deleted = 0 AND m.content LIKE ?
        ORDER BY m.created_at DESC

--- a/packages/shared/src/types/channel.ts
+++ b/packages/shared/src/types/channel.ts
@@ -2,7 +2,7 @@ export interface Channel {
   id: number;
   name: string;
   description: string | null;
-  createdBy: number;
+  createdBy: number | null;
   createdAt: string;
   isPrivate: boolean;
   unreadCount: number;

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -15,7 +15,7 @@ export interface Attachment {
 export interface Message {
   id: number;
   channelId: number;
-  userId: number;
+  userId: number | null;
   username: string;
   avatarUrl: string | null;
   content: string; // TipTap JSON string

--- a/packages/shared/src/types/user.ts
+++ b/packages/shared/src/types/user.ts
@@ -6,4 +6,6 @@ export interface User {
   displayName: string | null;
   location: string | null;
   createdAt: string;
+  role: 'user' | 'admin';
+  isActive: boolean;
 }


### PR DESCRIPTION
## 概要

管理者ロールを持つユーザーが、ユーザー管理・チャンネル管理・システム統計を確認できる管理画面を実装する (#32)。

## 変更内容

- **DB スキーマ**: `users` テーブルに `role`（user/admin）・`is_active`・`last_login_at` カラムを追加
- **自動 admin 昇格**: 初回登録ユーザーを自動で admin に設定
- **認証強化**: 停止中ユーザー（`is_active=0`）はログイン時に 403、ログイン時に `last_login_at` を更新
- **`requireAdmin` ミドルウェア**: `/api/admin/*` を admin 専用に保護
- **管理者 API**:
  - `GET /api/admin/users` — 全ユーザー一覧（role/isActive/lastLoginAt 含む）
  - `PATCH /api/admin/users/:id/role` — ロール変更（自己変更不可）
  - `PATCH /api/admin/users/:id/status` — アカウント停止・復活
  - `DELETE /api/admin/users/:id` — ユーザー削除（自己削除不可）
  - `GET /api/admin/channels` — 全チャンネル（プライベート含む・メンバー数含む）
  - `DELETE /api/admin/channels/:id` — 強制削除
  - `GET /api/admin/stats` — 統計情報
- **AdminPage.tsx**: 統計・ユーザー管理・チャンネル管理タブの管理画面を新設（`/admin`）
- **ルーティング**: `/admin` ルートを追加（非 admin は `/` にリダイレクト）
- **サイドバー**: admin ユーザーのみ「管理画面」リンクを表示

## 影響範囲

- `packages/shared/src/types/user.ts` — `User` 型に `role`・`isActive` を追加（既存テストのフィクスチャを更新）
- `packages/server/src/services/authService.ts` — register/login ロジック変更
- `packages/server/src/services/channelService.ts` — `toUser` に role/isActive を追加
- `packages/client/src/components/Channel/ChannelList.tsx` — useAuth/useNavigate 追加
- 既存テスト: `users.ts` フィクスチャ・各テストファイルのダミーユーザーに `role`/`isActive` を追加

## 動作確認・テスト結果

- [x] ビルド通過 (`npm run build`)
- [x] サーバーテスト全通過（182件）
- [x] クライアントテスト全通過（195件）
- [x] 新規テスト: `adminController.test.ts`（統合）・`admin.test.ts`（ユニット）・`AdminPage.test.tsx`

## 関連Issue

Fixes #32

## チェックリスト

- [x] `npm run build` が通過している
- [x] `npm run test` が全件通過している
- [x] 既存テストの変更は仕様変更（User 型拡張）によるフィクスチャ更新のみ