### PR TITLE
feat: コードブロック構文ハイライト (#58)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3494,7 +3494,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7407,6 +7406,15 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -13561,6 +13569,7 @@
         "@emotion/styled": "^11.11.5",
         "@mui/icons-material": "^5.15.14",
         "@mui/material": "^5.15.14",
+        "highlight.js": "^11.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-quill-new": "^3.3.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -16,6 +16,7 @@
     "@emotion/styled": "^11.11.5",
     "@mui/icons-material": "^5.15.14",
     "@mui/material": "^5.15.14",
+    "highlight.js": "^11.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-quill-new": "^3.3.3",

--- a/packages/client/src/__tests__/CodeHighlight.test.tsx
+++ b/packages/client/src/__tests__/CodeHighlight.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * コードブロック構文ハイライト のユニットテスト (#58)
+ *
+ * テスト対象: utils/renderMessageContent.tsx（コードブロック検出・ハイライト）
+ * 戦略:
+ *   - renderMessageContent にコードブロックを含む Delta を渡して DOM を検証する
+ *   - highlight.js / Prism.js によるシンタックスハイライト適用後の DOM を検証する
+ *   - 通常テキストへの影響がないことも合わせて確認する
+ */
+
+import { describe, it } from 'vitest';
+
+describe('コードブロック構文ハイライト', () => {
+  describe('コードブロックの検出', () => {
+    it('```lang\\ncode\\n``` 形式の文字列を含むメッセージを正しく検出できる', () => {
+      // TODO: implement
+    });
+
+    it('言語指定なし（```\\ncode\\n```）のコードブロックを検出できる', () => {
+      // TODO: implement
+    });
+
+    it('言語指定あり（```js）のコードブロックを検出できる', () => {
+      // TODO: implement
+    });
+
+    it('言語指定あり（```python）のコードブロックを検出できる', () => {
+      // TODO: implement
+    });
+
+    it('言語指定あり（```tsx）のコードブロックを検出できる', () => {
+      // TODO: implement
+    });
+
+    it('コードブロックが複数含まれるメッセージをすべて検出できる', () => {
+      // TODO: implement
+    });
+  });
+
+  describe('シンタックスハイライトの適用', () => {
+    it('言語指定なしのコードブロックに対してハイライトが適用される（plain text / fallback）', () => {
+      // TODO: implement
+    });
+
+    it('```js のコードブロックに JavaScript のシンタックスハイライトが適用される', () => {
+      // TODO: implement
+    });
+
+    it('```python のコードブロックに Python のシンタックスハイライトが適用される', () => {
+      // TODO: implement
+    });
+
+    it('```tsx のコードブロックに TSX のシンタックスハイライトが適用される', () => {
+      // TODO: implement
+    });
+
+    it('ハイライト後の DOM にコードの文字列が含まれている', () => {
+      // TODO: implement
+    });
+
+    it('ハイライト後の DOM に <code> または <pre> 要素が存在する', () => {
+      // TODO: implement
+    });
+
+    it('ハイライトライブラリが付与するクラス名（hljs または token）が要素に存在する', () => {
+      // TODO: implement
+    });
+  });
+
+  describe('通常テキストへの影響なし', () => {
+    it('コードブロックを含まない通常テキストはそのまま描画される', () => {
+      // TODO: implement
+    });
+
+    it('コードブロックを含まないメッセージにハイライトクラスが付与されない', () => {
+      // TODO: implement
+    });
+
+    it('コードブロックと通常テキストが混在するとき、通常テキスト部分は変化しない', () => {
+      // TODO: implement
+    });
+  });
+
+  describe('MessageItem 経由でのレンダリング', () => {
+    it('コードブロックを含むメッセージが MessageItem で正しく表示される', () => {
+      // TODO: implement
+    });
+
+    it('言語指定ありのコードブロックが MessageItem 内でハイライト表示される', () => {
+      // TODO: implement
+    });
+  });
+});

--- a/packages/client/src/__tests__/CodeHighlight.test.tsx
+++ b/packages/client/src/__tests__/CodeHighlight.test.tsx
@@ -4,90 +4,178 @@
  * テスト対象: utils/renderMessageContent.tsx（コードブロック検出・ハイライト）
  * 戦略:
  *   - renderMessageContent にコードブロックを含む Delta を渡して DOM を検証する
- *   - highlight.js / Prism.js によるシンタックスハイライト適用後の DOM を検証する
+ *   - highlight.js によるシンタックスハイライト適用後の DOM を検証する
  *   - 通常テキストへの影響がないことも合わせて確認する
  */
 
-import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { renderMessageContent } from '../utils/renderMessageContent';
+
+/** Delta ops を JSON 文字列に変換するヘルパー */
+function makeDelta(ops: object[]): string {
+  return JSON.stringify({ ops });
+}
+
+/** renderMessageContent の結果を div にマウントして返す */
+function renderContent(content: string) {
+  return render(<div>{renderMessageContent(content)}</div>);
+}
 
 describe('コードブロック構文ハイライト', () => {
   describe('コードブロックの検出', () => {
     it('```lang\\ncode\\n``` 形式の文字列を含むメッセージを正しく検出できる', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'const x = 1;\n', attributes: { 'code-block': 'javascript' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
 
     it('言語指定なし（```\\ncode\\n```）のコードブロックを検出できる', () => {
-      // TODO: implement
+      const content = makeDelta([{ insert: 'plain code\n', attributes: { 'code-block': true } }]);
+      renderContent(content);
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
 
     it('言語指定あり（```js）のコードブロックを検出できる', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'console.log("hi");\n', attributes: { 'code-block': 'js' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
 
     it('言語指定あり（```python）のコードブロックを検出できる', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'print("hello")\n', attributes: { 'code-block': 'python' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
 
     it('言語指定あり（```tsx）のコードブロックを検出できる', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'const App = () => <div />\n', attributes: { 'code-block': 'tsx' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
 
     it('コードブロックが複数含まれるメッセージをすべて検出できる', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'const a = 1;\n', attributes: { 'code-block': 'js' } },
+        { insert: 'between\n' },
+        { insert: 'print("py")\n', attributes: { 'code-block': 'python' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelectorAll('pre').length).toBe(2);
     });
   });
 
   describe('シンタックスハイライトの適用', () => {
     it('言語指定なしのコードブロックに対してハイライトが適用される（plain text / fallback）', () => {
-      // TODO: implement
+      const content = makeDelta([{ insert: 'plain code\n', attributes: { 'code-block': true } }]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).toBeInTheDocument();
     });
 
     it('```js のコードブロックに JavaScript のシンタックスハイライトが適用される', () => {
-      // TODO: implement
+      const content = makeDelta([{ insert: 'const x = 1;\n', attributes: { 'code-block': 'js' } }]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).toBeInTheDocument();
     });
 
     it('```python のコードブロックに Python のシンタックスハイライトが適用される', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'def hello():\n    pass\n', attributes: { 'code-block': 'python' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).toBeInTheDocument();
     });
 
     it('```tsx のコードブロックに TSX のシンタックスハイライトが適用される', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'const App = () => <div />\n', attributes: { 'code-block': 'tsx' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).toBeInTheDocument();
     });
 
     it('ハイライト後の DOM にコードの文字列が含まれている', () => {
-      // TODO: implement
+      const code = 'const answer = 42;';
+      const content = makeDelta([
+        { insert: `${code}\n`, attributes: { 'code-block': 'javascript' } },
+      ]);
+      const { container } = renderContent(content);
+      expect(container.textContent).toContain(code);
     });
 
     it('ハイライト後の DOM に <code> または <pre> 要素が存在する', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'echo "hello"\n', attributes: { 'code-block': 'bash' } },
+      ]);
+      renderContent(content);
+      const hasCode = document.querySelector('code') !== null;
+      const hasPre = document.querySelector('pre') !== null;
+      expect(hasCode || hasPre).toBe(true);
     });
 
     it('ハイライトライブラリが付与するクラス名（hljs または token）が要素に存在する', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'const x = 1;\n', attributes: { 'code-block': 'javascript' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).not.toBeNull();
     });
   });
 
   describe('通常テキストへの影響なし', () => {
     it('コードブロックを含まない通常テキストはそのまま描画される', () => {
-      // TODO: implement
+      const content = makeDelta([{ insert: 'Hello world\n' }]);
+      renderContent(content);
+      expect(screen.getByText('Hello world')).toBeInTheDocument();
     });
 
     it('コードブロックを含まないメッセージにハイライトクラスが付与されない', () => {
-      // TODO: implement
+      const content = makeDelta([{ insert: 'No code here\n' }]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).toBeNull();
+      expect(document.querySelector('pre')).toBeNull();
     });
 
     it('コードブロックと通常テキストが混在するとき、通常テキスト部分は変化しない', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'Normal text before\n' },
+        { insert: 'const x = 1;\n', attributes: { 'code-block': 'js' } },
+        { insert: 'Normal text after\n' },
+      ]);
+      renderContent(content);
+      expect(screen.getByText('Normal text before')).toBeInTheDocument();
+      expect(screen.getByText('Normal text after')).toBeInTheDocument();
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
   });
 
   describe('MessageItem 経由でのレンダリング', () => {
     it('コードブロックを含むメッセージが MessageItem で正しく表示される', () => {
-      // TODO: implement
+      // MessageItem は内部で renderMessageContent を呼ぶ
+      // ここでは renderMessageContent の返り値を直接検証する（統合的なスモークテスト）
+      const content = makeDelta([
+        { insert: 'Hello\n' },
+        { insert: 'const x = 1;\n', attributes: { 'code-block': 'javascript' } },
+      ]);
+      renderContent(content);
+      expect(screen.getByText('Hello')).toBeInTheDocument();
+      expect(document.querySelector('pre')).toBeInTheDocument();
     });
 
     it('言語指定ありのコードブロックが MessageItem 内でハイライト表示される', () => {
-      // TODO: implement
+      const content = makeDelta([
+        { insert: 'print("hello")\n', attributes: { 'code-block': 'python' } },
+      ]);
+      renderContent(content);
+      expect(document.querySelector('code.hljs')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import 'highlight.js/styles/github-dark.css';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/client/src/utils/renderMessageContent.tsx
+++ b/packages/client/src/utils/renderMessageContent.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import hljs from 'highlight.js';
 
 interface DeltaOp {
   insert?: string | { mention?: { value: string }; image?: string };
@@ -8,10 +9,25 @@ interface DeltaOp {
     underline?: boolean;
     strike?: boolean;
     code?: boolean;
-    'code-block'?: boolean;
+    'code-block'?: boolean | string;
     color?: string;
     background?: string;
   };
+}
+
+/**
+ * コードブロックに highlight.js を適用してハイライト済み HTML を返す
+ * - 言語指定あり（string）: hljs.highlight を試みる。未知の言語は highlightAuto にフォールバック
+ * - 言語指定なし（true）: hljs.highlightAuto を使用
+ */
+function highlightCode(code: string, language: boolean | string): string {
+  if (typeof language === 'string') {
+    const lang = language.toLowerCase();
+    if (hljs.getLanguage(lang)) {
+      return hljs.highlight(code, { language: lang }).value;
+    }
+  }
+  return hljs.highlightAuto(code).value;
 }
 
 export function renderMessageContent(content: string): React.ReactNode {
@@ -46,20 +62,27 @@ export function renderMessageContent(content: string): React.ReactNode {
       const a = op.attributes;
 
       if (a?.['code-block']) {
+        const highlighted = highlightCode(text, a['code-block']);
         return (
           <Box
             key={i}
             component="pre"
             sx={{
-              display: 'inline',
-              background: 'action.hover',
-              px: 0.5,
+              background: '#282c34',
               borderRadius: 1,
+              p: 1.5,
+              my: 0.5,
+              overflowX: 'auto',
               fontFamily: 'monospace',
               fontSize: '0.85em',
+              lineHeight: 1.5,
             }}
           >
-            {text}
+            <code
+              className="hljs"
+               
+              dangerouslySetInnerHTML={{ __html: highlighted }}
+            />
           </Box>
         );
       }

--- a/packages/client/src/utils/renderMessageContent.tsx
+++ b/packages/client/src/utils/renderMessageContent.tsx
@@ -17,8 +17,6 @@ interface DeltaOp {
 
 /**
  * コードブロックに highlight.js を適用してハイライト済み HTML を返す
- * - 言語指定あり（string）: hljs.highlight を試みる。未知の言語は highlightAuto にフォールバック
- * - 言語指定なし（true）: hljs.highlightAuto を使用
  */
 function highlightCode(code: string, language: boolean | string): string {
   if (typeof language === 'string') {
@@ -30,99 +28,162 @@ function highlightCode(code: string, language: boolean | string): string {
   return hljs.highlightAuto(code).value;
 }
 
+function renderInlineOp(op: DeltaOp, key: string): React.ReactNode {
+  if (typeof op.insert !== 'string') return null;
+  const text = op.insert;
+  const a = op.attributes;
+  const inlineStyle: React.CSSProperties = {};
+  if (a?.color) inlineStyle.color = a.color;
+  if (a?.background) inlineStyle.backgroundColor = a.background;
+
+  let node: React.ReactNode = text;
+  if (a?.bold) node = <strong>{node}</strong>;
+  if (a?.italic) node = <em>{node}</em>;
+  if (a?.underline) node = <u>{node}</u>;
+  if (a?.strike) node = <s>{node}</s>;
+  if (a?.code)
+    node = (
+      <Box
+        component="code"
+        sx={{
+          background: 'action.hover',
+          px: 0.5,
+          borderRadius: 1,
+          fontFamily: 'monospace',
+          fontSize: '0.85em',
+        }}
+      >
+        {node}
+      </Box>
+    );
+  if (Object.keys(inlineStyle).length > 0) node = <span style={inlineStyle}>{node}</span>;
+  return <span key={key}>{node}</span>;
+}
+
 export function renderMessageContent(content: string): React.ReactNode {
   try {
     const delta = JSON.parse(content) as { ops?: DeltaOp[] };
     const ops = delta.ops ?? [];
 
-    return ops.map((op, i) => {
-      if (typeof op.insert === 'object' && op.insert?.mention) {
-        return (
-          <Box key={i} component="span" sx={{ color: 'primary.main', fontWeight: 600 }}>
-            @{op.insert.mention.value}
-          </Box>
-        );
+    const result: React.ReactNode[] = [];
+    // 現在の行に属するテキスト系 op を蓄積
+    let lineOps: DeltaOp[] = [];
+    // コードブロック行の蓄積: 各行は「テキスト + 言語」
+    let codeLines: { text: string; lang: boolean | string }[] = [];
+
+    const flushCodeBlock = () => {
+      if (codeLines.length === 0) return;
+      const code = codeLines.map((l) => l.text).join('\n');
+      const lang = codeLines[codeLines.length - 1].lang;
+      const highlighted = highlightCode(code, lang);
+      result.push(
+        <Box
+          key={result.length}
+          component="pre"
+          sx={{
+            background: '#282c34',
+            borderRadius: 1,
+            p: 1.5,
+            my: 0.5,
+            overflowX: 'auto',
+            fontFamily: 'monospace',
+            fontSize: '0.85em',
+            lineHeight: 1.5,
+          }}
+        >
+          <code className="hljs" dangerouslySetInnerHTML={{ __html: highlighted }} />
+        </Box>,
+      );
+      codeLines = [];
+    };
+
+    for (let i = 0; i < ops.length; i++) {
+      const op = ops[i];
+
+      // mention / image
+      if (typeof op.insert === 'object') {
+        flushCodeBlock();
+        lineOps.forEach((lo, j) => {
+          const n = renderInlineOp(lo, `${i}-${j}`);
+          if (n) result.push(n);
+        });
+        lineOps = [];
+        if (op.insert?.mention) {
+          result.push(
+            <Box key={i} component="span" sx={{ color: 'primary.main', fontWeight: 600 }}>
+              @{op.insert.mention.value}
+            </Box>,
+          );
+        } else if (op.insert?.image) {
+          result.push(
+            <Box
+              key={i}
+              component="img"
+              src={op.insert.image}
+              alt="Attached image"
+              sx={{ maxWidth: '100%', maxHeight: 300, borderRadius: 1, display: 'block', mt: 0.5 }}
+            />,
+          );
+        }
+        continue;
       }
 
-      if (typeof op.insert === 'object' && op.insert?.image) {
-        return (
-          <Box
-            key={i}
-            component="img"
-            src={op.insert.image}
-            alt="Attached image"
-            sx={{ maxWidth: '100%', maxHeight: 300, borderRadius: 1, display: 'block', mt: 0.5 }}
-          />
-        );
-      }
-
-      if (typeof op.insert !== 'string') return null;
+      if (typeof op.insert !== 'string') continue;
 
       const text = op.insert;
       const a = op.attributes;
 
+      // Quill は行末の \n に block 属性を付与する。
+      // パターン1: "\n" のみのop に code-block 属性 (標準的な Quill 2.x)
+      // パターン2: テキスト+"\\n" のopに code-block 属性 (まれ)
       if (a?.['code-block']) {
-        const highlighted = highlightCode(text, a['code-block']);
-        return (
-          <Box
-            key={i}
-            component="pre"
-            sx={{
-              background: '#282c34',
-              borderRadius: 1,
-              p: 1.5,
-              my: 0.5,
-              overflowX: 'auto',
-              fontFamily: 'monospace',
-              fontSize: '0.85em',
-              lineHeight: 1.5,
-            }}
-          >
-            <code
-              className="hljs"
-               
-              dangerouslySetInnerHTML={{ __html: highlighted }}
-            />
-          </Box>
-        );
+        // lineOps に溜まったテキスト + このopのテキスト(\n を除く) をコード行として記録
+        const lineText =
+          lineOps
+            .filter((lo) => typeof lo.insert === 'string')
+            .map((lo) => lo.insert as string)
+            .join('') + text.replace(/\n$/, '');
+        codeLines.push({ text: lineText, lang: a['code-block'] });
+        lineOps = [];
+        continue;
       }
 
-      const inlineStyle: React.CSSProperties = {};
-      if (a?.color) inlineStyle.color = a.color;
-      if (a?.background) inlineStyle.backgroundColor = a.background;
-
-      let node: React.ReactNode = text;
-      if (a?.bold) node = <strong key={`b${i}`}>{node}</strong>;
-      if (a?.italic) node = <em key={`i${i}`}>{node}</em>;
-      if (a?.underline) node = <u key={`u${i}`}>{node}</u>;
-      if (a?.strike) node = <s key={`s${i}`}>{node}</s>;
-      if (a?.code)
-        node = (
-          <Box
-            key={`c${i}`}
-            component="code"
-            sx={{
-              background: 'action.hover',
-              px: 0.5,
-              borderRadius: 1,
-              fontFamily: 'monospace',
-              fontSize: '0.85em',
-            }}
-          >
-            {node}
-          </Box>
-        );
-
-      if (Object.keys(inlineStyle).length > 0) {
-        node = (
-          <span key={`style${i}`} style={inlineStyle}>
-            {node}
-          </span>
-        );
+      // 通常テキストまたは改行
+      if (text === '\n') {
+        // コードブロック終了 → フラッシュ
+        flushCodeBlock();
+        lineOps.forEach((lo, j) => {
+          const n = renderInlineOp(lo, `${i}-${j}`);
+          if (n) result.push(n);
+        });
+        result.push(<br key={`br${i}`} />);
+        lineOps = [];
+      } else if (text.includes('\n')) {
+        // 改行を含む複合テキスト（貼り付けなど）
+        flushCodeBlock();
+        lineOps.forEach((lo, j) => {
+          const n = renderInlineOp(lo, `${i}-${j}`);
+          if (n) result.push(n);
+        });
+        lineOps = [];
+        const parts = text.split('\n');
+        parts.forEach((part, pi) => {
+          if (part) result.push(<span key={`${i}-p${pi}`}>{part}</span>);
+          if (pi < parts.length - 1) result.push(<br key={`${i}-br${pi}`} />);
+        });
+      } else {
+        lineOps.push(op);
       }
+    }
 
-      return <span key={i}>{node}</span>;
+    // 末尾の残り
+    flushCodeBlock();
+    lineOps.forEach((lo, j) => {
+      const n = renderInlineOp(lo, `end-${j}`);
+      if (n) result.push(n);
     });
+
+    return result;
   } catch {
     return content;
   }


### PR DESCRIPTION
## 概要

メッセージ内のコードブロックにシンタックスハイライトを適用する機能を実装した。Quill Delta の `code-block` 属性を持つ ops に対して highlight.js を使用し、言語指定の有無に応じてハイライト処理を行う。

## 変更内容

- `packages/client/package.json`: highlight.js（^11.10.0）を依存関係に追加
- `packages/client/src/main.tsx`: github-dark テーマの CSS をインポート
- `packages/client/src/utils/renderMessageContent.tsx`:
  - `highlightCode()` 関数を追加（言語指定あり: `hljs.highlight`、未知言語は `highlightAuto` にフォールバック、言語指定なし: `hljs.highlightAuto`）
  - `code-block` 属性の型を `boolean | string` に拡張
  - コードブロックを `<pre><code class="hljs" dangerouslySetInnerHTML>` でレンダリングするよう変更
- `packages/client/src/__tests__/CodeHighlight.test.tsx`: テストアサーションを実装（18テスト）

## 影響範囲

- `packages/client/src/utils/renderMessageContent.tsx`（コードブロックのレンダリング処理）
- `packages/client/src/main.tsx`（CSSインポート追加）
- `packages/client/package.json`（依存関係追加）
- フロントエンドのメッセージ表示全般（コードブロックを含むメッセージの表示に影響）

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（CodeHighlight: 18件、その他: 238件）
- [ ] バックエンドユニットテストがすべてパスする
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #58

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した