### PR TITLE
feat: ダークモードの実装

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -7,10 +7,11 @@ import {
   useParams,
   useSearchParams,
 } from 'react-router-dom';
-import { CssBaseline, ThemeProvider, createTheme, CircularProgress, Box } from '@mui/material';
+import { CircularProgress, Box } from '@mui/material';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { SocketProvider } from './contexts/SocketContext';
 import { SnackbarProvider } from './contexts/SnackbarContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ChatPage from './pages/ChatPage';
@@ -21,10 +22,6 @@ import DMPage from './pages/DMPage';
 import FilesPage from './pages/FilesPage';
 import { api } from './api/client';
 import type { User } from '@chat-app/shared';
-
-const theme = createTheme({
-  palette: { mode: 'light' },
-});
 
 /**
  * React 19 の concurrent モードではコミット前に同じコンポーネントが複数回インスタンス化される
@@ -198,8 +195,7 @@ function AppRoutes() {
 
 export default function App() {
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
+    <ThemeProvider>
       <BrowserRouter>
         {/* AuthProvider 自身が内部に Suspense を持ち、me() 解決中は CircularProgress を表示する */}
         <AuthProvider>

--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -17,6 +17,10 @@ vi.mock('../contexts/AuthContext', () => ({
   useAuth: () => ({ user: mockUser, logout: vi.fn() }),
 }));
 
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ mode: 'light', toggleTheme: vi.fn() }),
+}));
+
 vi.mock('../hooks/usePushNotifications', () => ({
   usePushNotifications: () => ({
     supported: false,

--- a/packages/client/src/__tests__/BookmarkPage.test.tsx
+++ b/packages/client/src/__tests__/BookmarkPage.test.tsx
@@ -75,6 +75,8 @@ const makeBookmark = (overrides: Partial<Bookmark> = {}): Bookmark => ({
     parentMessageId: null,
     rootMessageId: null,
     replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
   },
   ...overrides,
 });

--- a/packages/client/src/__tests__/DarkMode.test.tsx
+++ b/packages/client/src/__tests__/DarkMode.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * ダークモード機能のユニットテスト
+ *
+ * テスト対象: ダーク/ライトモード切り替え機能
+ * 戦略:
+ *   - OSのカラースキーム（prefers-color-scheme）をモックして初期値を検証する
+ *   - localStorageをモックして設定の永続化を検証する
+ *   - ユーザー操作によるモード切り替えを検証する
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('ダークモード機能', () => {
+  describe('初期値の反映', () => {
+    it('OSのカラースキームがダークの場合、ダークモードをデフォルトとして反映する');
+
+    it('OSのカラースキームがライトの場合、ライトモードをデフォルトとして反映する');
+  });
+
+  describe('モード切り替え', () => {
+    it('トグルボタンをクリックするとダークモードからライトモードに切り替わる');
+
+    it('トグルボタンをクリックするとライトモードからダークモードに切り替わる');
+  });
+
+  describe('設定の永続化', () => {
+    it('ダークモードに切り替えるとlocalStorageに設定が保存される');
+
+    it('ライトモードに切り替えるとlocalStorageに設定が保存される');
+  });
+
+  describe('設定の引き継ぎ', () => {
+    it('localStorageにダークモードの設定がある場合、次回アクセス時にダークモードが適用される');
+
+    it('localStorageにライトモードの設定がある場合、次回アクセス時にライトモードが適用される');
+
+    it('localStorageに設定がない場合、OSのカラースキームをデフォルトとして使用する');
+  });
+});

--- a/packages/client/src/__tests__/DarkMode.test.tsx
+++ b/packages/client/src/__tests__/DarkMode.test.tsx
@@ -8,34 +8,131 @@
  *   - ユーザー操作によるモード切り替えを検証する
  */
 
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ThemeProvider, useTheme } from '../contexts/ThemeContext';
+
+/** テスト用: useThemeの値を表示するコンポーネント */
+function ThemeDisplay() {
+  const { mode, toggleTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="mode">{mode}</span>
+      <button onClick={toggleTheme}>トグル</button>
+    </div>
+  );
+}
+
+function renderWithTheme() {
+  return render(
+    <ThemeProvider>
+      <ThemeDisplay />
+    </ThemeProvider>,
+  );
+}
+
+/** matchMedia をモックするヘルパー */
+function mockMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn((query: string) => ({
+      matches: query === '(prefers-color-scheme: dark)' ? prefersDark : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('ダークモード機能', () => {
   describe('初期値の反映', () => {
-    it('OSのカラースキームがダークの場合、ダークモードをデフォルトとして反映する');
+    it('OSのカラースキームがダークの場合、ダークモードをデフォルトとして反映する', () => {
+      mockMatchMedia(true);
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('dark');
+    });
 
-    it('OSのカラースキームがライトの場合、ライトモードをデフォルトとして反映する');
+    it('OSのカラースキームがライトの場合、ライトモードをデフォルトとして反映する', () => {
+      mockMatchMedia(false);
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('light');
+    });
   });
 
   describe('モード切り替え', () => {
-    it('トグルボタンをクリックするとダークモードからライトモードに切り替わる');
+    it('トグルボタンをクリックするとダークモードからライトモードに切り替わる', async () => {
+      mockMatchMedia(true);
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('dark');
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'トグル' }));
+      });
+      expect(screen.getByTestId('mode').textContent).toBe('light');
+    });
 
-    it('トグルボタンをクリックするとライトモードからダークモードに切り替わる');
+    it('トグルボタンをクリックするとライトモードからダークモードに切り替わる', async () => {
+      mockMatchMedia(false);
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('light');
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'トグル' }));
+      });
+      expect(screen.getByTestId('mode').textContent).toBe('dark');
+    });
   });
 
   describe('設定の永続化', () => {
-    it('ダークモードに切り替えるとlocalStorageに設定が保存される');
+    it('ダークモードに切り替えるとlocalStorageに設定が保存される', async () => {
+      mockMatchMedia(false);
+      renderWithTheme();
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'トグル' }));
+      });
+      expect(localStorage.getItem('theme-mode')).toBe('dark');
+    });
 
