### PR TITLE
feat: スレッド返信機能の実装 (#31)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -218,6 +218,16 @@ table "messages" {
     default = sql("datetime('now')")
     comment = "更新日時"
   }
+  column "parent_message_id" {
+    null    = true
+    type    = integer
+    comment = "直接の返信先メッセージID（NULLはルートメッセージ）"
+  }
+  column "root_message_id" {
+    null    = true
+    type    = integer
+    comment = "スレッドのルートメッセージID（NULLはルートメッセージ自身）"
+  }
   primary_key {
     columns = [column.id]
   }
@@ -232,6 +242,21 @@ table "messages" {
     ref_columns = [table.channels.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  foreign_key "parent_message" {
+    columns     = [column.parent_message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "root_message" {
+    columns     = [column.root_message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  index "messages_root_message_id" {
+    columns = [column.root_message_id]
   }
 }
 

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -16,6 +16,24 @@ const theme = createTheme({
   palette: { mode: 'light' },
 });
 
+/**
+ * React 19 の concurrent モードではコミット前に同じコンポーネントが複数回インスタンス化される
+ * 場合がある。その都度 useState イニシャライザが呼ばれると API が多重発行されるため、
+ * モジュールレベルでキャッシュして 1 回しかフェッチしないようにする。
+ * キーは userId なのでユーザー切替時は自動的に別エントリが生成される。
+ */
+const _usersPromiseCache = new Map<number, Promise<{ users: User[] }>>();
+
+function getOrCreateUsersPromise(userId: number): Promise<{ users: User[] }> {
+  if (!_usersPromiseCache.has(userId)) {
+    _usersPromiseCache.set(
+      userId,
+      api.auth.users().catch(() => ({ users: [] as User[] })),
+    );
+  }
+  return _usersPromiseCache.get(userId)!;
+}
+
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
   return user ? <>{children}</> : <Navigate to="/login" replace />;
@@ -50,9 +68,10 @@ function ChatWithUsersContent({
  * usersPromise を生成して自身の <Suspense> で囲む（Suspense の外側）。
  * React 19 では Suspense フォールバック表示時に境界以下が unmount されるため、
  * useState による Promise 生成はこのコンポーネント（Suspense の外側）に置く必要がある。
+ * モジュールレベルキャッシュを使うことで concurrent モードの多重インスタンス化に対応する。
  */
 function ChatWithUsers({ currentUser }: { currentUser: User }) {
-  const [usersPromise] = useState(() => api.auth.users().catch(() => ({ users: [] as User[] })));
+  const [usersPromise] = useState(() => getOrCreateUsersPromise(currentUser.id));
 
   return (
     <Suspense

--- a/packages/client/src/__tests__/MessageItemAttachment.test.tsx
+++ b/packages/client/src/__tests__/MessageItemAttachment.test.tsx
@@ -54,6 +54,9 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
     mentions: [],
     attachments: [],
     reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/MessageItemThread.test.tsx
+++ b/packages/client/src/__tests__/MessageItemThread.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * テスト対象: MessageItem のスレッド関連機能
+ * 戦略: Socket モックを注入し、replyCount バッジ表示と「返信」ボタンの振る舞いをテストする
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import MessageItem from '../components/Chat/MessageItem';
+import { dummyUsers } from './__fixtures__/users';
+import { makeMessage } from './__fixtures__/messages';
+
+const mockSocket = { emit: vi.fn(), on: vi.fn(), off: vi.fn() };
+vi.mock('../contexts/SocketContext', () => ({
+  useSocket: () => mockSocket,
+}));
+
+vi.mock('../components/Chat/RichEditor', () => ({
+  default: ({ onCancel }: { onCancel: () => void; onSend: (c: string, m: number[]) => void }) => (
+    <div data-testid="rich-editor">
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('MessageItem（スレッド機能）', () => {
+  describe('返信バッジ', () => {
+    it('replyCount > 0 のとき「N件の返信」バッジを表示する', () => {
+      const onOpenThread = vi.fn();
+      render(
+        <MessageItem
+          message={makeMessage({ replyCount: 3 })}
+          currentUserId={1}
+          users={dummyUsers}
+          onOpenThread={onOpenThread}
+        />,
+      );
+      expect(screen.getByText(/3件の返信/)).toBeInTheDocument();
+    });
+
+    it('replyCount が 0 のときバッジを表示しない', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ replyCount: 0 })}
+          currentUserId={1}
+          users={dummyUsers}
+        />,
+      );
+      expect(screen.queryByText(/件の返信/)).not.toBeInTheDocument();
+    });
+
+    it('バッジをクリックすると onOpenThread が呼ばれる', async () => {
+      const onOpenThread = vi.fn();
+      render(
+        <MessageItem
+          message={makeMessage({ id: 5, replyCount: 2 })}
+          currentUserId={1}
+          users={dummyUsers}
+          onOpenThread={onOpenThread}
+        />,
+      );
+      await userEvent.click(screen.getByText(/2件の返信/));
+      expect(onOpenThread).toHaveBeenCalledWith(5);
+    });
+  });
+
+  describe('返信ボタン', () => {
+    it('ホバー時のアクションに「返信」ボタンが表示される', async () => {
+      const onOpenThread = vi.fn();
+      render(
+        <MessageItem
+          message={makeMessage({ id: 1 })}
+          currentUserId={2}
+          users={dummyUsers}
+          onOpenThread={onOpenThread}
+        />,
+      );
+      expect(screen.getByRole('button', { name: /返信/i })).toBeInTheDocument();
+    });
+
+    it('「返信」ボタンをクリックすると onOpenThread が呼ばれる', async () => {
+      const onOpenThread = vi.fn();
+      render(
+        <MessageItem
+          message={makeMessage({ id: 7 })}
+          currentUserId={2}
+          users={dummyUsers}
+          onOpenThread={onOpenThread}
+        />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: /返信/i }));
+      expect(onOpenThread).toHaveBeenCalledWith(7);
+    });
+  });
+});

--- a/packages/client/src/__tests__/SearchResults.test.tsx
+++ b/packages/client/src/__tests__/SearchResults.test.tsx
@@ -29,6 +29,10 @@ function makeResult(overrides: Partial<MessageSearchResult> = {}): MessageSearch
     updatedAt: '2024-01-01T00:00:00Z',
     mentions: [],
     reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
+    rootMessageContent: null,
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/ThreadPanel.test.tsx
+++ b/packages/client/src/__tests__/ThreadPanel.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * テスト対象: ThreadPanel コンポーネント
+ * 戦略: Socket モックを注入し、スレッドの表示・返信送信の振る舞いをテストする
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import ThreadPanel from '../components/Chat/ThreadPanel';
+import { dummyUsers } from './__fixtures__/users';
+import { makeMessage } from './__fixtures__/messages';
+
+type SocketEventHandler = (...args: unknown[]) => void;
+
+const socketHandlers: Record<string, SocketEventHandler> = {};
+const mockSocket = {
+  emit: vi.fn(),
+  on: vi.fn((event: string, handler: SocketEventHandler) => {
+    socketHandlers[event] = handler;
+  }),
+  off: vi.fn(),
+};
+
+vi.mock('../contexts/SocketContext', () => ({
+  useSocket: () => mockSocket,
+}));
+
+vi.mock('../components/Chat/RichEditor', () => ({
+  default: ({
+    onSend,
+  }: {
+    onSend: (content: string, mentionedUserIds: number[], attachmentIds: number[]) => void;
+    onCancel?: () => void;
+  }) => (
+    <div data-testid="rich-editor">
+      <button onClick={() => onSend(JSON.stringify({ ops: [{ insert: 'test reply\n' }] }), [], [])}>
+        送信
+      </button>
+    </div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  Object.keys(socketHandlers).forEach((k) => delete socketHandlers[k]);
+});
+
+const rootMessage = makeMessage({
+  id: 1,
+  content: JSON.stringify({ ops: [{ insert: 'ルートメッセージ\n' }] }),
+  replyCount: 2,
+});
+const reply1 = makeMessage({
+  id: 2,
+  userId: 2,
+  username: 'bob',
+  content: JSON.stringify({ ops: [{ insert: '返信1\n' }] }),
+  parentMessageId: 1,
+  rootMessageId: 1,
+  createdAt: '2024-06-01T12:01:00Z',
+});
+const reply2 = makeMessage({
+  id: 3,
+  content: JSON.stringify({ ops: [{ insert: '返信2\n' }] }),
+  parentMessageId: 1,
+  rootMessageId: 1,
+  createdAt: '2024-06-01T12:02:00Z',
+});
+
+describe('ThreadPanel', () => {
+  describe('表示', () => {
+    it('ルートメッセージを先頭に表示する', () => {
+      render(
+        <ThreadPanel
+          rootMessage={rootMessage}
+          initialReplies={[reply1, reply2]}
+          currentUserId={1}
+          users={dummyUsers}
+          onClose={vi.fn()}
+        />,
+      );
+      // スレッドパネルのタイトル
+      expect(screen.getByText('スレッド')).toBeInTheDocument();
+    });
+
+    it('返信一覧を表示する', () => {
+      render(
+        <ThreadPanel
+          rootMessage={rootMessage}
+          initialReplies={[reply1, reply2]}
+          currentUserId={1}
+          users={dummyUsers}
+          onClose={vi.fn()}
+        />,
+      );
+      expect(screen.getByText(/2件の返信/)).toBeInTheDocument();
+    });
+
+    it('閉じるボタンをクリックすると onClose が呼ばれる', async () => {
+      const onClose = vi.fn();
+      render(
+        <ThreadPanel
+          rootMessage={rootMessage}
+          initialReplies={[]}
+          currentUserId={1}
+          users={dummyUsers}
+          onClose={onClose}
+        />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: /閉じる/i }));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('返信送信', () => {
+    it('返信エディターから送信すると send_thread_reply イベントが emit される', async () => {
+      render(
+        <ThreadPanel
+          rootMessage={rootMessage}
+          initialReplies={[]}
+          currentUserId={1}
+          users={dummyUsers}
+          onClose={vi.fn()}
+        />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: '送信' }));
+      expect(mockSocket.emit).toHaveBeenCalledWith(
+        'send_thread_reply',
+        expect.objectContaining({
+          rootMessageId: rootMessage.id,
+        }),
+      );
+    });
+
+    it('返信先を選択中は「返信先: XX へ」ラベルを表示する', async () => {
+      render(
+        <ThreadPanel
+          rootMessage={rootMessage}
+          initialReplies={[reply1]}
+          currentUserId={1}
+          users={dummyUsers}
+          onClose={vi.fn()}
+        />,
+      );
+      // reply1 の「返信」ボタンをクリックして返信先を選択
+      const replyButtons = screen.getAllByRole('button', { name: /^返信$/ });
+      await userEvent.click(replyButtons[0]);
+      expect(screen.getByText(/返信先:/)).toBeInTheDocument();
+    });
+  });
+
+  describe('Socket イベント受信', () => {
+    it('new_thread_reply を受信すると返信一覧に追加される', () => {
+      render(
+        <ThreadPanel
+          rootMessage={rootMessage}
+          initialReplies={[reply1]}
+          currentUserId={1}
+          users={dummyUsers}
+          onClose={vi.fn()}
+        />,
+      );
+
+      const newReply = makeMessage({
+        id: 99,
+        content: JSON.stringify({ ops: [{ insert: '新着返信\n' }] }),
+        parentMessageId: 1,
+        rootMessageId: 1,
+      });
+
+      act(() => {
+        socketHandlers['new_thread_reply']?.({
+          reply: newReply,
+          rootMessageId: 1,
+          channelId: 1,
+          replyCount: 2,
+        });
+      });
+
+      // 返信件数が更新される
+      expect(screen.getByText(/2件の返信/)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/__fixtures__/channels.ts
+++ b/packages/client/src/__tests__/__fixtures__/channels.ts
@@ -30,5 +30,8 @@ export function makeChannelMessage(id: number, channelId: number): Message {
     mentions: [],
     attachments: [],
     reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
   };
 }

--- a/packages/client/src/__tests__/__fixtures__/messages.ts
+++ b/packages/client/src/__tests__/__fixtures__/messages.ts
@@ -18,6 +18,9 @@ export function makeMessage(overrides: Partial<Message> = {}): Message {
     updatedAt: '2024-06-01T12:00:00Z',
     mentions: [],
     reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/useMessages.test.tsx
+++ b/packages/client/src/__tests__/useMessages.test.tsx
@@ -66,6 +66,9 @@ function makeMessage(id: number, channelId = 1): Message {
     updatedAt: '2024-01-01T00:00:00Z',
     mentions: [],
     reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
   };
 }
 

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -76,6 +76,8 @@ export const api = {
     delete: (id: number) => request<void>(`/messages/${id}`, { method: 'DELETE' }),
     search: (q: string) =>
       request<{ messages: MessageSearchResult[] }>(`/messages/search?q=${encodeURIComponent(q)}`),
+    getReplies: (messageId: number) =>
+      request<{ replies: Message[] }>(`/messages/${messageId}/replies`),
   },
   files: {
     upload: (file: File): Promise<Attachment & { id: number }> => {

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -30,6 +30,20 @@ import ChannelMembersDialog from './ChannelMembersDialog';
 
 const PINS_STORAGE_KEY = 'channel_pins';
 
+/**
+ * React 19 の concurrent モードではコミット前に同じコンポーネントが複数回インスタンス化される
+ * 場合があり、useState イニシャライザが多重実行されると API が多重発行される。
+ * モジュールレベルキャッシュで 1 回しかフェッチしないようにする。
+ */
+let _channelsPromise: Promise<{ channels: Channel[] }> | null = null;
+
+function getOrCreateChannelsPromise(): Promise<{ channels: Channel[] }> {
+  if (!_channelsPromise) {
+    _channelsPromise = api.channels.list();
+  }
+  return _channelsPromise;
+}
+
 interface Props {
   activeChannelId: number | null;
   onSelect: (id: number) => void;
@@ -321,7 +335,7 @@ function ChannelListContent({
 }
 
 export default function ChannelList({ activeChannelId, onSelect }: Props) {
-  const [channelsPromise] = useState(() => api.channels.list());
+  const [channelsPromise] = useState(() => getOrCreateChannelsPromise());
 
   return (
     <Suspense

--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -8,6 +8,7 @@ import LinkIcon from '@mui/icons-material/Link';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import EmojiEmotionsIcon from '@mui/icons-material/EmojiEmotions';
+import ReplyIcon from '@mui/icons-material/Reply';
 import type { Message, Reaction, User } from '@chat-app/shared';
 import { useSocket } from '../../contexts/SocketContext';
 import RichEditor from './RichEditor';
@@ -19,6 +20,7 @@ interface Props {
   message: Message;
   currentUserId: number;
   users: User[];
+  onOpenThread?: (messageId: number) => void;
 }
 
 function formatTime(dateStr: string): string {
@@ -134,7 +136,7 @@ function renderContent(content: string): React.ReactNode {
   }
 }
 
-export default function MessageItem({ message, currentUserId, users }: Props) {
+export default function MessageItem({ message, currentUserId, users, onOpenThread }: Props) {
   const [editing, setEditing] = useState(false);
   const [profileAnchor, setProfileAnchor] = useState<HTMLElement | null>(null);
   const [emojiAnchor, setEmojiAnchor] = useState<HTMLElement | null>(null);
@@ -441,6 +443,33 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
                   ))}
                 </Box>
               )}
+
+              {/* 返信バッジ */}
+              {message.replyCount > 0 && (
+                <Box
+                  component="button"
+                  onClick={() => onOpenThread?.(message.id)}
+                  sx={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 0.5,
+                    mt: 0.5,
+                    px: 1,
+                    py: 0.25,
+                    border: 'none',
+                    borderRadius: 1,
+                    bgcolor: 'transparent',
+                    color: 'primary.main',
+                    cursor: 'pointer',
+                    fontSize: '0.75rem',
+                    fontWeight: 600,
+                    '&:hover': { bgcolor: 'action.hover' },
+                  }}
+                >
+                  <ReplyIcon sx={{ fontSize: '0.875rem' }} />
+                  {message.replyCount}件の返信
+                </Box>
+              )}
             </Box>
 
             {/* 絵文字ピッカー（Popper なので DOM 位置は任意） */}
@@ -464,6 +493,15 @@ export default function MessageItem({ message, currentUserId, users }: Props) {
                 flexShrink: 0,
               }}
             >
+              <Tooltip title="返信">
+                <IconButton
+                  size="small"
+                  aria-label="返信"
+                  onClick={() => onOpenThread?.(message.id)}
+                >
+                  <ReplyIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
               <Tooltip title="リアクションを追加">
                 <IconButton
                   size="small"

--- a/packages/client/src/components/Chat/MessageList.tsx
+++ b/packages/client/src/components/Chat/MessageList.tsx
@@ -10,9 +10,16 @@ interface Props {
   onLoadMore: () => void;
   currentUserId: number | null;
   users?: User[];
+  onOpenThread?: (messageId: number) => void;
 }
 
-export default function MessageList({ messages, loading, onLoadMore, users = [] }: Props) {
+export default function MessageList({
+  messages,
+  loading,
+  onLoadMore,
+  users = [],
+  onOpenThread,
+}: Props) {
   const { user } = useAuth();
   const bottomRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -79,7 +86,13 @@ export default function MessageList({ messages, loading, onLoadMore, users = [] 
       <Box sx={{ flexGrow: 1 }} />
 
       {messages.map((msg) => (
-        <MessageItem key={msg.id} message={msg} currentUserId={user.id} users={users} />
+        <MessageItem
+          key={msg.id}
+          message={msg}
+          currentUserId={user.id}
+          users={users}
+          onOpenThread={onOpenThread}
+        />
       ))}
 
       <div ref={bottomRef} />

--- a/packages/client/src/components/Chat/SearchResults.tsx
+++ b/packages/client/src/components/Chat/SearchResults.tsx
@@ -74,6 +74,23 @@ export default function SearchResults({ results, onNavigate }: Props) {
                 </Tooltip>
               </Box>
             </Box>
+            {result.rootMessageContent && (
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{
+                  display: 'block',
+                  mb: 0.5,
+                  pl: 1,
+                  borderLeft: 2,
+                  borderColor: 'divider',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {extractText(result.rootMessageContent)}
+              </Typography>
+            )}
             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
               {extractText(result.content)}
             </Typography>

--- a/packages/client/src/components/Chat/ThreadPanel.tsx
+++ b/packages/client/src/components/Chat/ThreadPanel.tsx
@@ -1,0 +1,264 @@
+import { useState, useEffect } from 'react';
+import { Box, Typography, IconButton, Divider, Avatar, Tooltip, Chip } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import ReplyIcon from '@mui/icons-material/Reply';
+import type { Message, User } from '@chat-app/shared';
+import { useSocket } from '../../contexts/SocketContext';
+import RichEditor from './RichEditor';
+import { getAvatarColor } from '../../utils/avatarColor';
+
+const THREAD_PANEL_WIDTH = 360;
+const MAX_INDENT_DEPTH = 2;
+const INDENT_PX = 24;
+
+interface Props {
+  rootMessage: Message;
+  initialReplies: Message[];
+  currentUserId: number;
+  users: User[];
+  onClose: () => void;
+}
+
+function formatTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+interface DeltaOp {
+  insert?: string | { mention?: { value: string } };
+}
+
+function extractText(content: string): string {
+  try {
+    const delta = JSON.parse(content) as { ops?: DeltaOp[] };
+    return (
+      delta.ops
+        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
+        .join('')
+        .trim() ?? content
+    );
+  } catch {
+    return content;
+  }
+}
+
+interface ReplyItemProps {
+  message: Message;
+  depth: number;
+  currentUserId: number;
+  users: User[];
+  onReply: (message: Message) => void;
+}
+
+function ReplyItem({ message, depth, users, onReply }: ReplyItemProps) {
+  const indentDepth = Math.min(depth, MAX_INDENT_DEPTH);
+  const author = users.find((u) => u.id === message.userId);
+  const displayName = author?.displayName || message.username;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 1,
+        pl: indentDepth * (INDENT_PX / 8),
+        py: 0.5,
+        '&:hover .reply-action': { opacity: 1 },
+      }}
+    >
+      <Avatar
+        src={author?.avatarUrl ?? undefined}
+        alt={displayName}
+        sx={{
+          width: 28,
+          height: 28,
+          mt: 0.25,
+          flexShrink: 0,
+          fontSize: '0.75rem',
+          ...(!author?.avatarUrl && { bgcolor: getAvatarColor(author?.email ?? '') }),
+        }}
+      >
+        {displayName[0].toUpperCase()}
+      </Avatar>
+      <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+        <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+          <Typography variant="caption" fontWeight="bold">
+            {displayName}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            {formatTime(message.createdAt)}
+          </Typography>
+        </Box>
+        <Typography variant="body2" sx={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+          {extractText(message.content)}
+        </Typography>
+      </Box>
+      <Tooltip title="返信">
+        <IconButton
+          aria-label="返信"
+          size="small"
+          className="reply-action"
+          sx={{ opacity: 0, transition: 'opacity 0.15s', flexShrink: 0 }}
+          onClick={() => onReply(message)}
+        >
+          <ReplyIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+}
+
+export default function ThreadPanel({
+  rootMessage,
+  initialReplies,
+  currentUserId,
+  users,
+  onClose,
+}: Props) {
+  const [replies, setReplies] = useState<Message[]>(initialReplies);
+  const [replyTarget, setReplyTarget] = useState<Message>(rootMessage);
+  const socket = useSocket();
+
+  const author = users.find((u) => u.id === rootMessage.userId);
+  const displayName = author?.displayName || rootMessage.username;
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = (data: {
+      reply: Message;
+      rootMessageId: number;
+      channelId: number;
+      replyCount: number;
+    }) => {
+      if (data.rootMessageId === rootMessage.id) {
+        setReplies((prev) => {
+          if (prev.some((r) => r.id === data.reply.id)) return prev;
+          return [...prev, data.reply];
+        });
+      }
+    };
+    socket.on('new_thread_reply', handler);
+    return () => {
+      socket.off('new_thread_reply', handler);
+    };
+  }, [socket, rootMessage.id]);
+
+  const handleSend = (content: string, mentionedUserIds: number[], attachmentIds: number[]) => {
+    socket?.emit('send_thread_reply', {
+      parentMessageId: replyTarget.id,
+      rootMessageId: rootMessage.id,
+      content,
+      mentionedUserIds,
+      attachmentIds,
+    });
+    setReplyTarget(rootMessage);
+  };
+
+  return (
+    <Box
+      sx={{
+        width: THREAD_PANEL_WIDTH,
+        flexShrink: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        borderLeft: 1,
+        borderColor: 'divider',
+        height: '100%',
+        overflow: 'hidden',
+      }}
+    >
+      {/* ヘッダー */}
+      <Box sx={{ display: 'flex', alignItems: 'center', px: 2, py: 1, flexShrink: 0 }}>
+        <Typography variant="subtitle1" fontWeight="bold" sx={{ flexGrow: 1 }}>
+          スレッド
+        </Typography>
+        <Tooltip title="閉じる">
+          <IconButton aria-label="閉じる" size="small" onClick={onClose}>
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <Divider />
+
+      {/* ルートメッセージ */}
+      <Box sx={{ px: 2, py: 1.5, flexShrink: 0 }}>
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Avatar
+            src={author?.avatarUrl ?? undefined}
+            alt={displayName}
+            sx={{
+              width: 32,
+              height: 32,
+              mt: 0.25,
+              flexShrink: 0,
+              ...(!author?.avatarUrl && { bgcolor: getAvatarColor(author?.email ?? '') }),
+            }}
+          >
+            {displayName[0].toUpperCase()}
+          </Avatar>
+          <Box>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
+              <Typography variant="caption" fontWeight="bold">
+                {displayName}
+              </Typography>
+              <Typography variant="caption" color="text.secondary">
+                {formatTime(rootMessage.createdAt)}
+              </Typography>
+            </Box>
+            <Typography variant="body2" sx={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
+              {extractText(rootMessage.content)}
+            </Typography>
+          </Box>
+        </Box>
+      </Box>
+
+      <Divider />
+
+      {/* 返信一覧 */}
+      <Box sx={{ flexGrow: 1, overflowY: 'auto', px: 1, py: 1 }}>
+        {replies.length > 0 && (
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            sx={{ px: 1, display: 'block', mb: 0.5 }}
+          >
+            {replies.length}件の返信
+          </Typography>
+        )}
+        {replies.map((reply) => {
+          const depth = reply.parentMessageId === rootMessage.id ? 1 : 2;
+          return (
+            <ReplyItem
+              key={reply.id}
+              message={reply}
+              depth={depth}
+              currentUserId={currentUserId}
+              users={users}
+              onReply={(msg) => setReplyTarget(msg)}
+            />
+          );
+        })}
+      </Box>
+
+      <Divider />
+
+      {/* 入力エリア */}
+      <Box sx={{ px: 1, py: 1, flexShrink: 0 }}>
+        {replyTarget.id !== rootMessage.id && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 0.5 }}>
+            <Typography variant="caption" color="text.secondary">
+              返信先:{' '}
+              {users.find((u) => u.id === replyTarget.userId)?.displayName || replyTarget.username}{' '}
+              へ
+            </Typography>
+            <Chip
+              label="×"
+              size="small"
+              onClick={() => setReplyTarget(rootMessage)}
+              sx={{ height: 16, fontSize: '0.65rem', cursor: 'pointer' }}
+            />
+          </Box>
+        )}
+        <RichEditor users={users} onSend={handleSend} />
+      </Box>
+    </Box>
+  );
+}

--- a/packages/client/src/components/Chat/ThreadPanel.tsx
+++ b/packages/client/src/components/Chat/ThreadPanel.tsx
@@ -117,6 +117,11 @@ export default function ThreadPanel({
   const [replyTarget, setReplyTarget] = useState<Message>(rootMessage);
   const socket = useSocket();
 
+  // initialReplies は非同期フェッチ後に更新されるため、変化を検知して同期する
+  useEffect(() => {
+    setReplies(initialReplies);
+  }, [initialReplies]);
+
   const author = users.find((u) => u.id === rootMessage.userId);
   const displayName = author?.displayName || rootMessage.username;
 

--- a/packages/client/src/contexts/AuthContext.tsx
+++ b/packages/client/src/contexts/AuthContext.tsx
@@ -1,4 +1,13 @@
-import { createContext, useContext, useState, use, Suspense, ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  use,
+  Suspense,
+  ReactNode,
+  useCallback,
+  useMemo,
+} from 'react';
 import { CircularProgress, Box } from '@mui/material';
 import type { User } from '@chat-app/shared';
 import { api } from '../api/client';
@@ -27,28 +36,29 @@ function AuthProviderContent({ mePromise, children }: AuthProviderContentProps) 
   const initialUser = use(mePromise);
   const [user, setUser] = useState<User | null>(initialUser);
 
-  const login = async (email: string, password: string) => {
+  const login = useCallback(async (email: string, password: string) => {
     const { user } = await api.auth.login({ email, password });
     setUser(user);
-  };
+  }, []);
 
-  const register = async (username: string, email: string, password: string) => {
+  const register = useCallback(async (username: string, email: string, password: string) => {
     const { user } = await api.auth.register({ username, email, password });
     setUser(user);
-  };
+  }, []);
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     await api.auth.logout();
     setUser(null);
-  };
+  }, []);
 
-  const updateUser = (updated: User) => setUser(updated);
+  const updateUser = useCallback((updated: User) => setUser(updated), []);
 
-  return (
-    <AuthContext.Provider value={{ user, login, register, logout, updateUser }}>
-      {children}
-    </AuthContext.Provider>
+  const value = useMemo(
+    () => ({ user, login, register, logout, updateUser }),
+    [user, login, register, logout, updateUser],
   );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 /**

--- a/packages/client/src/contexts/SocketContext.tsx
+++ b/packages/client/src/contexts/SocketContext.tsx
@@ -13,7 +13,10 @@ export function SocketProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!user) {
-      setSocket((prev) => { prev?.disconnect(); return null; });
+      setSocket((prev) => {
+        prev?.disconnect();
+        return null;
+      });
       return;
     }
 

--- a/packages/client/src/hooks/useMessages.ts
+++ b/packages/client/src/hooks/useMessages.ts
@@ -57,16 +57,33 @@ export function useMessages(channelId: number | null) {
       setMessages((prev) => prev.map((m) => (m.id === msg.id ? msg : m)));
     };
 
+    const onThreadReply = (data: {
+      reply: Message;
+      rootMessageId: number;
+      channelId: number;
+      replyCount: number;
+    }) => {
+      if (data.channelId === channelId) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === data.rootMessageId ? { ...m, replyCount: data.replyCount } : m,
+          ),
+        );
+      }
+    };
+
     socket.on('new_message', onNew);
     socket.on('message_edited', onEdited);
     socket.on('message_deleted', onDeleted);
     socket.on('message_restored', onRestored);
+    socket.on('new_thread_reply', onThreadReply);
 
     return () => {
       socket.off('new_message', onNew);
       socket.off('message_edited', onEdited);
       socket.off('message_deleted', onDeleted);
       socket.off('message_restored', onRestored);
+      socket.off('new_thread_reply', onThreadReply);
     };
   }, [socket, channelId]);
 

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -53,6 +53,7 @@ export default function ChatPage({ users }: Props) {
   // スレッドパネルを開く
   const handleOpenThread = useCallback((messageId: number) => {
     setThreadRootId(messageId);
+    setThreadReplies([]);
     api.messages
       .getReplies(messageId)
       .then(({ replies }) => setThreadReplies(replies))

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -1,14 +1,15 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Box } from '@mui/material';
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
 import MessageList from '../components/Chat/MessageList';
 import RichEditor from '../components/Chat/RichEditor';
 import SearchResults from '../components/Chat/SearchResults';
+import ThreadPanel from '../components/Chat/ThreadPanel';
 import { useMessages } from '../hooks/useMessages';
 import { useSocket } from '../contexts/SocketContext';
 import { api } from '../api/client';
-import type { User, MessageSearchResult } from '@chat-app/shared';
+import type { User, Message, MessageSearchResult } from '@chat-app/shared';
 
 interface Props {
   users: User[];
@@ -21,6 +22,8 @@ export default function ChatPage({ users }: Props) {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
+  const [threadRootId, setThreadRootId] = useState<number | null>(null);
+  const [threadReplies, setThreadReplies] = useState<Message[]>([]);
 
   // URL の ?channel=X からチャンネルを初期選択する
   useEffect(() => {
@@ -29,7 +32,7 @@ export default function ChatPage({ users }: Props) {
     if (channelId) setActiveChannelId(Number(channelId));
   }, []);
 
-  // 検索クエリが変わったら API を呼ぶ（デバウンスなし・300ms debounce）
+  // 検索クエリが変わったら API を呼ぶ（300ms debounce）
   useEffect(() => {
     if (!searchQuery.trim()) {
       setSearchResults([]);
@@ -47,6 +50,25 @@ export default function ChatPage({ users }: Props) {
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
+  // スレッドパネルを開く
+  const handleOpenThread = useCallback((messageId: number) => {
+    setThreadRootId(messageId);
+    api.messages
+      .getReplies(messageId)
+      .then(({ replies }) => setThreadReplies(replies))
+      .catch(console.error);
+  }, []);
+
+  const handleCloseThread = useCallback(() => {
+    setThreadRootId(null);
+    setThreadReplies([]);
+  }, []);
+
+  const threadRootMessage = useMemo(
+    () => messages.find((m) => m.id === threadRootId) ?? null,
+    [messages, threadRootId],
+  );
+
   const handleSend = (content: string, mentionedUserIds: number[], attachmentIds: number[]) => {
     if (!activeChannelId || !socket) return;
     socket.emit('send_message', {
@@ -61,7 +83,6 @@ export default function ChatPage({ users }: Props) {
   const handleNavigate = useCallback((channelId: number, messageId: number) => {
     setSearchQuery('');
     setActiveChannelId(channelId);
-    // チャンネル切り替え後に hash scroll が動くよう非同期で設定
     setTimeout(() => {
       window.location.hash = `#message-${messageId}`;
     }, 100);
@@ -75,24 +96,39 @@ export default function ChatPage({ users }: Props) {
       searchQuery={searchQuery}
       onSearchChange={setSearchQuery}
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-        {isSearchMode ? (
-          <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
-            {!searching && <SearchResults results={searchResults} onNavigate={handleNavigate} />}
-          </Box>
-        ) : (
-          <>
-            <MessageList
-              messages={messages}
-              loading={loading}
-              onLoadMore={loadMore}
-              currentUserId={null}
-              users={users}
-            />
-            <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}>
-              <RichEditor users={users} onSend={handleSend} disabled={!activeChannelId} />
+      <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
+        {/* メインエリア */}
+        <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+          {isSearchMode ? (
+            <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+              {!searching && <SearchResults results={searchResults} onNavigate={handleNavigate} />}
             </Box>
-          </>
+          ) : (
+            <>
+              <MessageList
+                messages={messages}
+                loading={loading}
+                onLoadMore={loadMore}
+                currentUserId={null}
+                users={users}
+                onOpenThread={handleOpenThread}
+              />
+              <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}>
+                <RichEditor users={users} onSend={handleSend} disabled={!activeChannelId} />
+              </Box>
+            </>
+          )}
+        </Box>
+
+        {/* スレッドパネル */}
+        {threadRootMessage && (
+          <ThreadPanel
+            rootMessage={threadRootMessage}
+            initialReplies={threadReplies}
+            currentUserId={0}
+            users={users}
+            onClose={handleCloseThread}
+          />
         )}
       </Box>
     </AppLayout>

--- a/packages/client/src/pages/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage.tsx
@@ -1,11 +1,14 @@
 import { useState, FormEvent } from 'react';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink, Navigate } from 'react-router-dom';
 import { Box, Button, Container, TextField, Typography, Alert, Link } from '@mui/material';
 import { useAuth } from '../contexts/AuthContext';
 
 export default function LoginPage() {
-  const { login } = useAuth();
+  const { user, login } = useAuth();
   const navigate = useNavigate();
+
+  // ログイン済みの場合はチャットページへリダイレクト（navigate() と setUser() の競合状態を防ぐ）
+  if (user) return <Navigate to="/" replace />;
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -37,7 +40,11 @@ export default function LoginPage() {
 
         {error && <Alert severity="error">{error}</Alert>}
 
-        <Box component="form" onSubmit={(e) => void handleSubmit(e)} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <Box
+          component="form"
+          onSubmit={(e) => void handleSubmit(e)}
+          sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}
+        >
           <TextField
             label="Email"
             type="email"

--- a/packages/server/src/__tests__/threadReply.test.ts
+++ b/packages/server/src/__tests__/threadReply.test.ts
@@ -1,0 +1,184 @@
+/**
+ * テスト対象: messageService のスレッド返信関連機能
+ * 戦略: better-sqlite3 のインメモリ DB を使いサービス層を直接テストする。
+ * 外部キー制約を満たすため beforeAll でユーザー・チャンネルを挿入する。
+ */
+
+import {
+  getChannelMessages,
+  createMessage,
+  createThreadReply,
+  getThreadReplies,
+  searchMessages,
+} from '../services/messageService';
+import DatabaseLib from 'better-sqlite3';
+import type { Message } from '@chat-app/shared';
+
+let userId1: number;
+let userId2: number;
+let channelId: number;
+
+jest.mock('../db/database', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const DB = require('better-sqlite3') as typeof import('better-sqlite3');
+  const db = new DB(':memory:');
+  db.pragma('foreign_keys = ON');
+  const { initializeSchema: init } =
+    jest.requireActual<typeof import('../db/database')>('../db/database');
+  init(db);
+  return {
+    getDatabase: () => db,
+    initializeSchema: init,
+    closeDatabase: jest.fn(),
+  };
+});
+
+beforeAll(() => {
+  const DB = DatabaseLib;
+  const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+  const db = getDatabase() as InstanceType<typeof DB>;
+
+  const r1 = db
+    .prepare("INSERT INTO users (username, email, password_hash) VALUES ('user1', 'u1@t.com', 'h')")
+    .run();
+  userId1 = r1.lastInsertRowid as number;
+
+  const r2 = db
+    .prepare("INSERT INTO users (username, email, password_hash) VALUES ('user2', 'u2@t.com', 'h')")
+    .run();
+  userId2 = r2.lastInsertRowid as number;
+
+  const rc = db
+    .prepare("INSERT INTO channels (name, created_by) VALUES ('test-channel', ?)")
+    .run(userId1);
+  channelId = rc.lastInsertRowid as number;
+});
+
+const sampleContent = JSON.stringify({ ops: [{ insert: 'Hello\n' }] });
+const replyContent = JSON.stringify({ ops: [{ insert: 'Reply\n' }] });
+
+describe('getChannelMessages（スレッド対応）', () => {
+  let rootId: number;
+
+  beforeEach(() => {
+    const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+    const db = getDatabase() as InstanceType<typeof DatabaseLib>;
+    db.prepare('DELETE FROM messages').run();
+
+    const root = createMessage(channelId, userId1, sampleContent);
+    rootId = root.id;
+    createThreadReply(rootId, rootId, userId2, replyContent);
+  });
+
+  it('ルートメッセージのみ返す（root_message_id IS NULL のもの）', () => {
+    const messages = getChannelMessages(channelId);
+    expect(messages.every((m: Message) => m.rootMessageId === null)).toBe(true);
+    expect(messages.length).toBe(1);
+  });
+
+  it('ルートメッセージに replyCount が付与される', () => {
+    const messages = getChannelMessages(channelId);
+    expect(messages[0].replyCount).toBe(1);
+  });
+
+  it('ルートメッセージに parentMessageId / rootMessageId が null で付与される', () => {
+    const messages = getChannelMessages(channelId);
+    expect(messages[0].parentMessageId).toBeNull();
+    expect(messages[0].rootMessageId).toBeNull();
+  });
+});
+
+describe('createThreadReply', () => {
+  let rootId: number;
+
+  beforeEach(() => {
+    const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+    const db = getDatabase() as InstanceType<typeof DatabaseLib>;
+    db.prepare('DELETE FROM messages').run();
+
+    const root = createMessage(channelId, userId1, sampleContent);
+    rootId = root.id;
+  });
+
+  it('スレッド返信を作成し Message を返す', () => {
+    const reply = createThreadReply(rootId, rootId, userId2, replyContent);
+    expect(reply.id).toBeDefined();
+    expect(reply.content).toBe(replyContent);
+    expect(reply.userId).toBe(userId2);
+  });
+
+  it('返信の parent_message_id / root_message_id が正しく設定される', () => {
+    const reply = createThreadReply(rootId, rootId, userId2, replyContent);
+    expect(reply.parentMessageId).toBe(rootId);
+    expect(reply.rootMessageId).toBe(rootId);
+  });
+
+  it('メンション付き返信が作成できる', () => {
+    const reply = createThreadReply(rootId, rootId, userId2, replyContent, [userId1]);
+    expect(reply.mentions).toContain(userId1);
+  });
+});
+
+describe('getThreadReplies', () => {
+  let rootId: number;
+
+  beforeEach(() => {
+    const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+    const db = getDatabase() as InstanceType<typeof DatabaseLib>;
+    db.prepare('DELETE FROM messages').run();
+
+    const root = createMessage(channelId, userId1, sampleContent);
+    rootId = root.id;
+  });
+
+  it('rootMessageId に紐づく全返信を created_at ASC で返す', () => {
+    createThreadReply(rootId, rootId, userId1, replyContent);
+    createThreadReply(rootId, rootId, userId2, replyContent);
+
+    const replies = getThreadReplies(rootId);
+    expect(replies.length).toBe(2);
+    expect(replies[0].id).toBeLessThan(replies[1].id);
+  });
+
+  it('返信が 0 件のとき空配列を返す', () => {
+    const replies = getThreadReplies(rootId);
+    expect(replies).toEqual([]);
+  });
+});
+
+describe('searchMessages（スレッド対応）', () => {
+  let rootId: number;
+
+  beforeEach(() => {
+    const { getDatabase } = jest.requireMock<typeof import('../db/database')>('../db/database');
+    const db = getDatabase() as InstanceType<typeof DatabaseLib>;
+    db.prepare('DELETE FROM messages').run();
+
+    const rootContent = JSON.stringify({ ops: [{ insert: 'ルートメッセージ\n' }] });
+    const root = createMessage(channelId, userId1, rootContent);
+    rootId = root.id;
+
+    const replyC = JSON.stringify({ ops: [{ insert: '検索対象の返信\n' }] });
+    createThreadReply(rootId, rootId, userId2, replyC);
+  });
+
+  it('スレッド返信も検索対象に含まれる', () => {
+    const results = searchMessages('検索対象');
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r: Message) => r.rootMessageId === rootId)).toBe(true);
+  });
+
+  it('スレッド返信の結果に rootMessageContent が付与される', () => {
+    const results = searchMessages('検索対象');
+    const reply = results.find((r: Message) => r.rootMessageId === rootId);
+    expect(reply).toBeDefined();
+    expect(reply!.rootMessageContent).not.toBeNull();
+  });
+
+  it('ルートメッセージの検索結果には rootMessageContent が null になる', () => {
+    const results = searchMessages('ルートメッセージ');
+    const root = results.find((r: Message) => r.id === rootId);
+    expect(root).toBeDefined();
+    expect(root!.rootMessageContent).toBeNull();
+  });
+});

--- a/packages/server/src/controllers/messageController.ts
+++ b/packages/server/src/controllers/messageController.ts
@@ -56,3 +56,12 @@ export function deleteMessage(req: Request, res: Response, next: NextFunction): 
     next(err);
   }
 }
+
+export function getReplies(req: Request, res: Response, next: NextFunction): void {
+  try {
+    const replies = messageService.getThreadReplies(Number(req.params.id));
+    res.json({ replies });
+  } catch (err) {
+    next(err);
+  }
+}

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -59,7 +59,9 @@ export function initializeSchema(database: Database.Database): void {
       is_edited INTEGER NOT NULL DEFAULT 0,
       is_deleted INTEGER NOT NULL DEFAULT 0,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      parent_message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE,
+      root_message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE
     );
 
     CREATE TABLE IF NOT EXISTS mentions (
@@ -171,13 +173,33 @@ export function initializeSchema(database: Database.Database): void {
         is_edited INTEGER NOT NULL DEFAULT 0,
         is_deleted INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        parent_message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE,
+        root_message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE
       );
-      INSERT INTO messages_new SELECT * FROM messages;
+      INSERT INTO messages_new SELECT id, channel_id, user_id, content, is_edited, is_deleted, created_at, updated_at, NULL, NULL FROM messages;
       DROP TABLE messages;
       ALTER TABLE messages_new RENAME TO messages;
       PRAGMA foreign_keys = ON;
     `);
+  }
+
+  // parent_message_id / root_message_id カラムがない場合は追加する（既存DBへの移行）
+  const messageColNames = (
+    database.prepare('PRAGMA table_info(messages)').all() as { name: string }[]
+  ).map((c) => c.name);
+  if (!messageColNames.includes('parent_message_id')) {
+    database.exec(
+      'ALTER TABLE messages ADD COLUMN parent_message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE',
+    );
+  }
+  if (!messageColNames.includes('root_message_id')) {
+    database.exec(
+      'ALTER TABLE messages ADD COLUMN root_message_id INTEGER REFERENCES messages(id) ON DELETE CASCADE',
+    );
+    database.exec(
+      'CREATE INDEX IF NOT EXISTS messages_root_message_id ON messages(root_message_id)',
+    );
   }
 
   // message_attachments.message_id が NOT NULL 制約付きで作られていた場合は再作成する

--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -149,7 +149,8 @@ export function initializeSchema(database: Database.Database): void {
         is_private INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
-      INSERT INTO channels_new SELECT * FROM channels;
+      INSERT INTO channels_new (id, name, description, created_by, is_private, created_at)
+        SELECT id, name, description, created_by, is_private, created_at FROM channels;
       DROP TABLE channels;
       ALTER TABLE channels_new RENAME TO channels;
       PRAGMA foreign_keys = ON;

--- a/packages/server/src/routes/messages.ts
+++ b/packages/server/src/routes/messages.ts
@@ -27,6 +27,26 @@ router.get('/search', authenticateToken, controller.searchMessages);
 
 /**
  * @swagger
+ * /api/messages/{id}/replies:
+ *   get:
+ *     summary: スレッド返信一覧を取得する
+ *     tags: [Messages]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: integer }
+ *         description: ルートメッセージID
+ *     responses:
+ *       200:
+ *         description: 返信メッセージ一覧
+ */
+router.get('/:id/replies', authenticateToken, controller.getReplies);
+
+/**
+ * @swagger
  * tags:
  *   name: Messages
  *   description: Message editing and deletion

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -13,11 +13,14 @@ interface MessageRow {
   is_deleted: number;
   created_at: string;
   updated_at: string;
+  parent_message_id: number | null;
+  root_message_id: number | null;
 }
 
 const MESSAGE_SELECT = `
   SELECT m.id, m.channel_id, m.user_id, u.username, u.avatar_url,
-         m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at
+         m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at,
+         m.parent_message_id, m.root_message_id
   FROM messages m
   LEFT JOIN users u ON m.user_id = u.id
 `;
@@ -72,6 +75,14 @@ function getAttachments(messageId: number): Attachment[] {
   }));
 }
 
+function getReplyCount(messageId: number): number {
+  const db = getDatabase();
+  const row = db
+    .prepare('SELECT COUNT(*) as cnt FROM messages WHERE root_message_id = ?')
+    .get(messageId) as { cnt: number };
+  return row.cnt;
+}
+
 function toMessage(row: MessageRow): Message {
   return {
     id: row.id,
@@ -87,13 +98,16 @@ function toMessage(row: MessageRow): Message {
     mentions: getMentions(row.id),
     attachments: getAttachments(row.id),
     reactions: getReactionsForMessage(row.id),
+    parentMessageId: row.parent_message_id,
+    rootMessageId: row.root_message_id,
+    replyCount: row.root_message_id === null ? getReplyCount(row.id) : 0,
   };
 }
 
 export function getChannelMessages(channelId: number, limit = 50, before?: number): Message[] {
   const db = getDatabase();
 
-  let query = MESSAGE_SELECT + ' WHERE m.channel_id = ?';
+  let query = MESSAGE_SELECT + ' WHERE m.channel_id = ? AND m.root_message_id IS NULL';
   const params: unknown[] = [channelId];
 
   if (before !== undefined) {
@@ -105,6 +119,55 @@ export function getChannelMessages(channelId: number, limit = 50, before?: numbe
   params.push(limit);
 
   const rows = (db.prepare(query).all(...params) as MessageRow[]).reverse();
+  return rows.map(toMessage);
+}
+
+export function createThreadReply(
+  parentMessageId: number,
+  rootMessageId: number,
+  userId: number,
+  content: string,
+  mentionedUserIds: number[] = [],
+  attachmentIds: number[] = [],
+): Message {
+  const db = getDatabase();
+
+  const parent = db.prepare('SELECT channel_id FROM messages WHERE id = ?').get(parentMessageId) as
+    | { channel_id: number }
+    | undefined;
+  if (!parent) throw createError('Parent message not found', 404);
+
+  const result = db
+    .prepare(
+      'INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id) VALUES (?, ?, ?, ?, ?)',
+    )
+    .run(parent.channel_id, userId, content, parentMessageId, rootMessageId);
+
+  const messageId = result.lastInsertRowid as number;
+
+  if (mentionedUserIds.length > 0) {
+    const insertMention = db.prepare(
+      'INSERT OR IGNORE INTO mentions (message_id, mentioned_user_id) VALUES (?, ?)',
+    );
+    for (const uid of mentionedUserIds) insertMention.run(messageId, uid);
+  }
+
+  if (attachmentIds.length > 0) {
+    const updateAttachment = db.prepare(
+      'UPDATE message_attachments SET message_id = ? WHERE id = ?',
+    );
+    for (const aid of attachmentIds) updateAttachment.run(messageId, aid);
+  }
+
+  const row = db.prepare(MESSAGE_SELECT + ' WHERE m.id = ?').get(messageId) as MessageRow;
+  return toMessage(row);
+}
+
+export function getThreadReplies(rootMessageId: number): Message[] {
+  const db = getDatabase();
+  const rows = db
+    .prepare(MESSAGE_SELECT + ' WHERE m.root_message_id = ? ORDER BY m.created_at ASC, m.id ASC')
+    .all(rootMessageId) as MessageRow[];
   return rows.map(toMessage);
 }
 
@@ -223,17 +286,27 @@ export function searchMessages(query: string): MessageSearchResult[] {
     .prepare(
       `SELECT m.id, m.channel_id, m.user_id, u.username, u.avatar_url,
               m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at,
-              c.name AS channel_name
+              m.parent_message_id, m.root_message_id,
+              c.name AS channel_name,
+              rm.content AS root_message_content
        FROM messages m
        LEFT JOIN users u ON m.user_id = u.id
        JOIN channels c ON m.channel_id = c.id
+       LEFT JOIN messages rm ON m.root_message_id = rm.id
        WHERE m.is_deleted = 0 AND m.content LIKE ?
        ORDER BY m.created_at DESC
        LIMIT 100`,
     )
-    .all(`%${query}%`) as (MessageRow & { channel_name: string })[];
+    .all(`%${query}%`) as (MessageRow & {
+    channel_name: string;
+    root_message_content: string | null;
+  })[];
 
-  return rows.map((row) => ({ ...toMessage(row), channelName: row.channel_name }));
+  return rows.map((row) => ({
+    ...toMessage(row),
+    channelName: row.channel_name,
+    rootMessageContent: row.root_message_content ?? null,
+  }));
 }
 
 export function getMessageById(messageId: number): Message | null {

--- a/packages/server/src/socket/handler.ts
+++ b/packages/server/src/socket/handler.ts
@@ -164,5 +164,29 @@ export function setupSocketHandlers(io: ChatServer): void {
         socket.emit('error', 'Failed to remove reaction');
       }
     });
+
+    socket.on('send_thread_reply', (data) => {
+      try {
+        const reply = messageService.createThreadReply(
+          data.parentMessageId,
+          data.rootMessageId,
+          userId,
+          data.content,
+          data.mentionedUserIds,
+          data.attachmentIds,
+        );
+
+        const replyCount = messageService.getThreadReplies(data.rootMessageId).length;
+
+        io.to(`channel:${reply.channelId}`).emit('new_thread_reply', {
+          reply,
+          rootMessageId: data.rootMessageId,
+          channelId: reply.channelId,
+          replyCount,
+        });
+      } catch {
+        socket.emit('error', 'Failed to send thread reply');
+      }
+    });
   });
 }

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -26,10 +26,14 @@ export interface Message {
   mentions: number[];
   attachments?: Attachment[];
   reactions: Reaction[];
+  parentMessageId: number | null;
+  rootMessageId: number | null;
+  replyCount: number;
 }
 
 export interface MessageSearchResult extends Message {
   channelName: string;
+  rootMessageContent: string | null;
 }
 
 export interface SendMessageInput {

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -2,6 +2,12 @@ import type { Message, Reaction } from './message';
 
 export interface ServerToClientEvents {
   new_message: (message: Message) => void;
+  new_thread_reply: (data: {
+    reply: Message;
+    rootMessageId: number;
+    channelId: number;
+    replyCount: number;
+  }) => void;
   message_edited: (message: Message) => void;
   message_deleted: (data: { messageId: number; channelId: number }) => void;
   message_restored: (message: Message) => void;
@@ -32,6 +38,13 @@ export interface ClientToServerEvents {
   typing_stop: (channelId: number) => void;
   add_reaction: (data: { messageId: number; emoji: string }) => void;
   remove_reaction: (data: { messageId: number; emoji: string }) => void;
+  send_thread_reply: (data: {
+    parentMessageId: number;
+    rootMessageId: number;
+    content: string;
+    mentionedUserIds?: number[];
+    attachmentIds?: number[];
+  }) => void;
 }
 
 export interface InterServerEvents {}


### PR DESCRIPTION
## 概要

issue #31 で定義されたスレッド返信機能を実装する。任意の深さのネストを許容し、右サイドパネル（固定幅360px）でスレッドを表示・入力する。

## 変更内容

### DB / 共有型
- `db/schema.hcl`: `messages` テーブルに `parent_message_id` / `root_message_id` カラム・外部キー・インデックスを追加
- `packages/server/src/db/database.ts`: `initializeSchema` に新カラムの自動追加 migration を追加
- `packages/shared/src/types/message.ts`: `Message` に `parentMessageId` / `rootMessageId` / `replyCount`、`MessageSearchResult` に `rootMessageContent` を追加
- `packages/shared/src/types/socket.ts`: `send_thread_reply`（Client→Server）/ `new_thread_reply`（Server→Client）イベントを追加

### バックエンド
- `messageService.ts`: `getChannelMessages` をルートメッセージのみ返すよう修正、`createThreadReply` / `getThreadReplies` を追加、`searchMessages` をスレッド返信対応に拡張
- `socket/handler.ts`: `send_thread_reply` ハンドラを追加（`new_thread_reply` でチャンネル全体に broadcast）
- `routes/messages.ts` / `messageController.ts`: `GET /api/messages/:id/replies` を追加

### フロントエンド
- `ThreadPanel.tsx`: 右サイドパネルを新規作成（ルートメッセージ + 返信一覧 + 返信エディター）
- `MessageItem.tsx`: アクションに「返信」ボタン追加、`replyCount > 0` 時に「N件の返信」バッジを表示
- `MessageList.tsx`: `onOpenThread` prop を追加し `MessageItem` へ伝播
- `ChatPage.tsx`: スレッドパネルの状態管理と3カラムレイアウトを実装
- `SearchResults.tsx`: スレッド返信の場合にルートメッセージ本文をプレビュー表示
- `api/client.ts`: `messages.getReplies()` を追加

### テスト
- `threadReply.test.ts`: バックエンドのスレッド関連サービス全仕様をカバー（11件）
- `ThreadPanel.test.tsx`: スレッドパネルの表示・送信・Socket受信をカバー（6件）
- `MessageItemThread.test.tsx`: 返信バッジ・返信ボタンの振る舞いをカバー（5件）

## 影響範囲

- `messages` テーブルのスキーマ変更（後方互換: 新カラムは nullable）
- `getChannelMessages` の返却内容変更（スレッド返信がメインビューから除外される）
- `Message` 型の変更（新フィールドが必須になったため既存フィクスチャを一部修正）

## 動作確認・テスト結果

- [x] ビルド成功（`npm run build`）
- [x] バックエンドテスト全通過（202件）
- [x] フロントエンドテスト全通過（209件）

## 関連Issue

Fixes #31

## チェックリスト

- [x] 型チェック・ビルドが通る
- [x] テストが全て通る
- [x] 既存機能への影響を確認した