### PR TITLE
fix(test): ChatPage テストで SearchFilterPanel をモックし未ハンドル Promise エラーを解消

### DIFF
--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../components/Layout/AppLayout', async () => {
 
 vi.mock('../components/Chat/MessageList', () => ({ default: () => null }));
 vi.mock('../components/Chat/RichEditor', () => ({ default: () => null }));
+vi.mock('../components/Chat/SearchFilterPanel', () => ({ default: () => null }));
 
 vi.mock('../hooks/useMessages', () => ({
   useMessages: () => ({ messages: [], loading: false, loadMore: vi.fn() }),


### PR DESCRIPTION
## 概要

`ChatPage.test.tsx` でテスト実行時に `Unhandled Rejection` が発生していた問題を修正する。

## 変更内容

- `packages/client/src/__tests__/ChatPage.test.tsx` に `SearchFilterPanel` のモックを追加

## 影響範囲

- `ChatPage.test.tsx` のみ（プロダクションコードの変更なし）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（477 tests passed, errors 0）
- [ ] バックエンドユニットテストがすべてパスする
- [ ] ビルドが正常に完了すること

## 原因詳細

`SearchFilterPanel.tsx` はモジュールレベルで `api.auth.users()` を即時実行している。
`ChatPage.test.tsx` は `SearchFilterPanel` をモックせずに `ChatPage` をインポートするため、
テスト環境（BASE URL なし）でフェッチが走り Unhandled Rejection が発生していた。

## 関連Issue
Fixes #

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した

🤖 Generated with [Claude Code](https://claude.com/claude-code)