### PR TITLE
docs: 実行計画の完了状態を反映（#111 / #114 / #118）

### DIFF
--- a/doc/implementation-plans/111-message-templates.md
+++ b/doc/implementation-plans/111-message-templates.md
@@ -3,6 +3,7 @@
 - Issue: [#111](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/111)
 - 難易度: 低
 - ブランチ: `feature/message-templates/#111`
+- **状態**: ✅ 完了（PR [#122](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/122) マージ済み）
 
 ## 1. ゴール（受入条件）
 

--- a/doc/implementation-plans/114-onboarding.md
+++ b/doc/implementation-plans/114-onboarding.md
@@ -3,6 +3,7 @@
 - Issue: [#114](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/114)
 - 難易度: 低
 - ブランチ: `feature/onboarding/#114`
+- **状態**: ✅ 完了（PR [#123](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/123) マージ済み）
 
 ## 1. ゴール（受入条件）
 

--- a/doc/implementation-plans/118-audit-log-export.md
+++ b/doc/implementation-plans/118-audit-log-export.md
@@ -3,6 +3,7 @@
 - Issue: [#118](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/118)
 - 難易度: 低
 - ブランチ: `feature/audit-log-export/#118`
+- **状態**: ✅ 完了（PR [#121](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/121) マージ済み）
 
 ## 1. ゴール（受入条件）
 

--- a/doc/implementation-plans/README.md
+++ b/doc/implementation-plans/README.md
@@ -8,20 +8,22 @@
 
 ## 1. 実装対象 Issue 一覧
 
-| # | タイトル | 難易度 | 主体 | 計画書 |
-|---|---|---|---|---|
-| [#107](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/107) | メッセージ転送 | 中 | メッセージ | [107-message-forward.md](107-message-forward.md) |
-| [#108](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/108) | 会話イベント投稿 | 中 | メッセージ | [108-event-post.md](108-event-post.md) |
-| [#109](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/109) | 通知設定のカスタマイズ | 中 | チャンネル | [109-channel-notification-settings.md](109-channel-notification-settings.md) |
-| [#110](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/110) | 予約送信 | 中 | メッセージ | [110-scheduled-message.md](110-scheduled-message.md) |
-| [#111](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/111) | メッセージテンプレート/定型文 | 低 | 入力支援 | [111-message-templates.md](111-message-templates.md) |
-| [#112](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/112) | 招待リンク | 中 | チャンネル | [112-invite-link.md](112-invite-link.md) |
-| [#113](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/113) | 投稿権限制御チャンネル | 中 | チャンネル | [113-channel-posting-permission.md](113-channel-posting-permission.md) |
-| [#114](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/114) | ワークスペース初回オンボーディング | 低 | オンボード | [114-onboarding.md](114-onboarding.md) |
-| [#115](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/115) | タグ機能 | 中 | 情報整理 | [115-tags.md](115-tags.md) |
-| [#116](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/116) | 通報 / モデレーションキュー | 中 | 運用管理 | [116-moderation-queue.md](116-moderation-queue.md) |
-| [#117](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/117) | NG ワード / 添付制限 | 中 | 運用管理 | [117-ng-words-attachment-blocklist.md](117-ng-words-attachment-blocklist.md) |
-| [#118](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/118) | 監査ログのエクスポート | 低 | 運用管理 | [118-audit-log-export.md](118-audit-log-export.md) |
+状態: ✅ 完了 / ⏳ 未着手
+
+| # | タイトル | 難易度 | 主体 | 状態 | PR | 計画書 |
+|---|---|---|---|---|---|---|
+| [#107](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/107) | メッセージ転送 | 中 | メッセージ | ⏳ | — | [107-message-forward.md](107-message-forward.md) |
+| [#108](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/108) | 会話イベント投稿 | 中 | メッセージ | ⏳ | — | [108-event-post.md](108-event-post.md) |
+| [#109](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/109) | 通知設定のカスタマイズ | 中 | チャンネル | ⏳ | — | [109-channel-notification-settings.md](109-channel-notification-settings.md) |
+| [#110](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/110) | 予約送信 | 中 | メッセージ | ⏳ | — | [110-scheduled-message.md](110-scheduled-message.md) |
+| [#111](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/111) | メッセージテンプレート/定型文 | 低 | 入力支援 | ✅ | [#122](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/122) | [111-message-templates.md](111-message-templates.md) |
+| [#112](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/112) | 招待リンク | 中 | チャンネル | ⏳ | — | [112-invite-link.md](112-invite-link.md) |
+| [#113](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/113) | 投稿権限制御チャンネル | 中 | チャンネル | ⏳ | — | [113-channel-posting-permission.md](113-channel-posting-permission.md) |
+| [#114](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/114) | ワークスペース初回オンボーディング | 低 | オンボード | ✅ | [#123](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/123) | [114-onboarding.md](114-onboarding.md) |
+| [#115](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/115) | タグ機能 | 中 | 情報整理 | ⏳ | — | [115-tags.md](115-tags.md) |
+| [#116](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/116) | 通報 / モデレーションキュー | 中 | 運用管理 | ⏳ | — | [116-moderation-queue.md](116-moderation-queue.md) |
+| [#117](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/117) | NG ワード / 添付制限 | 中 | 運用管理 | ⏳ | — | [117-ng-words-attachment-blocklist.md](117-ng-words-attachment-blocklist.md) |
+| [#118](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/118) | 監査ログのエクスポート | 低 | 運用管理 | ✅ | [#121](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/121) | [118-audit-log-export.md](118-audit-log-export.md) |
 
 ---
 
@@ -29,11 +31,11 @@
 
 各 Phase 内は **並列実装可能**。Phase をまたぐ順序性は「衝突回避」と「依存機能の前提成立」を目的とする。
 
-### Phase 1 — 独立・低難易度（着手しやすい）
+### Phase 1 — 独立・低難易度（着手しやすい） ✅ 完了
 
-- **#111** メッセージテンプレート／定型文
-- **#114** ワークスペース初回オンボーディング
-- **#118** 監査ログのエクスポート
+- **#111** ✅ メッセージテンプレート／定型文（PR #122 マージ済み）
+- **#114** ✅ ワークスペース初回オンボーディング（PR #123 マージ済み）
+- **#118** ✅ 監査ログのエクスポート（PR #121 マージ済み）
 
 ### Phase 2 — 中難易度・独立性高
 


### PR DESCRIPTION
## 概要

Phase 1 の 3 Issue（#111 メッセージテンプレート / #114 オンボーディング / #118 監査ログエクスポート）がマージ済みとなったため、実行計画ドキュメント一式を更新する。

## 変更内容

- `doc/implementation-plans/README.md`
  - Issue 一覧テーブルに「状態」列と「PR」列を追加
  - Phase 1 セクションに完了マーカー（✅）と PR 番号を追記
- `doc/implementation-plans/111-message-templates.md` / `114-onboarding.md` / `118-audit-log-export.md`
  - 冒頭メタデータに「状態: ✅ 完了（PR #XXX マージ済み）」を追加

## 影響範囲

- ドキュメントのみ。コードへの影響なし。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（変更なし）
- [x] バックエンドユニットテストがすべてパスする（変更なし）
- [x] ビルドが正常に完了すること（変更なし）
- [x] (手動確認の場合) 確認した手順やスクリーンショット — Markdown の表示に崩れがないことを diff で確認

## 関連Issue
Fixes #

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した