-    it('ライトモードに切り替えるとlocalStorageに設定が保存される');
+    it('ライトモードに切り替えるとlocalStorageに設定が保存される', async () => {
+      mockMatchMedia(true);
+      renderWithTheme();
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'トグル' }));
+      });
+      expect(localStorage.getItem('theme-mode')).toBe('light');
+    });
   });
 
   describe('設定の引き継ぎ', () => {
-    it('localStorageにダークモードの設定がある場合、次回アクセス時にダークモードが適用される');
+    it('localStorageにダークモードの設定がある場合、次回アクセス時にダークモードが適用される', () => {
+      mockMatchMedia(false);
+      localStorage.setItem('theme-mode', 'dark');
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('dark');
+    });
 
-    it('localStorageにライトモードの設定がある場合、次回アクセス時にライトモードが適用される');
+    it('localStorageにライトモードの設定がある場合、次回アクセス時にライトモードが適用される', () => {
+      mockMatchMedia(true);
+      localStorage.setItem('theme-mode', 'light');
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('light');
+    });
 
-    it('localStorageに設定がない場合、OSのカラースキームをデフォルトとして使用する');
+    it('localStorageに設定がない場合、OSのカラースキームをデフォルトとして使用する', () => {
+      mockMatchMedia(true);
+      renderWithTheme();
+      expect(screen.getByTestId('mode').textContent).toBe('dark');
+    });
   });
 });

--- a/packages/client/src/__tests__/MessageItemAttachment.test.tsx
+++ b/packages/client/src/__tests__/MessageItemAttachment.test.tsx
@@ -57,6 +57,8 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
     parentMessageId: null,
     rootMessageId: null,
     replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/SearchResults.test.tsx
+++ b/packages/client/src/__tests__/SearchResults.test.tsx
@@ -33,6 +33,8 @@ function makeResult(overrides: Partial<MessageSearchResult> = {}): MessageSearch
     rootMessageId: null,
     replyCount: 0,
     rootMessageContent: null,
