### PR TITLE
refactor: skillsをcustom agentsに移行しmodel設定を有効化

### DIFF
--- a/.claude/agents/feature-worker.md
+++ b/.claude/agents/feature-worker.md
@@ -2,6 +2,7 @@
 name: feature-worker
 description: このプロジェクトのTDD開発フロー（AGENTS.md準拠）に従い、GitHub Issueを1件実装するスキル。ブランチ作成→テスト項目作成→ユーザー確認→テスト実装→プログラム実装→PR作成の順を厳守する。worktree環境での単独実行にも対応。
 model: sonnet
+effort: auto
 ---
 
 # Feature Worker

--- a/.claude/agents/feature-worker.md
+++ b/.claude/agents/feature-worker.md
@@ -1,7 +1,6 @@
 ---
 name: feature-worker
 description: このプロジェクトのTDD開発フロー（AGENTS.md準拠）に従い、GitHub Issueを1件実装するスキル。ブランチ作成→テスト項目作成→ユーザー確認→テスト実装→プログラム実装→PR作成の順を厳守する。worktree環境での単独実行にも対応。
-version: 0.2.0
 model: sonnet
 ---
 

--- a/.claude/agents/parallel-feature-dev.md
+++ b/.claude/agents/parallel-feature-dev.md
@@ -1,9 +1,7 @@
 ---
 name: parallel-feature-dev
 description: 複数のGitHub Issueを依存関係を考慮して並列worktreeで実装するオーケストレータースキル。ファイル競合を分析して並列グループを決定し、workerエージェントを並列起動してPR draft作成まで自動化する。テスト項目確認はGitHub PR画面で行う。
-version: 0.3.0
 model: opus
-effort: xhigh
 ---
 
 # Parallel Feature Dev（オーケストレーター）
@@ -66,6 +64,9 @@ Issue A が MessageItem.tsx、Issue B が ChannelList.tsx → 並列実行可能
    - 共有型定義（`packages/shared/src/types/`）の変更を伴う複雑な型設計
 
    **sonnet を使用する条件（上記に該当しない場合）:**
+   - フロントエンドUIのみの変更
+   - バックエンドの単一エンドポイント追加（既存パターンの踏襲）
+   - テストの追加・修正のみ
 
 分析結果を以下のフォーマットで提示してユーザーに確認を求める:
 

--- a/.claude/agents/parallel-feature-dev.md
+++ b/.claude/agents/parallel-feature-dev.md
@@ -2,6 +2,7 @@
 name: parallel-feature-dev
 description: 複数のGitHub Issueを依存関係を考慮して並列worktreeで実装するオーケストレータースキル。ファイル競合を分析して並列グループを決定し、workerエージェントを並列起動してPR draft作成まで自動化する。テスト項目確認はGitHub PR画面で行う。
 model: opus
+effort: xhigh
 ---
 
 # Parallel Feature Dev（オーケストレーター）


### PR DESCRIPTION
## 概要
SKILL.mdフォーマットでは `model`/`effort` フィールドが無視されるため、`.claude/agents/` 配下の Custom Agent 形式に移行する。

## 変更内容
- `.claude/skills/parallel-feature-dev/SKILL.md` → `.claude/agents/parallel-feature-dev.md`（`model: opus`）
- `.claude/skills/feature-worker/SKILL.md` → `.claude/agents/feature-worker.md`（`model: sonnet`）
- フロントマターから `version` フィールドを削除（Custom Agent形式では不要）

## 影響範囲
- `/parallel-feature-dev`、`/feature-worker` コマンドは引き続き同名で呼び出し可能
- モデル設定が実際に反映されるようになる

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする
- [x] バックエンドユニットテストがすべてパスする
- [x] ビルドが正常に完了すること

## 関連Issue
なし

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した