### PR TITLE
fix: 並列開発のサブワーカー権限問題を修正

### DIFF
--- a/.claude/skills/parallel-feature-dev/SKILL.md
+++ b/.claude/skills/parallel-feature-dev/SKILL.md
@@ -77,7 +77,9 @@ Issue A が MessageItem.tsx、Issue B が ChannelList.tsx → 並列実行可能
 
 ### Phase 1: テスト項目作成（worktree並列）
 
-並列グループのIssueごとに `isolation: "worktree"` でworkerエージェントを**同時に**起動する。
+並列グループのIssueごとに `isolation: "worktree"`, `mode: "bypassPermissions"` でworkerエージェントを**同時に**起動する。
+
+**重要**: `mode: "bypassPermissions"` を必ず指定すること。指定しないとサブワーカーが権限確認でstopする。
 
 各workerへの指示:
 
@@ -123,7 +125,7 @@ Issue: #{番号}
 
 ### Phase 2: 実装・PR更新（worktree並列）
 
-承認を得たIssueごとに `isolation: "worktree"` でworkerエージェントを**同時に**再起動する。
+承認を得たIssueごとに `isolation: "worktree"`, `mode: "bypassPermissions"` でworkerエージェントを**同時に**再起動する。
 
 各workerへの指示:
 


### PR DESCRIPTION
## 概要
並列開発時、worktreeサブワーカーが権限確認ダイアログでstopしてしまう問題を修正する。

## 変更内容
- `parallel-feature-dev/SKILL.md` のPhase 1・Phase 2で、Agent起動時に `mode: "bypassPermissions"` を明示指定するよう指示を追加

## 影響範囲
- `.claude/skills/parallel-feature-dev/SKILL.md`

## 動作確認・テスト結果
- [ ] フロントエンドユニットテストがすべてパスする
- [ ] バックエンドユニットテストがすべてパスする
- [ ] ビルドが正常に完了すること

スキル定義ファイルの修正のため、コード上のテストは対象外。

## 関連Issue
Fixes #69

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した