+    quotedMessageId: null,
+    quotedMessage: null,
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/__fixtures__/channels.ts
+++ b/packages/client/src/__tests__/__fixtures__/channels.ts
@@ -33,5 +33,7 @@ export function makeChannelMessage(id: number, channelId: number): Message {
     parentMessageId: null,
     rootMessageId: null,
     replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
   };
 }

--- a/packages/client/src/__tests__/__fixtures__/messages.ts
+++ b/packages/client/src/__tests__/__fixtures__/messages.ts
@@ -21,6 +21,8 @@ export function makeMessage(overrides: Partial<Message> = {}): Message {
     parentMessageId: null,
     rootMessageId: null,
     replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
     ...overrides,
   };
 }

--- a/packages/client/src/__tests__/useMessages.test.tsx
+++ b/packages/client/src/__tests__/useMessages.test.tsx
@@ -69,6 +69,8 @@ function makeMessage(id: number, channelId = 1): Message {
     parentMessageId: null,
     rootMessageId: null,
     replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
   };
 }
 

--- a/packages/client/src/components/Layout/AppLayout.tsx
+++ b/packages/client/src/components/Layout/AppLayout.tsx
@@ -19,8 +19,11 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import SearchIcon from '@mui/icons-material/Search';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import LightModeIcon from '@mui/icons-material/LightMode';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { useTheme } from '../../contexts/ThemeContext';
 import { usePushNotifications } from '../../hooks/usePushNotifications';
 
 const DRAWER_WIDTH = 240;
