### PR TITLE
docs: Issue #107〜#118 の実行計画ドキュメントを追加

### DIFF
--- a/doc/implementation-plans/107-message-forward.md
+++ b/doc/implementation-plans/107-message-forward.md
@@ -1,0 +1,127 @@
+# #107 メッセージ転送 — 実行計画
+
+- Issue: [#107](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/107)
+- 難易度: 中
+- ブランチ: `feature/message-forward/#107`
+
+## 1. ゴール（受入条件）
+
+- メッセージのコンテキストメニュー（`MessageActions`）に「転送」を追加
+- 転送ダイアログでチャンネル or DM を選択できる
+- 元メッセージが引用として付与される（既存 `quoted_message_id` と同じ表示）
+- 任意のコメントを添えて転送できる
+- 元メッセージが削除されても転送後のメッセージは残る（スナップショット保持）
+- 添付は **転送しない**（リンクではなくチャンネル内のコピーを前提にすると権限問題が発生するため）※ Issue で要確認
+
+## 2. 依存・前提
+
+- 既存機能: `quoted_message_id`（引用返信 #57）、`MessageActions.tsx`、`DM` 機能（#43）
+- 他 Issue との衝突: `MessageActions.tsx` で **#116（通報）と競合**、`messageService` 送信経路で **#113 / #117** と競合
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+# messages テーブルに追加
+column "forwarded_from_message_id" {
+  null    = true
+  type    = integer
+  comment = "転送元メッセージID（NULL = 転送でない）"
+}
+foreign_key "fk_messages_forwarded" {
+  columns     = [column.forwarded_from_message_id]
+  ref_columns = [table.messages.column.id]
+  on_update   = NO_ACTION
+  on_delete   = SET_NULL
+}
+```
+
+> DM 側も転送先として扱うなら `dm_messages` にも同様のカラムを追加するか、統一のためチャンネルに自動作成される「DM 代替チャンネル」を使う。**MVP はチャンネル間転送に限定**しても Issue の受入は満たせる。
+
+## 4. shared types
+
+```ts
+// Message に追加
+forwardedFromMessageId?: number | null;
+forwardedFromMessage?: QuotedMessage | null;  // 既存 QuotedMessage を流用
+// ForwardMessageInput 新規
+export interface ForwardMessageInput {
+  targetChannelId?: number;
+  targetDmConversationId?: number;
+  comment?: string;
+}
+```
+
+## 5. サーバー変更
+
+### 変更ファイル
+
+- `packages/server/src/services/messageService.ts`
+  - `forwardMessage(userId, sourceMessageId, input)` を追加
+    - 権限チェック: 元メッセージのチャンネルのメンバーであること、転送先のチャンネルのメンバーかつ `posting_permission`（#113 実装後）を満たすこと
+    - 既存 `sendMessage` を呼び、`forwarded_from_message_id = sourceMessageId`、`content = comment ?? ''` で insert
+    - `quoted_message_id` に元メッセージ ID を入れるか、独立カラムで扱うかは設計判断（**両方を埋める** と UI 側で既存の引用表示が流用できる）
+  - `list*` 系の `MESSAGE_SELECT` に `forwarded_from_message_id` + JOIN を追加（既存の `quoted_message_id` と同パターン）
+
+- `packages/server/src/routes/messages.ts`
+  - `POST /api/messages/:id/forward` `{ targetChannelId?, targetDmConversationId?, comment? }` → 転送後の `Message` を返す
+
+- Socket: `message:new` を転送先チャンネルへ emit（既存の sendMessage 経路を通すので追加実装不要）
+
+### 監査ログ
+- 特に追加しなくてよい（通常の投稿として記録される）。必要なら `message.forward` を追加
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Chat/ForwardMessageDialog.tsx`
+  - チャンネル一覧 + DM 会話一覧を検索可能なリスト
+  - コメント入力欄
+  - 送信ボタン
+
+### 変更ファイル
+- `packages/client/src/components/Chat/MessageActions.tsx`
+  - 「転送」メニューを追加（#116 の「通報」と共存できるように順序決定）
+- `packages/client/src/components/Chat/MessageItem.tsx`
+  - `forwardedFromMessage` を使って「○○さんが転送」ヘッダーを表示
+  - 本体は既存 `QuotedMessageBanner` を流用
+- `packages/client/src/api/client.ts`
+  - `messages.forward(messageId, input)`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/messageForward.test.ts`（正常系 / 転送先未加入 / 元メッセージ削除後の表示）
+   - client: `ForwardMessageDialog.test.tsx`、`MessageItem.test.tsx` 追記、`MessageActions.test.tsx` 追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- メンバーでないチャンネルへの転送は 403
+- 転送先に元メッセージの添付は **コピーされない**（MVP）
+- 元メッセージ削除後も `forwardedFromMessage.content` が保存スナップショットで表示できる（※ スナップショット保持を採用する場合は専用テーブルか `content_snapshot` カラムが必要。採用しないなら JOIN 結果が null で「削除された投稿」と表示）
+- DM 転送も同様に動く
+
+### クライアント
+- ダイアログのチャンネル/DM 切替
+- 選択後にコメント入力 → 送信で API 呼び出し
+- 転送メッセージに「○○ が転送」ヘッダーが表示される
+
+## 9. 注意点
+
+- **スナップショット保持の方針**: 元メッセージが後から削除・編集されたとき、転送先にどう反映するかを決める
+  - **方針 A**: 転送先は常に元メッセージを JOIN で参照（削除されたら空になる）
+  - **方針 B**: `content_snapshot_*` カラムを追加して転送時点のスナップショットを保持
+  - **推奨**: 方針 A（シンプル、編集が反映される）
+- `quoted_message_id` と `forwarded_from_message_id` を両方埋めると UI が混乱する可能性がある。**どちらか片方のみ使う** か、UI で明確に区別
+- DM への転送は初版スコープ外でもよい。段階実装を推奨
+
+## 10. 見積もり / リスク
+
+- 規模: 中
+- リスク: `MessageActions` の並び・デザインが #116 と干渉。**先にマージされた方** の UI に合わせて後発は微調整

--- a/doc/implementation-plans/108-event-post.md
+++ b/doc/implementation-plans/108-event-post.md
@@ -1,0 +1,141 @@
+# #108 会話イベント投稿 — 実行計画
+
+- Issue: [#108](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/108)
+- 難易度: 中
+- ブランチ: `feature/event-post/#108`
+
+## 1. ゴール（受入条件）
+
+- チャンネル内にイベント（日時・タイトル・説明）を投稿できる（通常メッセージの特殊形として扱う）
+- メンバーが「参加する / 不参加 / 未定」を選択できる（1 人 1 レコード、更新可）
+- イベントメッセージ上で 3 種類の集計と参加者一覧を確認できる
+- 既存のメッセージ表示と同じタイムライン上に溶け込む（添付ブロックのようなリッチコンポーネントで表示）
+
+## 2. 依存・前提
+
+- 既存機能: `messageService`, `MessageItem.tsx`
+- 他 Issue との衝突: `MessageItem.tsx` は複数 Issue で触るので UI 部分は最後にマージするか、描画分岐を `event` に閉じる
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "events" {
+  schema  = schema.public
+  comment = "会話イベント"
+  column "id"          { null = false, type = serial }
+  column "message_id"  { null = false, type = integer }   # 関連するイベント投稿メッセージ
+  column "title"       { null = false, type = text }
+  column "description" { null = true,  type = text }
+  column "starts_at"   { null = false, type = timestamptz }
+  column "ends_at"     { null = true,  type = timestamptz }
+  column "created_by"  { null = true,  type = integer }
+  column "created_at"  { null = false, type = timestamptz, default = sql("NOW()") }
+  column "updated_at"  { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_events_message" { columns = [column.message_id], ref_columns = [table.messages.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_events_user"    { columns = [column.created_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_events_message" { unique = true, columns = [column.message_id] }
+  index "idx_events_starts_at" { columns = [column.starts_at] }
+}
+
+table "event_rsvps" {
+  schema  = schema.public
+  comment = "イベント参加可否"
+  column "event_id"   { null = false, type = integer }
+  column "user_id"    { null = false, type = integer }
+  column "status"     { null = false, type = text }   # going / not_going / maybe
+  column "updated_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.event_id, column.user_id] }
+  foreign_key "fk_rsvp_event" { columns = [column.event_id], ref_columns = [table.events.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_rsvp_user"  { columns = [column.user_id], ref_columns = [table.users.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/event.ts 新規
+export type RsvpStatus = 'going' | 'not_going' | 'maybe';
+export interface ChatEvent {
+  id: number; messageId: number; title: string; description: string | null;
+  startsAt: string; endsAt: string | null; createdBy: number | null;
+  createdAt: string; updatedAt: string;
+  rsvpCounts: { going: number; notGoing: number; maybe: number };
+  myRsvp: RsvpStatus | null;
+}
+export interface CreateEventInput {
+  channelId: number;
+  title: string;
+  description?: string;
+  startsAt: string;
+  endsAt?: string;
+}
+```
+
+`Message` にも `event?: ChatEvent | null` を追加してタイムラインで同時取得できるようにする。
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/eventService.ts`
+  - `create(userId, input)` — まず `messageService.sendMessage` で type 付きメッセージを作成し、その `message_id` で `events` を insert
+  - `update(userId, id, input)` / `delete(userId, id)`（作成者のみ）
+  - `setRsvp(userId, eventId, status)`
+  - `getByMessageId(messageId)` — メッセージ取得時のバルクロード用 `getByMessageIds`
+- `packages/server/src/routes/events.ts`
+  - `POST /api/events` / `PATCH /api/events/:id` / `DELETE /api/events/:id` / `POST /api/events/:id/rsvp`
+
+### 変更ファイル
+- `packages/server/src/services/messageService.ts`
+  - `list*` 系で `events` を LEFT JOIN し、`event` フィールドを埋める（n+1 回避で bulk fetch）
+- Socket: `event:rsvp_updated` を発火して即時集計更新
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Chat/EventCard.tsx` — メッセージ内に表示するイベントカード（タイトル、日時、集計、RSVP ボタン）
+- `packages/client/src/components/Chat/CreateEventDialog.tsx` — 日時ピッカー + タイトル + 説明
+
+### 変更ファイル
+- `packages/client/src/components/Chat/MessageItem.tsx`
+  - `message.event` が存在するとき `EventCard` を表示
+- `packages/client/src/components/Chat/RichEditor.tsx`
+  - スラッシュコマンド `/event` で作成ダイアログを開く
+- `packages/client/src/api/client.ts`
+  - `events.create` / `update` / `delete` / `setRsvp`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/event.test.ts`（作成 / RSVP / 集計）
+   - client: `EventCard.test.tsx`、`CreateEventDialog.test.tsx`、`MessageItem.test.tsx` 追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- `starts_at` は `ends_at` より前
+- RSVP が冪等（同一ユーザーが連続で POST しても重複しない）
+- 集計値が正しい（各ステータスの COUNT）
+- 作成者以外は update / delete できない
+
+### クライアント
+- カード上でボタンクリックで RSVP 更新
+- Socket 経由で集計がリアルタイム更新される
+- `/event` コマンドでダイアログが開く
+
+## 9. 注意点
+
+- **イベント更新時のメッセージ本文**: メッセージ本文には「〜イベント作成」などの短いプレースホルダを入れ、ビジュアルは EventCard で描画する
+- **繰り返しイベント**: スコープ外（将来拡張）
+- **参加者通知**: RSVP 変更で主催者にメンション通知するのは任意機能
+
+## 10. 見積もり / リスク
+
+- 規模: 中〜大（新規 2 テーブル + 独自カード UI）
+- リスク: メッセージ API レスポンスに `event` フィールドを追加する影響範囲。`optional` にして既存テストを壊さない

--- a/doc/implementation-plans/109-channel-notification-settings.md
+++ b/doc/implementation-plans/109-channel-notification-settings.md
@@ -1,0 +1,128 @@
+# #109 通知設定のカスタマイズ — 実行計画
+
+- Issue: [#109](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/109)
+- 難易度: 中
+- ブランチ: `feature/channel-notification-settings/#109`
+
+## 1. ゴール（受入条件）
+
+- チャンネル単位で通知レベルを選択できる: `all`（全件）/ `mentions`（メンションのみ）/ `muted`（ミュート）
+- デフォルトは `all`
+- ユーザーごとに独立（チャンネルごとに他ユーザーの設定に影響しない）
+- サイドバー（`ChannelItem`）から 1 クリックで変更可能（3 択のポップオーバー）
+- ミュート中のチャンネルはサイドバーで **未読バッジを薄く/非表示** にする（視認性の調整）
+- プッシュ通知・メンションバッジの発火が設定に従う
+
+## 2. 依存・前提
+
+- 既存機能: `pushService`, `mentionsテーブル`, `channel_read_status`
+- 他 Issue との衝突: なし（`channel_members` とは別テーブルなので独立）
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "channel_notification_settings" {
+  schema  = schema.public
+  comment = "チャンネル通知設定（ユーザー × チャンネル）"
+  column "user_id"    { null = false, type = integer }
+  column "channel_id" { null = false, type = integer }
+  column "level"      { null = false, type = text, default = "all" }  # all / mentions / muted
+  column "updated_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.user_id, column.channel_id] }
+  foreign_key "fk_cns_user" {
+    columns = [column.user_id], ref_columns = [table.users.column.id],
+    on_delete = CASCADE, on_update = NO_ACTION
+  }
+  foreign_key "fk_cns_channel" {
+    columns = [column.channel_id], ref_columns = [table.channels.column.id],
+    on_delete = CASCADE, on_update = NO_ACTION
+  }
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/channel.ts に追記
+export type ChannelNotificationLevel = 'all' | 'mentions' | 'muted';
+export interface ChannelNotificationSetting {
+  channelId: number;
+  level: ChannelNotificationLevel;
+  updatedAt: string;
+}
+```
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/channelNotificationService.ts`
+  - `getForUser(userId)` — ユーザーの全設定 Map を返す
+  - `set(userId, channelId, level)` — UPSERT
+  - `getLevel(userId, channelId)` — 存在しなければ `'all'` を返す（内部 helper）
+
+### 変更ファイル
+- `packages/server/src/routes/channels.ts`
+  - `GET /api/channels/notifications` — 自分の全設定取得
+  - `PUT /api/channels/:id/notifications` — レベル更新（body: `{ level }`）
+- `packages/server/src/services/pushService.ts`
+  - 通知送信前に `getLevel(userId, channelId)` を呼ぶ
+  - `'muted'` なら送信しない
+  - `'mentions'` ならメンション対象者のみ送信
+- `packages/server/src/socket/messageHandler.ts`
+  - 通知・バッジ更新イベント発火前に同様のチェック
+
+### 監査ログ
+
+通知設定はユーザーの個人設定なので監査対象外。
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Channel/NotificationLevelMenu.tsx` — 3 択ラジオのポップオーバー
+- `packages/client/src/hooks/useChannelNotifications.ts` — Map でキャッシュ、`use()` で初回解決
+
+### 変更ファイル
+- `packages/client/src/api/client.ts`
+  - `channels.getNotifications()` / `channels.setNotificationLevel(channelId, level)`
+- `packages/client/src/components/Channel/ChannelItem.tsx`
+  - 右クリック or `⋮` アイコンでメニュー表示
+  - ミュート時は名前をグレーで表示
+- `packages/client/src/hooks/useMessages.ts` / `useMentions.ts`（存在すれば）
+  - ミュート判定で未読バッジを非表示にする
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. `db/schema.hcl` 編集 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/channelNotification.test.ts`、`pushService` 既存テストに「ミュート時は送信されない」を追記
+   - client: `__tests__/NotificationLevelMenu.test.tsx`、`ChannelItem.test.tsx` 追記、`useChannelNotifications.test.ts`
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- `level` バリデーション（`all` / `mentions` / `muted` 以外は 400）
+- レコード未作成ユーザーの `getLevel` が `'all'` を返す
+- UPSERT が冪等
+- `pushService.sendToUser` がレベルに従って発火する/しない
+- メンション通知がレベル `'mentions'` で送られ、`'muted'` で送られない
+
+### クライアント
+- メニュー操作で API が呼ばれる
+- 反映後に `ChannelItem` のスタイルが変わる
+- ミュート中はメンションバッジも非表示
+
+## 9. 注意点
+
+- **既存ユーザーのデフォルト**: テーブルにレコードがないユーザーは `'all'` と解釈する（row が無い＝未設定）。全ユーザー × 全チャンネル分のレコードを前もって生成しない（維持コスト増）
+- プッシュ通知は非同期なので、設定変更の「即時反映」は多少遅れる可能性あり。ユーザー体験上問題ないレベル
+- Socket 経由の `message:new` イベントは全員に流すが、**クライアント側でもミュート中は通知・バッジ増分をスキップ** する二重防御にすると安全
+
+## 10. 見積もり / リスク
+
+- 規模: 中（サーバー 1 service + 2 route、クライアント 2 コンポーネント + 1 hook + pushService の条件分岐）
+- リスク: プッシュ通知の既存テストを壊す可能性 → `getLevel` の default-all 挙動を確実に担保する

--- a/doc/implementation-plans/110-scheduled-message.md
+++ b/doc/implementation-plans/110-scheduled-message.md
@@ -1,0 +1,157 @@
+# #110 予約送信 — 実行計画
+
+- Issue: [#110](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/110)
+- 難易度: 中
+- ブランチ: `feature/scheduled-message/#110`
+
+## 1. ゴール（受入条件）
+
+- メッセージ入力欄から **送信日時（未来）** を指定して予約できる
+- 予約済みメッセージ一覧を確認・編集・キャンセルできる
+- 指定時刻になると自動でチャンネルへ投稿され、通常の `message:new` として全員に配信される
+- 添付ファイル付きメッセージも予約可能（`message_attachments.message_id` を後付けで紐付け）
+- 失敗時はユーザーに通知（エラー理由を `scheduled_messages.error` に保存）
+
+## 2. 依存・前提
+
+- 既存機能: `messageService.sendMessage`, `RichEditor`, `message_attachments`
+- 他 Issue との衝突: `messageService` は #113 / #117 と同時変更しやすい。**#113 / #117 を先にマージ** してから着手するとコンフリクト回避
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "scheduled_messages" {
+  schema  = schema.public
+  comment = "予約送信メッセージ"
+  column "id"             { null = false, type = serial }
+  column "user_id"        { null = false, type = integer }
+  column "channel_id"     { null = false, type = integer }
+  column "content"        { null = false, type = text }
+  column "scheduled_at"   { null = false, type = timestamptz }
+  column "status"         { null = false, type = text, default = "pending" }  # pending / sent / failed / canceled
+  column "error"          { null = true,  type = text }
+  column "sent_message_id"{ null = true,  type = integer }
+  column "created_at"     { null = false, type = timestamptz, default = sql("NOW()") }
+  column "updated_at"     { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_sched_user"    { columns = [column.user_id], ref_columns = [table.users.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_sched_channel" { columns = [column.channel_id], ref_columns = [table.channels.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_sched_sent"    { columns = [column.sent_message_id], ref_columns = [table.messages.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_sched_pending"      { columns = [column.status, column.scheduled_at] }
+}
+```
+
+添付ファイルは `message_attachments.scheduled_message_id` を追加してもよい。
+
+```hcl
+# message_attachments テーブルに追加
+column "scheduled_message_id" {
+  null    = true
+  type    = integer
+  comment = "予約送信メッセージID（NULL = 通常添付）"
+}
+foreign_key "fk_attachments_scheduled" {
+  columns = [column.scheduled_message_id], ref_columns = [table.scheduled_messages.column.id],
+  on_delete = CASCADE, on_update = NO_ACTION
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/scheduledMessage.ts 新規
+export type ScheduledMessageStatus = 'pending' | 'sent' | 'failed' | 'canceled';
+export interface ScheduledMessage {
+  id: number;
+  userId: number;
+  channelId: number;
+  content: string;
+  scheduledAt: string;
+  status: ScheduledMessageStatus;
+  error: string | null;
+  sentMessageId: number | null;
+  attachments: Attachment[];
+  createdAt: string;
+  updatedAt: string;
+}
+export interface CreateScheduledMessageInput {
+  channelId: number;
+  content: string;
+  scheduledAt: string;
+  attachmentIds?: number[];
+}
+```
+
+## 5. サーバー変更
+
+### 新規ファイル
+
+- `packages/server/src/services/scheduledMessageService.ts`
+  - `list(userId)` / `create(userId, input)` / `update(userId, id, input)` / `cancel(userId, id)` / `pickDue(limit)` / `markSent(id, messageId)` / `markFailed(id, error)`
+- `packages/server/src/routes/scheduledMessages.ts`
+  - `GET /api/scheduled-messages` / `POST /api/scheduled-messages` / `PATCH /api/scheduled-messages/:id` / `DELETE /api/scheduled-messages/:id`
+- `packages/server/src/jobs/scheduledMessageWorker.ts`
+  - `setInterval` で 30 秒ごとに `scheduled_at <= NOW() AND status = 'pending'` をピック → `messageService.sendMessage` を呼ぶ → Socket で `message:new` を emit
+  - トランザクションで `pending → sent` をアトミックに UPDATE（先にステータスを `sending` に変えて二重送信防止）
+
+### 変更ファイル
+- `packages/server/src/index.ts` — アプリ起動時に worker を起動（`if (process.env.NODE_ENV !== 'test')` でテスト時のみ抑止）
+- `packages/server/src/services/messageService.ts` — 予約経由の呼び出し用に `sendMessageFromScheduled(scheduledId)` を追加（または既存 `sendMessage` を再利用）
+
+### 監査ログ
+- 予約送信は通常のメッセージ送信として監査ログ（既存分）に記録されるため追加は不要。ただし「予約失敗」は `message.schedule.failed` として記録してもよい
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Chat/ScheduleSendButton.tsx` — 送信ボタン横のアイコン。クリックで日時ピッカーを開く
+- `packages/client/src/components/Chat/ScheduledMessagesDialog.tsx` — 予約一覧（編集・キャンセル可能）
+- `packages/client/src/hooks/useScheduledMessages.ts`
+
+### 変更ファイル
+- `packages/client/src/components/Chat/RichEditor.tsx`
+  - `ScheduleSendButton` を組み込み、予約時は `onSend` の代わりに `onSchedule(datetime)` を呼ぶ
+- `packages/client/src/pages/ChatPage.tsx`
+  - サイドバー or ヘッダーから `ScheduledMessagesDialog` を開く
+- `packages/client/src/api/client.ts`
+  - `scheduledMessages.list()` / `create(input)` / `update(id, input)` / `cancel(id)`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/scheduledMessage.test.ts`（CRUD + worker ピック + 送信）
+   - client: `ScheduleSendButton.test.tsx` / `ScheduledMessagesDialog.test.tsx`
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- 過去日時の予約は 400
+- 予約済みメッセージのキャンセル後は `status = canceled` になり、worker がピックしない
+- worker が `scheduled_at <= NOW()` のレコードだけを対象にする
+- 送信成功時に `status = sent` / `sent_message_id` が埋まる
+- 送信失敗（例: チャンネル削除済み）で `status = failed` / `error` が埋まる
+- 他人の予約を編集・削除できない
+
+### クライアント
+- 日時ピッカーで未来時刻を選ぶと `api.scheduledMessages.create` が呼ばれる
+- 予約一覧で編集・キャンセルが反映される
+- 予約時にスナックバー「〜に予約しました」が出る（`doc/snackbar-spec.md` 準拠）
+
+## 9. 注意点
+
+- **二重送信防止**: worker はマルチプロセス想定を今はしないが、`UPDATE ... WHERE status='pending'` のアトミック性で保護
+- **タイムゾーン**: 入力値は UTC へ変換して保存。UI は端末ローカル TZ で表示
+- **冪等性**: 送信失敗時のリトライはしない（手動で再度予約し直す方針）。将来リトライを追加するなら `retry_count` カラムを検討
+- **worker 停止時の未送信**: 起動時に `pending AND scheduled_at <= NOW()` を即時処理する
+- 添付ファイルの扱いが複雑なので、**初版は添付なしで実装** → 次 PR で添付対応、とステップを分けるのも有効（PR 規模を小さくできる）
+
+## 10. 見積もり / リスク
+
+- 規模: 中〜大（worker + CRUD + UI）
+- リスク: worker の起動／テスト分離。テストでは worker を起動せず、`pickDue` → `messageService.sendMessage` の単体テストで担保する

--- a/doc/implementation-plans/111-message-templates.md
+++ b/doc/implementation-plans/111-message-templates.md
@@ -1,0 +1,116 @@
+# #111 メッセージテンプレート / 定型文 — 実行計画
+
+- Issue: [#111](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/111)
+- 難易度: 低
+- ブランチ: `feature/message-templates/#111`
+
+## 1. ゴール（受入条件）
+
+- ユーザーが任意のテンプレート（タイトル + 本文）を登録・編集・削除・並び替えできる
+- メッセージ入力中に **スラッシュコマンド `/tpl`** もしくはツールバーボタンでテンプレート選択ダイアログを開ける
+- 選択したテンプレートが RichEditor の本文へ挿入される（既存文字列は保持）
+- テンプレートは **ユーザー単位で独立**（ワークスペース共有は対象外）
+
+## 2. 依存・前提
+
+- 既存機能: `RichEditor.tsx`（Quill ベース）、`MentionDropdown.tsx` のショートカット検知ロジック
+- 他 Issue との衝突: なし（独立）
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "message_templates" {
+  schema  = schema.public
+  comment = "メッセージテンプレート（ユーザー単位）"
+  column "id"         { null = false, type = serial }
+  column "user_id"    { null = false, type = integer }
+  column "title"      { null = false, type = text }
+  column "body"       { null = false, type = text }
+  column "position"   { null = false, type = integer, default = 0 }
+  column "created_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  column "updated_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_message_templates_user" {
+    columns = [column.user_id], ref_columns = [table.users.column.id],
+    on_delete = CASCADE, on_update = NO_ACTION
+  }
+  index "idx_message_templates_user_position" { columns = [column.user_id, column.position] }
+}
+```
+
+## 4. shared types（`packages/shared/src/types/messageTemplate.ts` 新規）
+
+```ts
+export interface MessageTemplate {
+  id: number;
+  userId: number;
+  title: string;
+  body: string;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+}
+export interface CreateMessageTemplateInput { title: string; body: string; }
+export interface UpdateMessageTemplateInput { title?: string; body?: string; position?: number; }
+```
+
+`packages/shared/src/index.ts` から re-export する。
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/messageTemplateService.ts`
+  - `list(userId)` / `create(userId, input)` / `update(userId, id, input)` / `remove(userId, id)` / `reorder(userId, orderedIds)`
+- `packages/server/src/routes/messageTemplates.ts`
+  - `GET /api/templates` / `POST /api/templates` / `PATCH /api/templates/:id` / `DELETE /api/templates/:id` / `PUT /api/templates/reorder`
+  - 全エンドポイントで `authenticateToken` 必須、他人のレコード操作は 404 扱い
+
+### 変更ファイル
+- `packages/server/src/app.ts` にルート登録
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Chat/TemplatePicker.tsx` — テンプレート選択ダイアログ（検索 + 絞り込み、Enter で確定）
+- `packages/client/src/pages/TemplatesPage.tsx` — テンプレート CRUD 管理画面（サイドメニューからアクセス）
+- `packages/client/src/hooks/useMessageTemplates.ts` — `use()` で Promise を解決（`useMemo` で安定化）
+
+### 変更ファイル
+- `packages/client/src/api/client.ts` に `templates` セクション追加
+- `packages/client/src/components/Chat/RichEditor.tsx`
+  - `/` 検知時に `/tpl` コマンドをフィルタし、対応したら `TemplatePicker` を開く
+  - `insertContent(text)` API を親へ公開し、選択後に挿入する
+- サイドバーまたはプロフィールメニューに「テンプレート管理」導線を追加
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. `db/schema.hcl` を編集 → `atlas schema apply --env local --dry-run` で差分確認 → 適用
+3. shared types を追加してビルド
+4. **テスト項目列挙**（`describe`/`it` のみ）
+   - server: `__tests__/messageTemplate.test.ts`
+   - client: `__tests__/TemplatePicker.test.tsx`, `TemplatesPage.test.tsx`, `RichEditor.test.tsx` への追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → `npm run build && npm run test`
+7. PR テンプレートを埋めて Draft PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- CRUD・並び順の整合性・他人の ID でのアクセス禁止
+- `title`・`body` の空文字検証、`title` 長さ 100 文字上限（実装で enforce）
+
+### クライアント
+- `/tpl` 入力時にピッカーが開く
+- 選択したテンプレート本文が RichEditor にカーソル位置挿入される
+- テンプレート一覧の並び替え（drag & drop または ↑↓ ボタン）が API に反映される
+
+## 9. 注意点
+
+- RichEditor は Quill ベース。Delta 形式で挿入するとスタイルが壊れにくい。プレーンテキスト挿入の場合は `editor.insertText` を使う
+- 既存 `MentionDropdown` が `@` を監視しているので、`/` のキーフックは衝突しないように **別イベントハンドラ** で実装する
+
+## 10. 見積もり / リスク
+
+- 規模: 小（サーバー 1 service + 1 route、クライアント 2 コンポーネント + 1 hook）
+- リスク: Quill の挿入 API がテスト困難 → `TemplatesPage` のロジックと `insertContent` 呼び出し部分を切り離し、jsdom で扱えるスタブで検証する

--- a/doc/implementation-plans/112-invite-link.md
+++ b/doc/implementation-plans/112-invite-link.md
@@ -1,0 +1,147 @@
+# #112 招待リンク — 実行計画
+
+- Issue: [#112](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/112)
+- 難易度: 中
+- ブランチ: `feature/invite-link/#112`
+
+## 1. ゴール（受入条件）
+
+- チャンネル or ワークスペース単位で招待リンクを発行できる（ワークスペース全体招待は全公開チャンネルへの一括参加を意味する）
+- リンクに **有効期限** と **最大使用回数** を設定できる
+- リンクにアクセスしたログイン済みユーザーは対象に自動参加する
+- 未ログインユーザーはログイン／登録後に参加フローへ誘導される
+- 管理者は発行されたリンクを一覧・無効化できる
+
+## 2. 依存・前提
+
+- 既存機能: `authService`, `channelService.addMember`, `channel_members`
+- 他 Issue との衝突: なし
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "invite_links" {
+  schema  = schema.public
+  comment = "招待リンク"
+  column "id"              { null = false, type = serial }
+  column "token"           { null = false, type = text }           # URL-safe 乱数（32 文字以上）
+  column "channel_id"      { null = true,  type = integer }        # NULL = ワークスペース全体
+  column "created_by"      { null = true,  type = integer }
+  column "max_uses"        { null = true,  type = integer }        # NULL = 無制限
+  column "used_count"      { null = false, type = integer, default = 0 }
+  column "expires_at"      { null = true,  type = timestamptz }    # NULL = 無期限
+  column "is_revoked"      { null = false, type = boolean, default = false }
+  column "created_at"      { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_invite_channel" { columns = [column.channel_id], ref_columns = [table.channels.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_invite_creator" { columns = [column.created_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_invite_token" { unique = true, columns = [column.token] }
+}
+
+table "invite_link_uses" {
+  schema  = schema.public
+  comment = "招待リンク使用履歴"
+  column "id"        { null = false, type = serial }
+  column "invite_id" { null = false, type = integer }
+  column "user_id"   { null = true,  type = integer }
+  column "used_at"   { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_invite_use_invite" { columns = [column.invite_id], ref_columns = [table.invite_links.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_invite_use_user"   { columns = [column.user_id], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/invite.ts 新規
+export interface InviteLink {
+  id: number;
+  token: string;
+  channelId: number | null;
+  createdBy: number | null;
+  maxUses: number | null;
+  usedCount: number;
+  expiresAt: string | null;
+  isRevoked: boolean;
+  createdAt: string;
+}
+export interface CreateInviteLinkInput {
+  channelId?: number | null;
+  maxUses?: number | null;
+  expiresInHours?: number | null;
+}
+```
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/inviteService.ts`
+  - `create(userId, input)` — token を `crypto.randomBytes(24).toString('base64url')` で生成
+  - `listByChannel(channelId)` / `listAll()`（管理者用）
+  - `revoke(userId, id)`
+  - `redeem(token, userId)` — **トランザクション** で `used_count < max_uses` かつ `expires_at > NOW()` かつ `is_revoked = false` を満たす場合に `channel_members` を INSERT し `used_count += 1`、`invite_link_uses` に INSERT
+- `packages/server/src/routes/invites.ts`
+  - `POST /api/invites` — 作成（チャンネル管理者または admin のみ）
+  - `GET /api/invites?channelId=...` — 一覧
+  - `DELETE /api/invites/:id` — 無効化
+  - `POST /api/invites/:token/redeem` — 参加（認証必須）
+  - `GET /api/invites/:token` — トークンの有効性と対象チャンネル情報を返す（認証不要でもよい。ログイン前に「このチャンネルに招待されています」表示用）
+
+### 監査ログ
+- `invite.create` / `invite.revoke` / `invite.redeem` を `AuditActionType` に追加し、`auditLogService.record` を呼ぶ
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/pages/InviteRedeemPage.tsx` — `/invite/:token` ルート
+  - 未ログインなら「ログインして参加」→ ログイン後に token を保持してリダイレクト
+  - ログイン済みなら即 `redeem` API を叩く
+- `packages/client/src/components/Channel/InviteLinkDialog.tsx` — リンク生成・一覧・無効化 UI
+
+### 変更ファイル
+- `packages/client/src/App.tsx` — ルート `/invite/:token` を追加
+- `packages/client/src/components/Channel/ChannelMembersDialog.tsx` — 「招待リンクを作成」ボタンを追加
+- `packages/client/src/api/client.ts` — `invites.create` / `list` / `revoke` / `redeem` / `lookup`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/invite.test.ts`（生成・使用・期限切れ・上限到達・無効化）
+   - client: `InviteLinkDialog.test.tsx` / `InviteRedeemPage.test.tsx`
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- token は 32 文字以上、URL セーフ、一意
+- `maxUses` 到達後は `redeem` が 410 Gone
+- `expiresAt` 経過後は `redeem` が 410 Gone
+- `is_revoked = true` のリンクは `redeem` 不可
+- 既にメンバーのユーザーが再使用しても成功扱い（`used_count` は増やさない／増やすかは仕様決定要）→ **増やさない** で実装
+- 同時 redeem（レースコンディション）で `used_count` が `max_uses` を超えないこと（行ロックまたは条件付き UPDATE）
+- ワークスペース招待で全公開チャンネルに参加させる挙動の確認
+
+### クライアント
+- ダイアログ内でリンクが生成されコピーできる
+- 期限・上限を選択して作成できる
+- 管理者／作成者のみ「無効化」ボタンが見える
+- `/invite/:token` に未ログインでアクセスするとログインへリダイレクト
+- ログイン後に自動で `redeem` が走り該当チャンネルへ遷移する
+
+## 9. 注意点
+
+- **トークン推測攻撃**: 24 bytes の `randomBytes` で十分だが、**試行回数のレート制限** を `POST /api/invites/:token/redeem` に設ける（IP 単位で 60req/min など）。初版は最低限のスロットリングでもよい
+- **自動参加の範囲**: ワークスペース招待 = `is_private = false` の全チャンネルに `addMember`。既に参加しているものはスキップ
+- **プライベートチャンネル招待**: `channel_id` が指定されたリンクは `is_private = true` でも参加可能（発行者が権限を持つことが前提）
+- **ログイン前の token 保存**: `sessionStorage` に `redirect_after_login=/invite/<token>` を入れておきログイン成功後に読み出す
+
+## 10. 見積もり / リスク
+
+- 規模: 中（CRUD + redeem フロー + ログイン前リダイレクト）
+- リスク: レースコンディションでの `used_count` 超過 → 行ロック or `UPDATE ... WHERE used_count < max_uses` を `affectedRows` で判定

--- a/doc/implementation-plans/113-channel-posting-permission.md
+++ b/doc/implementation-plans/113-channel-posting-permission.md
@@ -1,0 +1,112 @@
+# #113 投稿権限制御チャンネル — 実行計画
+
+- Issue: [#113](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/113)
+- 難易度: 中
+- ブランチ: `feature/channel-posting-permission/#113`
+
+## 1. ゴール（受入条件）
+
+- チャンネル作成・編集時に **投稿権限** を選択できる
+  - `everyone` — 全員（既定・現状の挙動）
+  - `admins` — 管理者のみ（`users.role = 'admin'` または Moderator 以上）
+  - `readonly` — 閲覧専用（全員投稿不可。管理者による通知用チャンネルを想定）
+- 権限のないユーザーは `RichEditor` の入力欄が **disabled** になり、送信 API も 403 を返す
+- 既存ロール管理（Admin / Moderator / Member）と連携する
+
+## 2. 依存・前提
+
+- 既存機能: `users.role`, `channels`, `messageService.sendMessage`, `RichEditor`
+- 他 Issue との衝突: `messageService.sendMessage` に権限チェックを追加するので **#107 / #110 / #117 と衝突しやすい**。**#113 を先にマージ** 推奨
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+# channels テーブルに追加
+column "posting_permission" {
+  null    = false
+  type    = text
+  default = "everyone"
+  comment = "投稿権限（everyone / admins / readonly）"
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/channel.ts
+export type ChannelPostingPermission = 'everyone' | 'admins' | 'readonly';
+// Channel に追加
+postingPermission: ChannelPostingPermission;
+// CreateChannelInput / UpdateChannelInput に追加
+postingPermission?: ChannelPostingPermission;
+```
+
+## 5. サーバー変更
+
+### 変更ファイル
+- `packages/server/src/services/channelService.ts`
+  - create / update で `posting_permission` を扱う
+  - `canPost(userId, channelId)` helper を追加
+    - `readonly` → false
+    - `admins` → `users.role` が admin or moderator ならば true
+    - `everyone` → channel member か確認
+- `packages/server/src/services/messageService.ts`
+  - `sendMessage` の冒頭で `canPost` を呼び、false なら `throw createError(403, 'POSTING_FORBIDDEN', '...')`
+- `packages/server/src/routes/channels.ts`
+  - 既存の create / patch エンドポイントで `postingPermission` を受け取り検証
+- `packages/server/src/controllers/messageController.ts`
+  - `sendMessage` のエラーハンドリングで 403 を明確に
+
+### 監査ログ
+- `channel.permission.update` を追加し、`auditLogService.record` を呼ぶ
+
+## 6. クライアント変更
+
+### 変更ファイル
+- `packages/client/src/components/Channel/CreateChannelDialog.tsx`
+  - 権限選択（ラジオ 3 択）を追加
+- `packages/client/src/components/Channel/ChannelTopicBar.tsx` or 既存の設定ダイアログ
+  - 権限変更 UI を追加（管理者のみ変更可）
+- `packages/client/src/components/Chat/RichEditor.tsx`
+  - `canPost: boolean` prop を受け取り、disabled 時はプレースホルダを「このチャンネルには投稿できません」にする
+- `packages/client/src/pages/ChatPage.tsx`
+  - 現在チャンネルの `postingPermission` と `currentUser.role` から `canPost` を計算して `RichEditor` に渡す
+- `packages/client/src/api/client.ts`
+  - `channels.updatePermission(id, permission)`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/channelPermission.test.ts`、既存 `messageController.test.ts` に「readonly で 403」など追記
+   - client: `CreateChannelDialog.test.tsx` 追記、`ChatPage.test.tsx` に「readonly チャンネルで RichEditor が disabled」を追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- 権限値バリデーション（3 値以外は 400）
+- 一般ユーザーが `admins` チャンネルに投稿すると 403
+- `readonly` チャンネルは admin でも投稿不可（設計判断が必要。**admin も不可** を推奨。設定変更で `everyone` に戻すべき）
+- 既存チャンネル（新カラムのデフォルト）は `everyone` として振る舞う
+- Socket の `message:send` 経由でも同様に拒否される
+
+### クライアント
+- RichEditor の disabled 切替
+- 作成ダイアログ / 設定画面から権限変更できる
+- 権限変更が Socket 経由で他メンバーにも即時反映される（任意。重い場合はリロード時反映でも可）
+
+## 9. 注意点
+
+- **Socket 経由の送信**: `socket/messageHandler.ts` で emit 前にサーバー側で権限チェックを必ず行う
+- **Moderator の扱い**: 既存プロジェクトで Moderator ロールが定義されていれば admins に含める。未定義なら admin のみ
+- `readonly` 時の `#113` に合わせた UI 表示（グレーアウト + ツールチップ）
+
+## 10. 見積もり / リスク
+
+- 規模: 中
+- リスク: 既存の `sendMessage` 経路すべてに権限チェックを入れるので抜け漏れに注意（`socket/messageHandler.ts` も含む）

--- a/doc/implementation-plans/114-onboarding.md
+++ b/doc/implementation-plans/114-onboarding.md
@@ -1,0 +1,109 @@
+# #114 ワークスペース初回オンボーディング — 実行計画
+
+- Issue: [#114](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/114)
+- 難易度: 低
+- ブランチ: `feature/onboarding/#114`
+
+## 1. ゴール（受入条件）
+
+- 初回ログイン（`users.onboarding_completed_at IS NULL`）を検出してウェルカムモーダルを表示する
+- ステップ形式（3〜4 ステップ）で基本操作を案内
+  1. ようこそ画面（製品の簡単な説明）
+  2. おすすめチャンネル一覧 → 「このチャンネルに参加」ボタン（複数選択可）
+  3. メッセージ送信のガイド（スクリーンショットまたは動画）
+  4. チャンネル切替のガイド
+- 「スキップ」「完了」いずれでも `onboarding_completed_at` が NOW() に更新され、次回以降は出ない
+- 管理者がおすすめチャンネルを設定できる（Admin 画面にチェックボックス `is_recommended`）
+
+## 2. 依存・前提
+
+- 既存機能: `AuthContext.tsx`（ユーザー情報保持）、`channels` API
+- 他 Issue との衝突: なし（#112 招待リンクとは独立だが、将来的に「招待経由の初回」と統合してもよい）
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+# users テーブルにカラム追加
+column "onboarding_completed_at" {
+  null    = true
+  type    = timestamptz
+  comment = "オンボーディング完了日時（NULL = 未完了）"
+}
+
+# channels テーブルにカラム追加
+column "is_recommended" {
+  null    = false
+  type    = boolean
+  default = false
+  comment = "おすすめチャンネル（初回オンボーディング対象）"
+}
+```
+
+## 4. shared types 変更
+
+- `packages/shared/src/types/user.ts` の `User` に `onboardingCompletedAt: string | null` を追加
+- `packages/shared/src/types/channel.ts` の `Channel` に `isRecommended: boolean` を追加
+
+## 5. サーバー変更
+
+### 変更ファイル
+- `packages/server/src/services/authService.ts` — `me` レスポンス / ログインレスポンスに `onboardingCompletedAt` を含める
+- `packages/server/src/services/channelService.ts` — `isRecommended` を select 対象に含める
+- `packages/server/src/routes/auth.ts` — `POST /api/auth/onboarding/complete` を追加（認証済みユーザーのみ。`onboarding_completed_at = NOW()` を UPDATE）
+- `packages/server/src/services/adminService.ts` / `routes/admin.ts` — `PATCH /api/admin/channels/:id/recommend` で `is_recommended` をトグル
+
+### 監査ログ
+- `auth.onboarding.complete` を `AuditActionType` に追加（任意）
+- `admin.channel.recommend` / `admin.channel.unrecommend` を追加
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Onboarding/WelcomeModal.tsx` — 4 ステップのダイアログ（MUI Stepper を想定）
+- `packages/client/src/components/Onboarding/RecommendedChannelList.tsx`
+
+### 変更ファイル
+- `packages/client/src/App.tsx`（または `ChatPage.tsx`）
+  - 認証後に `user.onboardingCompletedAt === null` を検知して `WelcomeModal` を表示
+- `packages/client/src/pages/AdminPage.tsx`
+  - チャンネル管理タブに「おすすめにする／解除する」ボタン
+- `packages/client/src/api/client.ts`
+  - `auth.completeOnboarding()`
+  - `admin.setChannelRecommended(channelId, value)`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. `db/schema.hcl` 編集 → `atlas schema apply`
+3. shared types 更新（型の破壊変更なので依存コード全体をビルドしてエラー潰す）
+4. **テスト項目列挙**
+   - server: `__tests__/onboarding.test.ts`、既存 `authController.test.ts` / `adminController.test.ts` に追記
+   - client: 新規 `WelcomeModal.test.tsx`、`AuthContext.test.tsx` / `AdminPage.test.tsx` に追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- `POST /api/auth/onboarding/complete` が認証必須、呼び出すと `onboarding_completed_at` が埋まる
+- `me` API のレスポンスが新フィールドを含む
+- `is_recommended` フラグが channels select に含まれる
+- 管理者のみ推奨設定を変更できる（403 の確認）
+
+### クライアント
+- `user.onboardingCompletedAt === null` のときにモーダルが自動表示される
+- 「スキップ」「完了」どちらでも API が呼ばれる
+- 推奨チャンネル参加ボタンで `channels.join` が呼ばれる
+- 2 回目のログインではモーダルが出ない
+
+## 9. 注意点
+
+- モーダル表示中に `use(promise)` で取得したデータを `useMemo` で固定する（再レンダーでモーダルが再 mount されると進捗が消える）
+- 「スキップ」後に再表示させたい場合はプロフィールページから「オンボーディングをやり直す」リンクで `PATCH /api/auth/profile` などで `onboarding_completed_at = NULL` に戻す運用も可（任意）
+- Stepper の `activeStep` はローカル state でよい
+
+## 10. 見積もり / リスク
+
+- 規模: 小〜中（モーダル UI + API 2 本）
+- リスク: `AuthContext` 変更が他コンポーネントに波及する可能性。型追加のみなので実害は小さい

--- a/doc/implementation-plans/115-tags.md
+++ b/doc/implementation-plans/115-tags.md
@@ -1,0 +1,147 @@
+# #115 タグ機能 — 実行計画
+
+- Issue: [#115](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/115)
+- 難易度: 中
+- ブランチ: `feature/tags/#115`
+
+## 1. ゴール（受入条件）
+
+- メッセージまたはチャンネルに自由記述のタグ（例: `#bug`, `#idea`）を付与できる
+- タグでフィルタリング・検索ができる（既存 `messageSearch` と統合、または独立エンドポイント）
+- ワークスペース内でよく使われるタグを候補表示する（入力中の補完）
+- タグ削除時は紐付け（`message_tags` / `channel_tags`）も削除される
+
+## 2. 依存・前提
+
+- 既存機能: `messageService`, `searchService`（あれば）, `MessageItem.tsx`
+- 他 Issue との衝突: `messages` 周辺は #107 / #110 / #113 / #117 と衝突しやすい。`messages` 本体のカラムを増やさずジョイン方式にすれば影響は最小
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "tags" {
+  schema  = schema.public
+  comment = "タグ（ワークスペース共有）"
+  column "id"          { null = false, type = serial }
+  column "name"        { null = false, type = text }                # 大文字小文字は保存時に lowerCase
+  column "created_by"  { null = true,  type = integer }
+  column "use_count"   { null = false, type = integer, default = 0 }
+  column "created_at"  { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_tags_user" { columns = [column.created_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_tags_name" { unique = true, columns = [column.name] }
+  index "idx_tags_use_count" { columns = [column.use_count] }
+}
+
+table "message_tags" {
+  schema  = schema.public
+  comment = "メッセージとタグの紐付け"
+  column "message_id" { null = false, type = integer }
+  column "tag_id"     { null = false, type = integer }
+  column "created_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  column "created_by" { null = true,  type = integer }
+  primary_key { columns = [column.message_id, column.tag_id] }
+  foreign_key "fk_mt_message" { columns = [column.message_id], ref_columns = [table.messages.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_mt_tag"     { columns = [column.tag_id], ref_columns = [table.tags.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_mt_user"    { columns = [column.created_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+}
+
+table "channel_tags" {
+  schema  = schema.public
+  comment = "チャンネルとタグの紐付け"
+  column "channel_id" { null = false, type = integer }
+  column "tag_id"     { null = false, type = integer }
+  column "created_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.channel_id, column.tag_id] }
+  foreign_key "fk_ct_channel" { columns = [column.channel_id], ref_columns = [table.channels.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_ct_tag"     { columns = [column.tag_id], ref_columns = [table.tags.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/tag.ts 新規
+export interface Tag {
+  id: number;
+  name: string;
+  useCount: number;
+  createdAt: string;
+}
+export interface TagSuggestion { name: string; useCount: number; }
+```
+
+`Message` / `Channel` 型に `tags: Tag[]` を追加する（あるいは別取得）。
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/tagService.ts`
+  - `listSuggestions(prefix, limit)` — `use_count DESC, name ASC` の上位
+  - `findOrCreate(name, userId)` — 小文字正規化
+  - `attachToMessage(messageId, tagIds, userId)` / `detachFromMessage(messageId, tagIds)`
+  - `attachToChannel(channelId, tagIds)` / `detachFromChannel(channelId, tagIds)`
+  - `getForMessages(messageIds)` — N+1 回避の bulk fetch
+- `packages/server/src/routes/tags.ts`
+  - `GET /api/tags/suggestions?prefix=&limit=`
+  - `POST /api/messages/:id/tags` `{ names: string[] }` — findOrCreate → attach
+  - `DELETE /api/messages/:id/tags/:tagId`
+  - 同様にチャンネル版
+
+### 変更ファイル
+- `packages/server/src/services/messageService.ts`
+  - `list*` 系のレスポンスに `tags: Tag[]` を含める（bulk fetch で n+1 回避）
+- `packages/server/src/services/searchService.ts`（もしくは相当箇所）
+  - `MessageSearchFilters` に `tagIds?: number[]` を追加し、WHERE 句に `EXISTS (SELECT 1 FROM message_tags mt WHERE mt.message_id = m.id AND mt.tag_id = ANY($tagIds))` を差し込む
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Chat/TagChip.tsx` — クリックで検索にセット
+- `packages/client/src/components/Chat/TagInput.tsx` — 補完候補付きの入力（Autocomplete）
+- `packages/client/src/hooks/useTagSuggestions.ts`
+
+### 変更ファイル
+- `packages/client/src/components/Chat/MessageItem.tsx` — タグの表示・編集トグル
+- `packages/client/src/components/Chat/SearchFilterPanel.tsx` — タグフィルタを追加
+- `packages/client/src/components/Channel/CreateChannelDialog.tsx` / `ChannelTopicBar.tsx` — チャンネルタグの追加・表示
+- `packages/client/src/api/client.ts` — `tags.suggestions` / `messages.setTags` / `channels.setTags`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/tag.test.ts`、既存 `advanced-search.test.ts` に「タグフィルタ」を追記
+   - client: `TagInput.test.tsx` / `MessageItem.test.tsx` 追記 / `SearchFilterPanel.test.tsx` 追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- タグ名の **正規化**（前後空白除去、小文字化）
+- 同名タグは重複せず `findOrCreate` が既存 ID を返す
+- 付与/解除で `use_count` が増減する（またはトリガーやサービス層で更新）
+- `GET /api/tags/suggestions` が use_count 降順で返る
+- メッセージ検索で tagIds フィルタが効く
+- 他人のメッセージに対する付与可否（**作成者のみ付与可能** とするか全員可能とするかは仕様決定）→ **チャンネルメンバーなら誰でも付与可能** を推奨
+
+### クライアント
+- Autocomplete で候補が表示される
+- Enter で確定、Backspace で直近チップを削除
+- メッセージ削除時にタグチップも消える（サーバー CASCADE の結果）
+
+## 9. 注意点
+
+- **use_count** の整合性: レースコンディションで狂う可能性。`count_tags()` のような再計算ジョブを夜間に回す or `COUNT(*)` で毎回算出（負荷次第）→ 初版は `UPDATE tags SET use_count = use_count + 1` で OK
+- **タグ名の最大長**: 50 文字上限、`[^\s#]` の制約
+- **検索統合**: 既存の `MessageSearchFilters` を拡張するので、`SearchFilterPanel` 全体のテストが影響する可能性あり
+- Channel タグの用途が曖昧（カテゴリとの違い）なので、**実装は任意** として Issue に合わせて MVP はメッセージタグのみでも可
+
+## 10. 見積もり / リスク
+
+- 規模: 中〜大（3 テーブル + UI 複数箇所）
+- リスク: 既存メッセージ API のレスポンス変更で型エラー波及 → `tags` を **optional** で追加するとリスク減

--- a/doc/implementation-plans/116-moderation-queue.md
+++ b/doc/implementation-plans/116-moderation-queue.md
@@ -1,0 +1,128 @@
+# #116 通報 / モデレーションキュー — 実行計画
+
+- Issue: [#116](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/116)
+- 難易度: 中
+- ブランチ: `feature/moderation-queue/#116`
+
+## 1. ゴール（受入条件）
+
+- メッセージのコンテキストメニュー（`MessageActions`）から通報できる
+- 通報時に理由を選択（`spam` / `harassment` / `other` + 任意コメント）
+- 管理者画面（`AdminPage`）に **モデレーションキュー** タブを追加
+- キューで各通報を確認し、以下の対応を取れる
+  - `dismiss` — 却下（そのまま残す）
+  - `delete_message` — 該当メッセージを削除
+  - `warn_user` — ユーザーに警告（MVP は削除のみでもよい）
+- 1 メッセージに複数通報が付く場合はキュー上でグループ化表示（任意）
+
+## 2. 依存・前提
+
+- 既存機能: `messageService`, `MessageActions.tsx`, Admin 周辺
+- 他 Issue との衝突: `MessageActions.tsx` で **#107（転送）と競合**、`AdminPage.tsx` で **#117 / #118 と競合**
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "message_reports" {
+  schema  = schema.public
+  comment = "メッセージ通報"
+  column "id"            { null = false, type = serial }
+  column "message_id"    { null = false, type = integer }
+  column "reporter_id"   { null = true,  type = integer }
+  column "reason"        { null = false, type = text }    # spam / harassment / other
+  column "comment"       { null = true,  type = text }
+  column "status"        { null = false, type = text, default = "pending" }  # pending / dismissed / actioned
+  column "action_taken"  { null = true,  type = text }    # delete_message / warn_user / ...
+  column "handled_by"    { null = true,  type = integer }
+  column "handled_at"    { null = true,  type = timestamptz }
+  column "created_at"    { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_rep_message"  { columns = [column.message_id], ref_columns = [table.messages.column.id], on_delete = CASCADE, on_update = NO_ACTION }
+  foreign_key "fk_rep_reporter" { columns = [column.reporter_id], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  foreign_key "fk_rep_handler"  { columns = [column.handled_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_reports_status" { columns = [column.status, column.created_at] }
+  index "idx_reports_message_reporter" { unique = true, columns = [column.message_id, column.reporter_id] }  # 同一ユーザーの重複通報防止
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/moderation.ts に追記（または新規）
+export type ReportReason = 'spam' | 'harassment' | 'other';
+export type ReportStatus = 'pending' | 'dismissed' | 'actioned';
+export interface MessageReport {
+  id: number; messageId: number; reporterId: number | null; reporterUsername: string | null;
+  reason: ReportReason; comment: string | null;
+  status: ReportStatus; actionTaken: string | null;
+  handledBy: number | null; handledAt: string | null;
+  createdAt: string;
+}
+export interface ReportMessageInput { reason: ReportReason; comment?: string; }
+```
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/moderationReportService.ts`
+  - `report(userId, messageId, input)` — 同一 (messageId, reporterId) が既にあれば 409 Conflict or 冪等扱い
+  - `listQueue(filter)` — 管理者用
+  - `dismiss(id, userId)` / `actionDelete(id, userId)` — トランザクションで message を `is_deleted = true` にしつつレポートも `actioned` に
+- `packages/server/src/routes/messages.ts`
+  - `POST /api/messages/:id/report` — 認証ユーザー（自分のメッセージには通報不可）
+- `packages/server/src/routes/admin.ts`
+  - `GET /api/admin/reports` / `POST /api/admin/reports/:id/dismiss` / `POST /api/admin/reports/:id/action`
+
+### 監査ログ
+- `report.create` / `report.dismiss` / `report.action.delete_message` を `AuditActionType` に追加
+
+## 6. クライアント変更
+
+### 新規ファイル
+- `packages/client/src/components/Chat/ReportMessageDialog.tsx`
+- `packages/client/src/components/Admin/ModerationQueue.tsx`
+
+### 変更ファイル
+- `packages/client/src/components/Chat/MessageActions.tsx`
+  - 「通報」メニュー追加（自分のメッセージは非表示）
+- `packages/client/src/pages/AdminPage.tsx`
+  - タブに「通報キュー」を追加
+- `packages/client/src/api/client.ts`
+  - `messages.report(id, input)` / `admin.reports.list` / `admin.reports.dismiss` / `admin.reports.action`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/moderationReport.test.ts`（通報・却下・アクション削除）
+   - client: `ReportMessageDialog.test.tsx` / `ModerationQueue.test.tsx` / `AdminPage.test.tsx` 追記
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- 自分のメッセージを通報すると 400
+- 同一メッセージへの二重通報は 409（または既存レコード返却で冪等）
+- 管理者以外は `/api/admin/reports` に 403
+- `action.delete_message` 後に該当メッセージが `is_deleted = true`
+- 通報が監査ログに記録される
+
+### クライアント
+- 通報ダイアログの理由選択 + コメント + 送信
+- モデレーションキューの一覧・対応操作
+- 対応済みは `status = actioned/dismissed` として表示切替
+
+## 9. 注意点
+
+- **プライバシー**: 通報者の ID は管理者にのみ見えるようにする（他ユーザーから不可視）
+- **グループ化表示**: 同一メッセージへの複数通報は 1 行にまとめて人数表示すると UX 向上（初版は個別行でも可）
+- **通報者への結果通知**: スコープ外でよい
+
+## 10. 見積もり / リスク
+
+- 規模: 中
+- リスク: `MessageActions.tsx` / `AdminPage.tsx` で #107 / #117 / #118 との同時変更。**後発 PR がリベースで調整** する運用で対応

--- a/doc/implementation-plans/117-ng-words-attachment-blocklist.md
+++ b/doc/implementation-plans/117-ng-words-attachment-blocklist.md
@@ -1,0 +1,138 @@
+# #117 NG ワード / 添付制限 — 実行計画
+
+- Issue: [#117](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/117)
+- 難易度: 中
+- ブランチ: `feature/ng-words-attachment-blocklist/#117`
+
+## 1. ゴール（受入条件）
+
+- 管理者が **NG ワードリスト** を登録・管理できる
+- 投稿時に NG ワードを検出した場合、以下のアクションから選択可能
+  - **block** — 送信を拒否（既定）
+  - **warn** — クライアントで警告ダイアログ表示（送信は可能）
+- 添付ファイルの **拡張子ブラックリスト** を管理できる（例: `exe`, `bat`, `cmd`）
+- ブラックリスト対象のアップロードは拒否される
+
+## 2. 依存・前提
+
+- 既存機能: `messageService.sendMessage`, `fileStorageService`（添付アップロード）, Admin routes
+- 他 Issue との衝突: `messageService.sendMessage` で **#113 / #107 / #110 / #116 と衝突しやすい**。順序調整必要
+
+## 3. スキーマ変更（`db/schema.hcl`）
+
+```hcl
+table "ng_words" {
+  schema  = schema.public
+  comment = "NG ワード"
+  column "id"         { null = false, type = serial }
+  column "pattern"    { null = false, type = text }   # 単純な文字列 or 正規表現
+  column "is_regex"   { null = false, type = boolean, default = false }
+  column "action"     { null = false, type = text, default = "block" }  # block / warn
+  column "is_active"  { null = false, type = boolean, default = true }
+  column "created_by" { null = true,  type = integer }
+  column "created_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  column "updated_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_ng_user" { columns = [column.created_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_ng_active" { columns = [column.is_active] }
+}
+
+table "attachment_blocklist" {
+  schema  = schema.public
+  comment = "添付拡張子ブロックリスト"
+  column "id"         { null = false, type = serial }
+  column "extension"  { null = false, type = text }   # ドット無しの小文字（exe, bat...）
+  column "reason"     { null = true,  type = text }
+  column "created_by" { null = true,  type = integer }
+  column "created_at" { null = false, type = timestamptz, default = sql("NOW()") }
+  primary_key { columns = [column.id] }
+  foreign_key "fk_ablk_user" { columns = [column.created_by], ref_columns = [table.users.column.id], on_delete = SET_NULL, on_update = NO_ACTION }
+  index "idx_ablk_ext" { unique = true, columns = [column.extension] }
+}
+```
+
+## 4. shared types
+
+```ts
+// packages/shared/src/types/moderation.ts 新規
+export type NgWordAction = 'block' | 'warn';
+export interface NgWord {
+  id: number; pattern: string; isRegex: boolean; action: NgWordAction;
+  isActive: boolean; createdAt: string; updatedAt: string;
+}
+export interface BlockedExtension { id: number; extension: string; reason: string | null; createdAt: string; }
+```
+
+## 5. サーバー変更
+
+### 新規ファイル
+- `packages/server/src/services/moderationService.ts`
+  - `listNgWords()` / `createNgWord(input, userId)` / `updateNgWord(id, input)` / `deleteNgWord(id)`
+  - `listBlockedExtensions()` / `createBlockedExtension(ext, userId)` / `deleteBlockedExtension(id)`
+  - `checkContent(content)` — 有効な NG ワードを先頭一致で評価し、`{ action: 'block'|'warn'|null, matched: string }` を返す
+  - **キャッシュ**: 毎回 SELECT は重いので、プロセス内で 30 秒 TTL キャッシュ
+- `packages/server/src/routes/moderation.ts`（admin サブルート）
+  - CRUD: `/api/admin/ng-words`, `/api/admin/attachment-blocklist`
+
+### 変更ファイル
+- `packages/server/src/services/messageService.ts`
+  - `sendMessage` 冒頭で `moderationService.checkContent`
+    - `block` なら 400 返却
+    - `warn` の扱い: サーバーでは送信許可、**レスポンスに `warning: string` を含める**。クライアント側で UX 実装
+- `packages/server/src/services/fileStorageService.ts`（または `channelAttachmentsService`）
+  - アップロード時に拡張子を抽出し、ブラックリスト照合
+- `packages/server/src/socket/messageHandler.ts`
+  - Socket 経由でも `checkContent` を必ず通す
+
+### 監査ログ
+- `moderation.ngword.create/update/delete`、`moderation.blocklist.add/remove` を記録
+
+## 6. クライアント変更
+
+### 変更ファイル
+- `packages/client/src/pages/AdminPage.tsx`
+  - 「モデレーション設定」タブを追加
+  - NG ワード管理テーブル（pattern / is_regex / action / is_active の編集）
+  - 拡張子ブロックリスト管理
+- `packages/client/src/components/Chat/RichEditor.tsx`
+  - 送信時にサーバーのレスポンスを確認し、`block` エラー or `warn` ならトースト表示
+- `packages/client/src/api/client.ts`
+  - `admin.ngWords.*` / `admin.blockedExtensions.*`
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. スキーマ変更 → atlas apply
+3. shared types 追加
+4. **テスト項目列挙**
+   - server: `__tests__/moderation.test.ts`（NG ワード判定 / 添付拒否 / キャッシュ）
+   - client: `AdminPage.test.tsx` 追記（モデレーション CRUD）、`MessageArea.test.tsx` 追記（送信拒否時のエラー表示）
+5. **ユーザー確認**
+6. テスト実装 → 実装 → build + test
+7. PR 作成
+
+## 8. テスト方針
+
+### サーバー
+- `block` ワードを含む投稿が 400 で拒否される
+- `warn` ワードを含む投稿は送信成功、レスポンスに `warning` を含む
+- `is_active = false` なワードは無視される
+- 正規表現モード（`is_regex = true`）で動作する
+- ブラックリスト拡張子のアップロードが拒否される（大文字拡張子も拒否）
+- キャッシュ期限切れ後に変更が反映される
+
+### クライアント
+- Admin 管理画面での CRUD
+- 送信時に `block` エラーを受けたら入力内容はそのまま残す（書き直しやすく）
+- `warn` 時の警告ダイアログ
+
+## 9. 注意点
+
+- **正規表現の安全性**: ユーザー（管理者）入力の正規表現は ReDoS の危険。`safe-regex` などで事前検証するか、タイムアウトを設ける（Node には正規表現タイムアウトがないので **`RE2` ライブラリ** もしくは文字列一致のみ許可が無難）→ MVP は **文字列一致のみ** で実装し、`is_regex` は将来拡張としてスキーマだけ用意する選択肢も可
+- **大文字・全角**: 正規化（lowercase + NFKC）してから照合する
+- **パフォーマンス**: NG ワードが多数あると O(N*M) になる。初版は件数 200 以下想定。Aho–Corasick など高速化は将来
+
+## 10. 見積もり / リスク
+
+- 規模: 中（2 テーブル + CRUD + 送信経路のチェック）
+- リスク: `messageService` への割り込みで他 Issue とコンフリクト。**#113 と同じブランチライフサイクル** で扱うことも検討

--- a/doc/implementation-plans/118-audit-log-export.md
+++ b/doc/implementation-plans/118-audit-log-export.md
@@ -1,0 +1,114 @@
+# #118 監査ログのエクスポート — 実行計画
+
+- Issue: [#118](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/118)
+- 難易度: 低
+- ブランチ: `feature/audit-log-export/#118`
+
+## 1. ゴール（受入条件）
+
+- 管理者が監査ログを CSV でダウンロードできる
+- 日付範囲（from / to）、アクション種別（action_type）でフィルタリング可能
+- 既存 `auditLogService.getAuditLogs` のフィルタと同仕様
+- CSV カラム: `id, created_at, actor_user_id, actor_username, action_type, target_type, target_id, metadata_json`
+- UI: `AuditLogView.tsx` に「CSV エクスポート」ボタンを追加。現在のフィルタ条件を引き継いでダウンロード
+
+## 2. 依存・前提
+
+- 既存機能: `auditLogService`（#85 でマージ済）、`AuditLogView.tsx`、`AdminPage.tsx`
+- 他 Issue との衝突: なし。#116 / #117 で新しい `action_type` が追加されてもエクスポート仕様は変わらない
+
+## 3. スキーマ変更
+
+なし。
+
+## 4. shared types 変更
+
+なし（既存 `AuditLog` を CSV に変換するだけ）。
+
+ただし、エクスポート API のクエリパラメータ型を追加しておくと型安全：
+
+```ts
+// packages/shared/src/types/auditLog.ts
+export interface AuditLogExportQuery {
+  from?: string;           // ISO8601
+  to?: string;             // ISO8601
+  actionType?: string;
+  actorUserId?: number;
+}
+```
+
+## 5. サーバー変更
+
+### 変更ファイル
+
+- `packages/server/src/services/auditLogService.ts`
+  - `streamAuditLogsCsv(filter, writer)` を追加（大量レコード対応で Node stream もしくは配列で OK）
+- `packages/server/src/controllers/adminController.ts`
+  - `exportAuditLogs(req, res, next)` を追加
+    - `Content-Type: text/csv; charset=utf-8`
+    - `Content-Disposition: attachment; filename="audit-logs-<YYYYMMDD-HHMMSS>.csv"`
+    - UTF-8 BOM を先頭に出力（Excel 対応）
+    - 既存 `listAuditLogs` のフィルタ整形を再利用
+- `packages/server/src/routes/admin.ts`
+  - `GET /api/admin/audit-logs/export` を追加（`requireAdmin` ミドルウェア適用）
+
+### CSV 出力の実装
+
+- `csv-stringify` などの外部ライブラリ導入は避け、**自前で RFC 4180 準拠のエスケープ** を実装（カンマ・改行・ダブルクォートのエスケープ）
+- metadata は `JSON.stringify` して 1 カラムに格納。改行は含まないので CSV 化は容易
+
+### 監査ログ記録
+
+- **エクスポート自体も監査対象**。`auditLogService.record({ actorUserId, actionType: 'audit.export', metadata: { filter } })` を呼ぶ
+- `AuditActionType` に `'audit.export'` を追加
+
+## 6. クライアント変更
+
+### 変更ファイル
+
+- `packages/client/src/components/AuditLogView.tsx`
+  - 「CSV エクスポート」ボタンを追加
+  - 現在のフィルタ条件から query string を組み立て、`window.open('/api/admin/audit-logs/export?...')` で新規タブダウンロード
+  - もしくは `fetch` + `Blob` でダウンロード（Cookie 認証なのでどちらでも可）
+- `packages/client/src/api/client.ts`
+  - `admin.exportAuditLogs(filter)` は URL 生成のみのヘルパーとして実装
+
+## 7. 実装手順
+
+1. ブランチ作成
+2. **テスト項目列挙**
+   - server: `__tests__/integration/adminController.test.ts` に「CSV エクスポート」の describe を追記
+   - client: `__tests__/AuditLogView.test.tsx` に「エクスポートボタン」テストを追記
+3. **ユーザー確認**
+4. テスト実装 → 実装
+5. 手動確認: CSV を Excel / Numbers で開いて文字化けしないか、metadata が壊れないか
+6. `npm run build && npm run test` → PR 作成
+
+## 8. テスト方針
+
+### サーバー
+
+- フィルタなし: 既存全件が CSV で返る
+- `from` / `to` で日付範囲が適用される
+- `action_type` フィルタで該当ログのみ返る
+- カンマ・改行・ダブルクォートを含む metadata が正しくエスケープされる
+- UTF-8 BOM が先頭にあり、日本語の actor_username が文字化けしない
+- 非管理者は 403
+- エクスポート実行が監査ログに `audit.export` として記録される
+
+### クライアント
+
+- 「エクスポート」ボタン押下でダウンロード用 URL が生成される（既存のフィルタ state を反映）
+- ダウンロード URL に `from` / `to` / `action_type` が入っている
+- （必要なら）ダウンロードイベントの発火確認
+
+## 9. 注意点
+
+- **大量データ対策**: 監査ログは将来的に数万件を超える可能性がある。全件メモリに載せず、`query` を使った cursor 読み出しまたはページング読み出しで書き出す設計を推奨（初回は 10 万件上限 + 警告で簡易対応してもよい。ただし設計の余地を確保）
+- `metadata` が `null` の場合は空文字で CSV 出力する
+- タイムゾーン: `created_at` は `timestamptz` なので UTC で出力するか、`Asia/Tokyo` に変換するかを決める。**UTC 固定 + 列名で明示** を推奨（`created_at_utc`）
+
+## 10. 見積もり / リスク
+
+- 規模: 小（新規エンドポイント 1 本 + ボタン 1 個）
+- リスク: CSV エスケープ不備で Excel が崩れる → ダブルクォート囲み + BOM + 改行統一（\r\n）で RFC 4180 準拠すれば安全

--- a/doc/implementation-plans/README.md
+++ b/doc/implementation-plans/README.md
@@ -1,0 +1,181 @@
+# Issue #107〜#118 実行計画（全体俯瞰）
+
+本ディレクトリは、`feat: メッセージ転送`〜`feat: 監査ログのエクスポート` の 12 Issue を **別セッションで個別実装** できるように切り分けた実行計画集である。
+
+各 Issue の詳細は対応する `<番号>-<kebab名>.md` を参照すること。セッション開始時はまず該当ファイルを読み、`AGENTS.md` の TDD フロー（テスト項目 → 確認 → 実装 → テスト）を厳守する。
+
+---
+
+## 1. 実装対象 Issue 一覧
+
+| # | タイトル | 難易度 | 主体 | 計画書 |
+|---|---|---|---|---|
+| [#107](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/107) | メッセージ転送 | 中 | メッセージ | [107-message-forward.md](107-message-forward.md) |
+| [#108](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/108) | 会話イベント投稿 | 中 | メッセージ | [108-event-post.md](108-event-post.md) |
+| [#109](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/109) | 通知設定のカスタマイズ | 中 | チャンネル | [109-channel-notification-settings.md](109-channel-notification-settings.md) |
+| [#110](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/110) | 予約送信 | 中 | メッセージ | [110-scheduled-message.md](110-scheduled-message.md) |
+| [#111](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/111) | メッセージテンプレート/定型文 | 低 | 入力支援 | [111-message-templates.md](111-message-templates.md) |
+| [#112](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/112) | 招待リンク | 中 | チャンネル | [112-invite-link.md](112-invite-link.md) |
+| [#113](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/113) | 投稿権限制御チャンネル | 中 | チャンネル | [113-channel-posting-permission.md](113-channel-posting-permission.md) |
+| [#114](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/114) | ワークスペース初回オンボーディング | 低 | オンボード | [114-onboarding.md](114-onboarding.md) |
+| [#115](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/115) | タグ機能 | 中 | 情報整理 | [115-tags.md](115-tags.md) |
+| [#116](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/116) | 通報 / モデレーションキュー | 中 | 運用管理 | [116-moderation-queue.md](116-moderation-queue.md) |
+| [#117](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/117) | NG ワード / 添付制限 | 中 | 運用管理 | [117-ng-words-attachment-blocklist.md](117-ng-words-attachment-blocklist.md) |
+| [#118](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/118) | 監査ログのエクスポート | 低 | 運用管理 | [118-audit-log-export.md](118-audit-log-export.md) |
+
+---
+
+## 2. Phase（推奨実装順）
+
+各 Phase 内は **並列実装可能**。Phase をまたぐ順序性は「衝突回避」と「依存機能の前提成立」を目的とする。
+
+### Phase 1 — 独立・低難易度（着手しやすい）
+
+- **#111** メッセージテンプレート／定型文
+- **#114** ワークスペース初回オンボーディング
+- **#118** 監査ログのエクスポート
+
+### Phase 2 — 中難易度・独立性高
+
+- **#109** 通知設定のカスタマイズ
+- **#110** 予約送信
+- **#112** 招待リンク
+- **#115** タグ機能
+
+### Phase 3 — メッセージ送信経路に影響
+
+- **#113** 投稿権限制御チャンネル（送信前チェック基盤）
+- **#117** NG ワード / 添付制限（送信前チェック基盤）
+- **#107** メッセージ転送
+- **#108** 会話イベント投稿
+- **#116** 通報 / モデレーションキュー
+
+> **ヒント**: Phase 3 は `messageService.sendMessage` や `MessageActions.tsx` で衝突しやすい。#113 と #117 を先にマージしてから、#107 / #108 / #116 に着手するとコンフリクトが減る。
+
+---
+
+## 3. ファイル競合マトリクス（主な共有ファイル）
+
+`◎` 大きく変更 / `○` 追記 / `-` 無関係
+
+| ファイル | 107 | 108 | 109 | 110 | 111 | 112 | 113 | 114 | 115 | 116 | 117 | 118 |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `db/schema.hcl` | ○ | ◎ | ○ | ◎ | ○ | ◎ | ○ | ○ | ◎ | ◎ | ◎ | - |
+| `packages/shared/src/types/*` | ○ | ◎ | ○ | ◎ | ○ | ◎ | ○ | ○ | ◎ | ◎ | ◎ | ○ |
+| `packages/shared/src/types/socket.ts` | ○ | ○ | ○ | ○ | - | ○ | - | - | ○ | ○ | ○ | - |
+| `packages/server/src/services/messageService.ts` | ◎ | - | - | ○ | - | - | ○ | - | ○ | - | ◎ | - |
+| `packages/server/src/routes/messages.ts` | ○ | - | - | - | - | - | ○ | - | ○ | ○ | ○ | - |
+| `packages/server/src/routes/channels.ts` | - | - | ○ | - | - | ○ | ○ | - | - | - | - | - |
+| `packages/server/src/routes/admin.ts` | - | - | - | - | - | - | - | - | - | ○ | ○ | ○ |
+| `packages/server/src/services/adminService.ts` | - | - | - | - | - | - | - | - | - | ○ | ○ | ○ |
+| `packages/server/src/services/auditLogService.ts` | - | - | - | - | - | - | - | - | - | ○ | - | ○ |
+| `packages/client/src/api/client.ts` | ○ | ○ | ○ | ○ | ○ | ○ | ○ | ○ | ○ | ○ | ○ | ○ |
+| `packages/client/src/components/Chat/MessageActions.tsx` | ◎ | - | - | - | - | - | - | - | ○ | ◎ | - | - |
+| `packages/client/src/components/Chat/MessageItem.tsx` | ○ | ○ | - | - | - | - | - | - | ○ | - | - | - |
+| `packages/client/src/components/Chat/RichEditor.tsx` | - | - | - | ○ | ○ | - | ○ | - | - | - | ○ | - |
+| `packages/client/src/components/Channel/ChannelItem.tsx` | - | - | ◎ | - | - | - | ○ | - | - | - | - | - |
+| `packages/client/src/components/Channel/CreateChannelDialog.tsx` | - | - | - | - | - | - | ◎ | - | - | - | - | - |
+| `packages/client/src/pages/AdminPage.tsx` | - | - | - | - | - | - | - | - | - | ○ | ○ | ○ |
+| `packages/client/src/pages/ChatPage.tsx` | ○ | ○ | ○ | ○ | - | - | - | ○ | - | - | - | - |
+| `packages/client/src/App.tsx` | - | - | - | - | - | ○ | - | ○ | - | - | - | - |
+
+**競合しやすいホットスポット**
+
+- `packages/shared/src/types/socket.ts` — Socket.IO のイベント契約。複数 PR が同時にイベントを追加すると必ず衝突する。マージ順を調整する。
+- `packages/client/src/api/client.ts` — 全 Issue が触る。マージ時に `git merge` の小さな衝突が起きやすい（新規メソッド追記だけなので機械的解決可能）。
+- `packages/client/src/components/Chat/MessageActions.tsx` — **#107（転送）と #116（通報）が同じ「...」メニュー** を取り合う。先にマージされた方に合わせる。
+- `packages/client/src/pages/AdminPage.tsx` — #116 / #117 / #118 が **タブ追加** で衝突。
+
+---
+
+## 4. 共通ルール（全 Issue 共通）
+
+各計画書の「実装手順」は以下のテンプレートを具体化したもの。セッション開始前に必ず確認する。
+
+### ブランチ命名
+
+```
+feature/<機能名kebab>/#<issue番号>
+```
+例: `feature/message-forward/#107`
+
+### 実装フロー（TDD）
+
+1. **ブランチ作成** `git checkout -b feature/xxx/#NNN`
+2. **DB スキーマ変更**（必要な場合）
+   - `db/schema.hcl` を編集
+   - `atlas schema apply --env local --dry-run` で差分確認
+   - `atlas schema apply --env local` で適用
+3. **shared types 追加** `packages/shared/src/types/*.ts`
+4. **テスト項目を列挙**（describe / it のネストのみ、中身は `// TODO`）
+5. **ユーザー確認**（必須。承認後にアサーションを書く）
+6. **テストコード実装** → **プログラム実装** → **テスト通過**
+7. `npm run build` と `npm run test` を全通過
+8. `.github/PULL_REQUEST_TEMPLATE.md` の全セクションを埋めて PR 作成
+
+### テスト配置
+
+- **サーバー**
+  - 単体: `packages/server/src/__tests__/unit/<name>.test.ts`
+  - 機能: `packages/server/src/__tests__/<name>.test.ts`
+  - 統合: `packages/server/src/__tests__/integration/<controller>.test.ts`
+- **クライアント**
+  - 既存コンポーネントへの追加: 既存テストに **追記**（例: `MessageItem.test.tsx`）
+  - 新規コンポーネント: 対応するファイル名で新規作成
+  - ネットワーク: `vi.mock('../api/client')`、Socket.IO: 手動モック
+
+### フロントエンド
+
+- React 19 の `use()` フック + `<Suspense>` を使い、`useEffect + fetch` は避ける
+- `use(promise)` に渡す Promise は `useState` または `useMemo` で安定化させる
+
+### 監査ログ
+
+- 管理者操作（ロール変更・チャンネル削除など）および本計画で新設する管理者操作（モデレーション対応・NG ワード更新・エクスポートなど）は `auditLogService.record()` を呼ぶ
+- 既存の `AuditActionType` 文字列リテラルに不足があれば `packages/shared/src/types/auditLog.ts` に追加する
+
+### 共通仕様
+
+- スナックバー: `doc/snackbar-spec.md`
+- DB テスト: `doc/db-test-guide.md`
+- 既存機能一覧: `doc/feature-ideas.md`
+
+---
+
+## 5. スキーマ変更サマリ（全 Issue 合計）
+
+| Issue | 新規テーブル | 既存テーブル変更 |
+|---|---|---|
+| #107 | （なし。`messages.forwarded_from_message_id` カラム追加で実装） | `messages` に `forwarded_from_message_id` 追加 |
+| #108 | `events`, `event_rsvps` | （なし） |
+| #109 | `channel_notification_settings` | （なし） |
+| #110 | `scheduled_messages` | （なし） |
+| #111 | `message_templates` | （なし） |
+| #112 | `invite_links`, `invite_link_uses` | （なし） |
+| #113 | （なし） | `channels` に `posting_permission` 追加 |
+| #114 | （なし） | `users` に `onboarding_completed_at` 追加 |
+| #115 | `tags`, `message_tags`, `channel_tags` | （なし） |
+| #116 | `message_reports` | （なし） |
+| #117 | `ng_words`, `attachment_blocklist` | （なし） |
+| #118 | （なし。エクスポートのみ） | （なし） |
+
+**重要**: 複数 Issue を並列で DB 変更すると `atlas schema apply` の差分が競合する可能性がある。**Phase 単位でマージしてから次の Phase に進む** か、Phase 内のローカル開発では各自が個別にスキーマ適用し、マージ後にメインブランチで `atlas schema apply` を必ず流す運用を徹底する。
+
+---
+
+## 6. セッション着手の手順（別セッション用）
+
+新しいセッションを開く人は、以下を順に行えばよい。
+
+1. 本 README で Phase と並列グループを確認する
+2. 対象 Issue の計画書（例 `107-message-forward.md`）を **冒頭から末尾まで読み通す**
+3. `AGENTS.md` と `CLAUDE.md`（プロジェクト / 個人）のルールを確認する
+4. `gh issue view <番号>` で最新コメントを確認する（受入条件の更新があるかも）
+5. 計画書の「実装手順」に従って TDD で進める
+6. 迷ったらユーザーへ質問（推測禁止）
+
+---
+
+## 7. 未着手の feature-ideas（Issue 化候補）
+
+本計画の範囲外だが、`doc/feature-ideas.md` 未チェック項目は将来 Issue 化の候補。今回の 12 Issue に依存しないので並行検討可能。


### PR DESCRIPTION
## 概要

Issue #107〜#118（`feat: メッセージ転送` 〜 `feat: 監査ログのエクスポート`）の 12 件について、別セッションで個別に TDD 実装できるよう実行計画ドキュメントを `doc/implementation-plans/` 配下に追加する。

## 変更内容

- `doc/implementation-plans/README.md` — 全体俯瞰（Phase 分割・並列実行グループ・ファイル競合マトリクス・共通ルール）
- `doc/implementation-plans/107-message-forward.md` — メッセージ転送
- `doc/implementation-plans/108-event-post.md` — 会話イベント投稿
- `doc/implementation-plans/109-channel-notification-settings.md` — チャンネル通知設定
- `doc/implementation-plans/110-scheduled-message.md` — 予約送信
- `doc/implementation-plans/111-message-templates.md` — メッセージテンプレート
- `doc/implementation-plans/112-invite-link.md` — 招待リンク
- `doc/implementation-plans/113-channel-posting-permission.md` — 投稿権限制御チャンネル
- `doc/implementation-plans/114-onboarding.md` — 初回オンボーディング
- `doc/implementation-plans/115-tags.md` — タグ機能
- `doc/implementation-plans/116-moderation-queue.md` — 通報 / モデレーションキュー
- `doc/implementation-plans/117-ng-words-attachment-blocklist.md` — NG ワード / 添付制限
- `doc/implementation-plans/118-audit-log-export.md` — 監査ログエクスポート

各計画書には以下を記載:
- ブランチ名（`AGENTS.md` のブランチ命名規則に準拠）
- 受入条件（Issue ゴールを具体化）
- DB スキーマ変更（`db/schema.hcl` の差分案）
- shared types / サーバー / クライアントの変更ファイルと設計方針
- TDD フローに沿った実装手順
- サーバー / クライアント双方のテスト方針
- 注意点・リスク・見積もり規模

## 影響範囲

- ドキュメント追加のみ。コード変更・DB スキーマ変更・設定変更なし
- 既存ドキュメント（`doc/feature-ideas.md` 等）との内容重複なし

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（**N/A**: コード変更なし）
- [x] バックエンドユニットテストがすべてパスする（**N/A**: コード変更なし）
- [x] ビルドが正常に完了すること（**N/A**: コード変更なし）
- [x] (手動確認の場合) 確認した手順やスクリーンショット
      → Markdown のリンク・テーブル整形を `doc/implementation-plans/README.md` で目視確認

## 関連Issue

Fixes #

（本 PR はドキュメント整備のため個別 Issue なし。対応対象 Issue は #107 / #108 / #109 / #110 / #111 / #112 / #113 / #114 / #115 / #116 / #117 / #118）

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている（**N/A**: ドキュメントのみ）
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（`doc/implementation-plans/README.md` を追加。既存 `CLAUDE.md` / `AGENTS.md` への追記は不要と判断）

🤖 Generated with [Claude Code](https://claude.com/claude-code)