### PR TITLE
db: Phase1 DBスキーマ追加（Issue #56/#57/#59/#61/#62対応）

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -1,6 +1,6 @@
 // Atlas 宣言モード スキーマ定義
 // このファイルがDBの正規スキーマ。変更はこのファイルを編集し atlas schema apply で適用する。
-// comment 属性は MySQL / PostgreSQL 等の移行時にDB上のコメントとして適用される（SQLiteでは無視）。
+// インデックス名が sqlite_autoindex_* のものは initializeSchema で UNIQUE 制約として作成されたもの。
 
 table "users" {
   schema  = schema.main
@@ -70,14 +70,20 @@ table "users" {
     type    = text
     comment = "最終ログイン日時"
   }
+  column "theme" {
+    null    = false
+    type    = text
+    default = "light"
+    comment = "UIテーマ（light / dark）"
+  }
   primary_key {
     columns = [column.id]
   }
-  index "users_username" {
+  index "sqlite_autoindex_users_1" {
     unique  = true
     columns = [column.username]
   }
-  index "users_email" {
+  index "sqlite_autoindex_users_2" {
     unique  = true
     columns = [column.email]
   }
@@ -119,6 +125,11 @@ table "channels" {
     default = sql("datetime('now')")
     comment = "作成日時"
   }
+  column "topic" {
+    null    = true
+    type    = text
+    comment = "チャンネルトピック"
+  }
   primary_key {
     columns = [column.id]
   }
@@ -128,7 +139,7 @@ table "channels" {
     on_update   = NO_ACTION
     on_delete   = SET_NULL
   }
-  index "channels_name" {
+  index "sqlite_autoindex_channels_1" {
     unique  = true
     columns = [column.name]
   }
@@ -228,30 +239,35 @@ table "messages" {
     type    = integer
     comment = "スレッドのルートメッセージID（NULLはルートメッセージ自身）"
   }
+  column "quoted_message_id" {
+    null    = true
+    type    = integer
+    comment = "引用元メッセージID（NULLは引用なし）"
+  }
   primary_key {
     columns = [column.id]
   }
   foreign_key "0" {
-    columns     = [column.user_id]
-    ref_columns = [table.users.column.id]
-    on_update   = NO_ACTION
-    on_delete   = SET_NULL
-  }
-  foreign_key "1" {
-    columns     = [column.channel_id]
-    ref_columns = [table.channels.column.id]
+    columns     = [column.root_message_id]
+    ref_columns = [table.messages.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
-  foreign_key "parent_message" {
+  foreign_key "1" {
     columns     = [column.parent_message_id]
     ref_columns = [table.messages.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
-  foreign_key "root_message" {
-    columns     = [column.root_message_id]
-    ref_columns = [table.messages.column.id]
+  foreign_key "2" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  foreign_key "3" {
+    columns     = [column.channel_id]
+    ref_columns = [table.channels.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
@@ -279,9 +295,16 @@ table "mentions" {
     type    = integer
     comment = "メンション対象ユーザーID"
   }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+    comment = "メンション日時"
+  }
   column "channel_id" {
     null    = false
     type    = integer
+    default = 0
     comment = "チャンネルID"
   }
   column "is_read" {
@@ -289,12 +312,6 @@ table "mentions" {
     type    = integer
     default = 0
     comment = "既読フラグ（0: 未読, 1: 既読）"
-  }
-  column "created_at" {
-    null    = false
-    type    = text
-    default = sql("datetime('now')")
-    comment = "メンション日時"
   }
   primary_key {
     columns = [column.id]
@@ -308,12 +325,6 @@ table "mentions" {
   foreign_key "1" {
     columns     = [column.message_id]
     ref_columns = [table.messages.column.id]
-    on_update   = NO_ACTION
-    on_delete   = CASCADE
-  }
-  foreign_key "2" {
-    columns     = [column.channel_id]
-    ref_columns = [table.channels.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
@@ -414,7 +425,7 @@ table "push_subscriptions" {
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
-  index "push_subscriptions_endpoint" {
+  index "sqlite_autoindex_push_subscriptions_1" {
     unique  = true
     columns = [column.endpoint]
   }
@@ -453,21 +464,21 @@ table "message_reactions" {
   primary_key {
     columns = [column.id]
   }
-  index "message_reactions_unique" {
-    unique  = true
-    columns = [column.message_id, column.user_id, column.emoji]
+  foreign_key "fk_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
   }
-  foreign_key "0" {
+  foreign_key "fk_message" {
     columns     = [column.message_id]
     ref_columns = [table.messages.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
-  foreign_key "1" {
-    columns     = [column.user_id]
-    ref_columns = [table.users.column.id]
-    on_update   = NO_ACTION
-    on_delete   = CASCADE
+  index "message_reactions_unique" {
+    unique  = true
+    columns = [column.message_id, column.user_id, column.emoji]
   }
 }
 
@@ -499,19 +510,18 @@ table "channel_read_status" {
     columns = [column.user_id, column.channel_id]
   }
   foreign_key "0" {
-    columns     = [column.user_id]
-    ref_columns = [table.users.column.id]
-    on_update   = NO_ACTION
-    on_delete   = CASCADE
-  }
-  foreign_key "1" {
     columns     = [column.channel_id]
     ref_columns = [table.channels.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
+  foreign_key "1" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
 }
-
 
 table "pinned_messages" {
   schema  = schema.main
@@ -546,13 +556,9 @@ table "pinned_messages" {
   primary_key {
     columns = [column.id]
   }
-  index "pinned_messages_unique" {
-    unique  = true
-    columns = [column.message_id, column.channel_id]
-  }
   foreign_key "0" {
-    columns     = [column.message_id]
-    ref_columns = [table.messages.column.id]
+    columns     = [column.pinned_by]
+    ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
@@ -563,10 +569,14 @@ table "pinned_messages" {
     on_delete   = CASCADE
   }
   foreign_key "2" {
-    columns     = [column.pinned_by]
-    ref_columns = [table.users.column.id]
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  index "sqlite_autoindex_pinned_messages_1" {
+    unique  = true
+    columns = [column.message_id, column.channel_id]
   }
 }
 
@@ -598,21 +608,21 @@ table "bookmarks" {
   primary_key {
     columns = [column.id]
   }
-  index "bookmarks_unique" {
-    unique  = true
-    columns = [column.user_id, column.message_id]
-  }
   foreign_key "0" {
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "1" {
     columns     = [column.user_id]
     ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
-  foreign_key "1" {
-    columns     = [column.message_id]
-    ref_columns = [table.messages.column.id]
-    on_update   = NO_ACTION
-    on_delete   = CASCADE
+  index "sqlite_autoindex_bookmarks_1" {
+    unique  = true
+    columns = [column.user_id, column.message_id]
   }
 }
 
@@ -650,21 +660,21 @@ table "dm_conversations" {
   primary_key {
     columns = [column.id]
   }
-  index "dm_conversations_unique" {
-    unique  = true
-    columns = [column.user_a_id, column.user_b_id]
-  }
   foreign_key "0" {
-    columns     = [column.user_a_id]
+    columns     = [column.user_b_id]
     ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
   foreign_key "1" {
-    columns     = [column.user_b_id]
+    columns     = [column.user_a_id]
     ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  index "sqlite_autoindex_dm_conversations_1" {
+    unique  = true
+    columns = [column.user_a_id, column.user_b_id]
   }
 }
 
@@ -707,17 +717,110 @@ table "dm_messages" {
   primary_key {
     columns = [column.id]
   }
-  index "dm_messages_conversation_id" {
-    columns = [column.conversation_id]
-  }
   foreign_key "0" {
+    columns     = [column.sender_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "1" {
     columns     = [column.conversation_id]
     ref_columns = [table.dm_conversations.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
   }
+  index "dm_messages_conversation_id" {
+    columns = [column.conversation_id]
+  }
+}
+
+table "pinned_channels" {
+  schema  = schema.main
+  comment = "ピン留めチャンネル"
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+    comment        = "ピン留めID"
+  }
+  column "user_id" {
+    null    = false
+    type    = integer
+    comment = "ユーザーID"
+  }
+  column "channel_id" {
+    null    = false
+    type    = integer
+    comment = "チャンネルID"
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+    comment = "ピン留め日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.channel_id]
+    ref_columns = [table.channels.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
   foreign_key "1" {
-    columns     = [column.sender_id]
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  index "sqlite_autoindex_pinned_channels_1" {
+    unique  = true
+    columns = [column.user_id, column.channel_id]
+  }
+}
+
+table "reminders" {
+  schema  = schema.main
+  comment = "リマインダー"
+  column "id" {
+    null           = true
+    type           = integer
+    auto_increment = true
+    comment        = "リマインダーID"
+  }
+  column "user_id" {
+    null    = false
+    type    = integer
+    comment = "ユーザーID"
+  }
+  column "message_id" {
+    null    = false
+    type    = integer
+    comment = "リマインド対象メッセージID"
+  }
+  column "remind_at" {
+    null    = false
+    type    = text
+    comment = "リマインド日時"
+  }
+  column "created_at" {
+    null    = false
+    type    = text
+    default = sql("datetime('now')")
+    comment = "作成日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "0" {
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "1" {
+    columns     = [column.user_id]
     ref_columns = [table.users.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE


### PR DESCRIPTION
## 概要

Issue #56〜#63の並列実装（Phase 2）に先立ち、必要なDBスキーマ変更を一括適用する。
`doc/parallel-dev-plan-56-63.md` の Phase 1 に対応。

## 変更内容

### カラム追加
- `users.theme` TEXT NOT NULL DEFAULT 'light' — ダークモード設定保存 [#56]
- `channels.topic` TEXT NULL — チャンネルトピック [#62]
- `messages.quoted_message_id` INTEGER NULL — 引用返信元メッセージID [#57]

### テーブル新規作成
- `pinned_channels` — ユーザーごとのピン留めチャンネル管理 [#59]
- `reminders` — メッセージリマインダー [#61]

### schema.hcl の整備
- `atlas schema inspect` の出力と完全一致するよう HCL を再整理
- 既存の `sqlite_autoindex_*` インデックス名の drift を修正

## 影響範囲

- `db/schema.hcl` のみ
- DBファイル（`packages/server/data/chat.db`）はスキーマ適用済み
- アプリケーションコードへの影響なし（既存APIの変更なし）

## 動作確認・テスト結果
- [ ] フロントエンドユニットテストがすべてパスする
- [ ] バックエンドユニットテストがすべてパスする
- [ ] ビルドが正常に完了すること
- [x] (手動確認) sqlite3 で全カラム・テーブルの存在を確認済み

## 関連Issue
関連: #56, #57, #59, #61, #62

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した