@@ -35,6 +38,7 @@ interface Props {
 export default function AppLayout({ sidebar, children, searchQuery = '', onSearchChange }: Props) {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const { user, logout } = useAuth();
+  const { mode, toggleTheme } = useTheme();
   const { supported, subscribed, loading, error, subscribe, unsubscribe } = usePushNotifications();
   const navigate = useNavigate();
   const searchRef = useRef<HTMLInputElement>(null);
@@ -104,6 +108,16 @@ export default function AppLayout({ sidebar, children, searchQuery = '', onSearc
           <Box sx={{ flexGrow: 1 }} />
 
           <Typography variant="body2">{user?.displayName ?? user?.username}</Typography>
+
+          <Tooltip title={mode === 'dark' ? 'ライトモードに切り替える' : 'ダークモードに切り替える'}>
+            <IconButton
+              color="inherit"
+              aria-label={mode === 'dark' ? 'ライトモードに切り替える' : 'ダークモードに切り替える'}
+              onClick={toggleTheme}
+            >
+              {mode === 'dark' ? <LightModeIcon /> : <DarkModeIcon />}
+            </IconButton>
+          </Tooltip>
 
           {supported && (
             <Tooltip title={subscribed ? 'Disable notifications' : 'Enable notifications'}>

--- a/packages/client/src/contexts/ThemeContext.tsx
+++ b/packages/client/src/contexts/ThemeContext.tsx
@@ -1,0 +1,59 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from 'react';
+import { ThemeProvider as MuiThemeProvider, createTheme } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+
+const STORAGE_KEY = 'theme-mode';
+
+type ThemeMode = 'dark' | 'light';
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function getInitialMode(): ThemeMode {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'dark' || stored === 'light') return stored;
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+  return 'light';
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>(getInitialMode);
+
+  const toggleTheme = useCallback(() => {
+    setMode((prev) => {
+      const next: ThemeMode = prev === 'dark' ? 'light' : 'dark';
+      localStorage.setItem(STORAGE_KEY, next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo(() => ({ mode, toggleTheme }), [mode, toggleTheme]);
+
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+
+  return (
+    <ThemeContext.Provider value={value}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used inside ThemeProvider');
+  return ctx;
+}

--- a/packages/server/src/services/bookmarkService.ts
+++ b/packages/server/src/services/bookmarkService.ts
@@ -46,6 +46,8 @@ function rowToBookmark(row: BookmarkRow): Bookmark {
       parentMessageId: null,
       rootMessageId: null,
       replyCount: 0,
+      quotedMessageId: null,
+      quotedMessage: null,
     };
     bookmark.message = message;
   }

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -101,6 +101,8 @@ function toMessage(row: MessageRow): Message {
     parentMessageId: row.parent_message_id,
     rootMessageId: row.root_message_id,
     replyCount: row.root_message_id === null ? getReplyCount(row.id) : 0,
+    quotedMessageId: null,
+    quotedMessage: null,
   };
 }
 

--- a/packages/server/src/services/pinMessageService.ts
+++ b/packages/server/src/services/pinMessageService.ts
@@ -49,6 +49,8 @@ function rowToPinnedMessage(row: PinnedMessageRow): PinnedMessage {
       parentMessageId: null,
       rootMessageId: null,
       replyCount: 0,
+      quotedMessageId: null,
+      quotedMessage: null,
     };
     pm.message = message;
   }

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -12,6 +12,13 @@ export interface Attachment {
   mimeType: string;
 }
 
+export interface QuotedMessage {
+  id: number;
+  content: string;
+  username: string;
+  createdAt: string;
+}
+
 export interface Message {
   id: number;
   channelId: number;
@@ -29,6 +36,8 @@ export interface Message {
   parentMessageId: number | null;
   rootMessageId: number | null;
   replyCount: number;
+  quotedMessageId: number | null;
+  quotedMessage: QuotedMessage | null;
 }
 
 export interface MessageSearchResult extends Message {
@@ -41,6 +50,7 @@ export interface SendMessageInput {
   content: string;
   mentionedUserIds?: number[];
   attachmentIds?: number[];
+  quotedMessageId?: number;
 }
 
 export interface EditMessageInput {


### PR DESCRIPTION
## 概要

Issue #56 の対応として、アプリにダーク/ライトモード切り替え機能を実装した。OSのカラースキーム設定をデフォルト値として読み込み、ユーザーが手動で切り替えた設定をlocalStorageに永続化する。

## 変更内容

- `packages/client/src/contexts/ThemeContext.tsx` を新規作成
  - OSの `prefers-color-scheme` をデフォルト値として読み込む
  - localStorage (`theme-mode`) に設定を保存・復元する
  - `ThemeProvider` コンポーネントと `useTheme` フックを提供
  - MUIの `createTheme({ palette: { mode } })` でダーク/ライトテーマを切り替え
- `packages/client/src/App.tsx`: MUI標準の ThemeProvider/CssBaseline を独自 ThemeProvider に置き換え
- `packages/client/src/components/Layout/AppLayout.tsx`: ヘッダーにダーク/ライトモードトグルボタン（DarkModeIcon/LightModeIcon）を追加
- `packages/client/src/__tests__/DarkMode.test.tsx`: テストアサーションを実装（9件）
- `packages/shared/src/types/message.ts`: worktreeのビルド互換性のため `quotedMessageId`/`quotedMessage` フィールドを追加
- 関連するテストフィクスチャ（channels.ts, messages.ts, BookmarkPage.test.tsx等）を型変更に合わせて更新
- `packages/server/src/services/` の Message生成箇所に `quotedMessageId: null, quotedMessage: null` を追加

## 影響範囲

- `packages/client/src/contexts/ThemeContext.tsx`（新規）
- `packages/client/src/App.tsx`
- `packages/client/src/components/Layout/AppLayout.tsx`
- `packages/client/src/__tests__/DarkMode.test.tsx`
- `packages/client/src/__tests__/AppLayout.test.tsx`（ThemeContextのモック追加）
- `packages/shared/src/types/message.ts`
- `packages/server/src/services/bookmarkService.ts`
- `packages/server/src/services/messageService.ts`
- `packages/server/src/services/pinMessageService.ts`
- テストフィクスチャファイル群

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（DarkMode: 9/9, AppLayout: 2/2 など。ChannelList/ChatPage の失敗はブランチ開始前からの既存問題）
- [x] バックエンドユニットテストがすべてパスする
- [x] ビルドが正常に完了すること（`npm run build` 成功）
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue
Fixes #56

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した