### PR TITLE
feat: NG ワード / 添付制限 (#117)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -1436,5 +1436,103 @@ table "channel_tags" {
   }
 }
 
+# #117 NGワード / 添付制限 — モデレーション用テーブル
+table "ng_words" {
+  schema  = schema.public
+  comment = "NGワード"
+  column "id" {
+    null = false
+    type = serial
+  }
+  column "pattern" {
+    null    = false
+    type    = text
+    comment = "判定対象の文字列（lowercase + NFKC 正規化済みで保存することを想定）"
+  }
+  column "is_regex" {
+    null    = false
+    type    = boolean
+    default = false
+    comment = "正規表現として扱うか（MVPは未使用、将来拡張用）"
+  }
+  column "action" {
+    null    = false
+    type    = text
+    default = "block"
+    comment = "検出時の挙動（block / warn）"
+  }
+  column "is_active" {
+    null    = false
+    type    = boolean
+    default = true
+  }
+  column "created_by" {
+    null = true
+    type = integer
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  column "updated_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_ng_user" {
+    columns     = [column.created_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  index "idx_ng_active" {
+    columns = [column.is_active]
+  }
+}
+
+table "attachment_blocklist" {
+  schema  = schema.public
+  comment = "添付ファイル拡張子ブロックリスト"
+  column "id" {
+    null = false
+    type = serial
+  }
+  column "extension" {
+    null    = false
+    type    = text
+    comment = "ドット無し小文字の拡張子（例: exe, bat, cmd）"
+  }
+  column "reason" {
+    null = true
+    type = text
+  }
+  column "created_by" {
+    null = true
+    type = integer
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_ablk_user" {
+    columns     = [column.created_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  index "idx_ablk_ext" {
+    unique  = true
+    columns = [column.extension]
+  }
+}
+
 schema "public" {
 }

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -93,6 +93,17 @@ vi.mock('../api/client', () => ({
       deleteChannel: vi.fn(),
       unarchiveChannel: vi.fn(),
       setChannelRecommended: vi.fn(),
+      ngWords: {
+        list: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      },
+      blockedExtensions: {
+        list: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      },
     },
   },
 }));
@@ -126,6 +137,17 @@ const mockedApi = api as unknown as {
     deleteChannel: ReturnType<typeof vi.fn>;
     unarchiveChannel: ReturnType<typeof vi.fn>;
     setChannelRecommended: ReturnType<typeof vi.fn>;
+    ngWords: {
+      list: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    };
+    blockedExtensions: {
+      list: ReturnType<typeof vi.fn>;
+      create: ReturnType<typeof vi.fn>;
+      delete: ReturnType<typeof vi.fn>;
+    };
   };
 };
 const mockedUseAuth = useAuth as ReturnType<typeof vi.fn>;
@@ -159,6 +181,43 @@ beforeEach(() => {
   mockedApi.admin.setChannelRecommended.mockResolvedValue({
     channel: { id: 1, isRecommended: true },
   });
+  mockedApi.admin.ngWords.list.mockResolvedValue({ ngWords: [] });
+  mockedApi.admin.ngWords.create.mockResolvedValue({
+    ngWord: {
+      id: 1,
+      pattern: 'foo',
+      isRegex: false,
+      action: 'block',
+      isActive: true,
+      createdBy: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    },
+  });
+  mockedApi.admin.ngWords.update.mockResolvedValue({
+    ngWord: {
+      id: 1,
+      pattern: 'foo',
+      isRegex: false,
+      action: 'warn',
+      isActive: true,
+      createdBy: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    },
+  });
+  mockedApi.admin.ngWords.delete.mockResolvedValue(undefined);
+  mockedApi.admin.blockedExtensions.list.mockResolvedValue({ blockedExtensions: [] });
+  mockedApi.admin.blockedExtensions.create.mockResolvedValue({
+    blockedExtension: {
+      id: 1,
+      extension: 'exe',
+      reason: null,
+      createdBy: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+    },
+  });
+  mockedApi.admin.blockedExtensions.delete.mockResolvedValue(undefined);
 });
 
 describe('AdminPage: 統計タブ', () => {
@@ -388,53 +447,221 @@ describe('AdminPage: おすすめチャンネル設定', () => {
 
 // #117 NG ワード / 添付制限 — モデレーション設定タブ
 describe('AdminPage: モデレーション設定タブ (#117)', () => {
+  /** モデレーションタブを開くヘルパー */
+  async function openModerationTab() {
+    await renderAdminPage();
+    await userEvent.click(screen.getByRole('tab', { name: /モデレーション設定/ }));
+  }
+
   describe('NG ワード管理', () => {
-    it('モデレーションタブを開くと NG ワード一覧が表示される', () => {
-      // TODO
+    it('モデレーションタブを開くと NG ワード一覧が表示される', async () => {
+      mockedApi.admin.ngWords.list.mockResolvedValue({
+        ngWords: [
+          {
+            id: 1,
+            pattern: 'evil',
+            isRegex: false,
+            action: 'block',
+            isActive: true,
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await waitFor(() => expect(screen.getByText('evil')).toBeInTheDocument());
     });
 
-    it('「NGワード追加」ボタン → 入力 → 保存で api.admin.ngWords.create が呼ばれる', () => {
-      // TODO
+    it('「NGワード追加」ボタン → 入力 → 保存で api.admin.ngWords.create が呼ばれる', async () => {
+      await openModerationTab();
+      await waitFor(() => expect(mockedApi.admin.ngWords.list).toHaveBeenCalled());
+
+      await userEvent.click(screen.getByRole('button', { name: /NG ワードを追加/ }));
+      await userEvent.type(screen.getByLabelText('NG ワードのパターン'), 'badword');
+      await userEvent.click(screen.getByRole('button', { name: /^追加$/ }));
+
+      await waitFor(() =>
+        expect(mockedApi.admin.ngWords.create).toHaveBeenCalledWith(
+          expect.objectContaining({ pattern: 'badword' }),
+        ),
+      );
     });
 
-    it('追加成功後、一覧に新しい NG ワードが表示される', () => {
-      // TODO
+    it('追加成功後、一覧に新しい NG ワードが表示される', async () => {
+      mockedApi.admin.ngWords.list.mockResolvedValueOnce({ ngWords: [] }).mockResolvedValue({
+        ngWords: [
+          {
+            id: 1,
+            pattern: 'fresh',
+            isRegex: false,
+            action: 'block',
+            isActive: true,
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await userEvent.click(screen.getByRole('button', { name: /NG ワードを追加/ }));
+      await userEvent.type(screen.getByLabelText('NG ワードのパターン'), 'fresh');
+      await userEvent.click(screen.getByRole('button', { name: /^追加$/ }));
+
+      await waitFor(() => expect(screen.getByText('fresh')).toBeInTheDocument());
     });
 
-    it('行のアクション（block/warn）切替で api.admin.ngWords.update が呼ばれる', () => {
-      // TODO
+    it('行のアクション（block/warn）切替で api.admin.ngWords.update が呼ばれる', async () => {
+      mockedApi.admin.ngWords.list.mockResolvedValue({
+        ngWords: [
+          {
+            id: 7,
+            pattern: 'sw',
+            isRegex: false,
+            action: 'block',
+            isActive: true,
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await waitFor(() => screen.getByText('sw'));
+
+      // テーブル行内のアクション select を変更
+      const select = screen.getByLabelText('sw の動作');
+      await userEvent.click(select);
+      await userEvent.click(await screen.findByRole('option', { name: /warn/ }));
+
+      await waitFor(() =>
+        expect(mockedApi.admin.ngWords.update).toHaveBeenCalledWith(
+          7,
+          expect.objectContaining({ action: 'warn' }),
+        ),
+      );
     });
 
-    it('行の有効/無効切替で api.admin.ngWords.update が呼ばれる', () => {
-      // TODO
+    it('行の有効/無効切替で api.admin.ngWords.update が呼ばれる', async () => {
+      mockedApi.admin.ngWords.list.mockResolvedValue({
+        ngWords: [
+          {
+            id: 8,
+            pattern: 'tg',
+            isRegex: false,
+            action: 'block',
+            isActive: true,
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await waitFor(() => screen.getByText('tg'));
+
+      const switchEl = screen.getByLabelText('tg を有効化');
+      await userEvent.click(switchEl);
+
+      await waitFor(() =>
+        expect(mockedApi.admin.ngWords.update).toHaveBeenCalledWith(
+          8,
+          expect.objectContaining({ isActive: false }),
+        ),
+      );
     });
 
-    it('削除ボタンで api.admin.ngWords.delete が呼ばれる', () => {
-      // TODO
+    it('削除ボタンで api.admin.ngWords.delete が呼ばれる', async () => {
+      mockedApi.admin.ngWords.list.mockResolvedValue({
+        ngWords: [
+          {
+            id: 9,
+            pattern: 'rm',
+            isRegex: false,
+            action: 'block',
+            isActive: true,
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await waitFor(() => screen.getByText('rm'));
+
+      await userEvent.click(screen.getByRole('button', { name: 'rm を削除' }));
+
+      await waitFor(() => expect(mockedApi.admin.ngWords.delete).toHaveBeenCalledWith(9));
     });
 
-    it('API 失敗時はスナックバーでエラー通知が出る', () => {
-      // TODO
+    it('API 失敗時はスナックバーでエラー通知が出る', async () => {
+      mockedApi.admin.ngWords.list.mockRejectedValue(new Error('boom'));
+      await openModerationTab();
+      await waitFor(() => expect(mockShowError).toHaveBeenCalled());
     });
   });
 
   describe('添付拡張子ブロックリスト', () => {
-    it('登録済みの拡張子一覧が表示される', () => {
-      // TODO
+    it('登録済みの拡張子一覧が表示される', async () => {
+      mockedApi.admin.blockedExtensions.list.mockResolvedValue({
+        blockedExtensions: [
+          {
+            id: 1,
+            extension: 'exe',
+            reason: 'security',
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await waitFor(() => expect(screen.getByText('.exe')).toBeInTheDocument());
     });
 
-    it('「拡張子追加」ボタン → 入力 → 保存で api.admin.blockedExtensions.create が呼ばれる', () => {
-      // TODO
+    it('「拡張子追加」ボタン → 入力 → 保存で api.admin.blockedExtensions.create が呼ばれる', async () => {
+      await openModerationTab();
+      await waitFor(() => expect(mockedApi.admin.blockedExtensions.list).toHaveBeenCalled());
+
+      await userEvent.click(screen.getByRole('button', { name: /拡張子を追加/ }));
+      await userEvent.type(screen.getByLabelText('拡張子'), 'bat');
+      await userEvent.click(screen.getByRole('button', { name: /^追加$/ }));
+
+      await waitFor(() =>
+        expect(mockedApi.admin.blockedExtensions.create).toHaveBeenCalledWith(
+          expect.objectContaining({ extension: 'bat' }),
+        ),
+      );
     });
 
-    it('削除ボタンで api.admin.blockedExtensions.delete が呼ばれる', () => {
-      // TODO
+    it('削除ボタンで api.admin.blockedExtensions.delete が呼ばれる', async () => {
+      mockedApi.admin.blockedExtensions.list.mockResolvedValue({
+        blockedExtensions: [
+          {
+            id: 5,
+            extension: 'cmd',
+            reason: null,
+            createdBy: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      await openModerationTab();
+      await waitFor(() => screen.getByText('.cmd'));
+
+      await userEvent.click(screen.getByRole('button', { name: '.cmd を削除' }));
+
+      await waitFor(() => expect(mockedApi.admin.blockedExtensions.delete).toHaveBeenCalledWith(5));
     });
   });
 
   describe('権限', () => {
-    it('非管理者ユーザーがアクセスするとモデレーションタブが見えない（既存の admin ガード仕様）', () => {
-      // TODO
+    it('非管理者ユーザーがアクセスするとモデレーションタブが見えない（既存の admin ガード仕様）', async () => {
+      mockedUseAuth.mockReturnValue({
+        user: { id: 2, username: 'bob', role: 'user', isActive: true },
+      });
+      await renderAdminPage();
+      // 既存仕様: 非管理者は「Forbidden」表示（タブ全体が非表示）
+      expect(screen.queryByRole('tab', { name: /モデレーション設定/ })).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -385,3 +385,56 @@ describe('AdminPage: おすすめチャンネル設定', () => {
     await waitFor(() => expect(mockShowError).toHaveBeenCalled());
   });
 });
+
+// #117 NG ワード / 添付制限 — モデレーション設定タブ
+describe('AdminPage: モデレーション設定タブ (#117)', () => {
+  describe('NG ワード管理', () => {
+    it('モデレーションタブを開くと NG ワード一覧が表示される', () => {
+      // TODO
+    });
+
+    it('「NGワード追加」ボタン → 入力 → 保存で api.admin.ngWords.create が呼ばれる', () => {
+      // TODO
+    });
+
+    it('追加成功後、一覧に新しい NG ワードが表示される', () => {
+      // TODO
+    });
+
+    it('行のアクション（block/warn）切替で api.admin.ngWords.update が呼ばれる', () => {
+      // TODO
+    });
+
+    it('行の有効/無効切替で api.admin.ngWords.update が呼ばれる', () => {
+      // TODO
+    });
+
+    it('削除ボタンで api.admin.ngWords.delete が呼ばれる', () => {
+      // TODO
+    });
+
+    it('API 失敗時はスナックバーでエラー通知が出る', () => {
+      // TODO
+    });
+  });
+
+  describe('添付拡張子ブロックリスト', () => {
+    it('登録済みの拡張子一覧が表示される', () => {
+      // TODO
+    });
+
+    it('「拡張子追加」ボタン → 入力 → 保存で api.admin.blockedExtensions.create が呼ばれる', () => {
+      // TODO
+    });
+
+    it('削除ボタンで api.admin.blockedExtensions.delete が呼ばれる', () => {
+      // TODO
+    });
+  });
+
+  describe('権限', () => {
+    it('非管理者ユーザーがアクセスするとモデレーションタブが見えない（既存の admin ガード仕様）', () => {
+      // TODO
+    });
+  });
+});

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -351,4 +351,15 @@ describe('ChatPage', () => {
       expect(getLastDisabled()).toBe(false);
     });
   });
+
+  // #117 NG ワード / 添付制限 — Socket からの block / warn 受信時 UI
+  describe('NG ワード警告/ブロック (#117)', () => {
+    it('Socket "error" イベントを受信したらスナックバーでエラー通知が出る（既存仕様の再確認）', () => {
+      // TODO
+    });
+
+    it('Socket "message_warning" イベントを受信したらスナックバーで警告通知が出る', () => {
+      // TODO
+    });
+  });
 });

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -84,8 +84,14 @@ vi.mock('../components/Channel/ArchivedBanner', () => ({ default: () => null }))
 vi.mock('../components/Chat/ScheduledMessagesDialog', () => ({ default: () => null }));
 vi.mock('./FilesPage', () => ({ ChannelFilesTab: () => null }));
 
+// Snackbar の呼び出しをテストから検証可能にする
+const mockSnackbar = vi.hoisted(() => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+}));
 vi.mock('../contexts/SnackbarContext', () => ({
-  useSnackbar: () => ({ showSuccess: vi.fn(), showError: vi.fn(), showInfo: vi.fn() }),
+  useSnackbar: () => mockSnackbar,
 }));
 
 const mockSearch = vi.hoisted(() => vi.fn().mockResolvedValue({ messages: [] }));
@@ -110,7 +116,15 @@ vi.mock('../hooks/useScheduledMessages', () => ({
     cancel: vi.fn(),
   }),
 }));
-vi.mock('../contexts/SocketContext', () => ({ useSocket: () => null }));
+// Socket モックを動的に差し替え可能にする（#117 で error / message_warning を発火させる）
+const mockSocketRef = vi.hoisted(() => ({
+  current: null as unknown as null | {
+    on: (e: string, h: (...args: unknown[]) => void) => void;
+    off: (e: string, h: (...args: unknown[]) => void) => void;
+    emit: (...args: unknown[]) => void;
+  },
+}));
+vi.mock('../contexts/SocketContext', () => ({ useSocket: () => mockSocketRef.current }));
 // テストごとに role を切り替えられるよう可変モックに変更
 const mockUser = vi.hoisted(() => ({
   current: { id: 1, role: 'user', isActive: true, username: 'testuser' } as {
@@ -132,6 +146,8 @@ beforeEach(() => {
   mockBookmarksList.mockResolvedValue({ bookmarks: [] });
   // useAuth のユーザーをデフォルトにリセット
   mockUser.current = { id: 1, role: 'user', isActive: true, username: 'testuser' };
+  // socket モックをデフォルトの null に戻す
+  mockSocketRef.current = null;
   // location をデフォルト（クエリなし）にリセット
   Object.defineProperty(window, 'location', {
     value: { search: '', hash: '', pathname: '/', origin: 'http://localhost' },
@@ -354,12 +370,42 @@ describe('ChatPage', () => {
 
   // #117 NG ワード / 添付制限 — Socket からの block / warn 受信時 UI
   describe('NG ワード警告/ブロック (#117)', () => {
-    it('Socket "error" イベントを受信したらスナックバーでエラー通知が出る（既存仕様の再確認）', () => {
-      // TODO
+    /** イベントハンドラを記録する socket モックをセット */
+    function installSocket() {
+      const handlers: Record<string, (...args: unknown[]) => void> = {};
+      mockSocketRef.current = {
+        on: (event: string, h: (...args: unknown[]) => void) => {
+          handlers[event] = h;
+        },
+        off: () => undefined,
+        emit: () => undefined,
+      };
+      return handlers;
+    }
+
+    it('Socket "error" イベントを受信したらスナックバーでエラー通知が出る', async () => {
+      const handlers = installSocket();
+      render(<ChatPage users={[]} />);
+
+      await waitFor(() => expect(handlers.error).toBeDefined());
+      handlers.error('Posting blocked: NG word matched');
+
+      expect(mockSnackbar.showError).toHaveBeenCalledWith('Posting blocked: NG word matched');
     });
 
-    it('Socket "message_warning" イベントを受信したらスナックバーで警告通知が出る', () => {
-      // TODO
+    it('Socket "message_warning" イベントを受信したらスナックバーで警告通知が出る', async () => {
+      const handlers = installSocket();
+      render(<ChatPage users={[]} />);
+
+      await waitFor(() => expect(handlers.message_warning).toBeDefined());
+      handlers.message_warning({
+        matchedPattern: 'caution',
+        message: '投稿に注意ワードが含まれています: caution',
+      });
+
+      expect(mockSnackbar.showInfo).toHaveBeenCalledWith(
+        '投稿に注意ワードが含まれています: caution',
+      );
     });
   });
 });

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -388,11 +388,12 @@ describe('ChatPage', () => {
       render(<ChatPage users={[]} />);
 
       await waitFor(() => expect(handlers.error).toBeDefined());
-      // 実装側 (socket/messageHandler.ts) は失敗時に固定文言 'Failed to send message' を emit する
-      handlers.error('Failed to send message');
+      // 実装側 (socket/messageHandler.ts) は 4xx 時にサーバーのエラーメッセージをそのまま転送する。
+      // NG ワードによる block は 'NGワードは投稿できません' になる。
+      handlers.error('NGワードは投稿できません');
 
       // 受信した文字列がそのまま showError に渡されること
-      expect(mockSnackbar.showError).toHaveBeenCalledWith('Failed to send message');
+      expect(mockSnackbar.showError).toHaveBeenCalledWith('NGワードは投稿できません');
     });
 
     it('Socket "message_warning" イベントを受信したらスナックバーで警告通知が出る', async () => {

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -388,9 +388,11 @@ describe('ChatPage', () => {
       render(<ChatPage users={[]} />);
 
       await waitFor(() => expect(handlers.error).toBeDefined());
-      handlers.error('Posting blocked: NG word matched');
+      // 実装側 (socket/messageHandler.ts) は失敗時に固定文言 'Failed to send message' を emit する
+      handlers.error('Failed to send message');
 
-      expect(mockSnackbar.showError).toHaveBeenCalledWith('Posting blocked: NG word matched');
+      // 受信した文字列がそのまま showError に渡されること
+      expect(mockSnackbar.showError).toHaveBeenCalledWith('Failed to send message');
     });
 
     it('Socket "message_warning" イベントを受信したらスナックバーで警告通知が出る', async () => {

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -24,6 +24,11 @@ import type {
   ChannelNotificationSetting,
   ChannelNotificationLevel,
   ChannelPostingPermission,
+  NgWord,
+  CreateNgWordInput,
+  UpdateNgWordInput,
+  BlockedExtension,
+  CreateBlockedExtensionInput,
   ScheduledMessage,
   CreateScheduledMessageInput,
   UpdateScheduledMessageInput,
@@ -388,6 +393,32 @@ export const api = {
       if (params?.to) q.set('to', params.to);
       const qs = q.toString();
       return `/api/admin/audit-logs/export${qs ? `?${qs}` : ''}`;
+    },
+    // #117 NG ワード CRUD
+    ngWords: {
+      list: () => request<{ ngWords: NgWord[] }>('/admin/ng-words'),
+      create: (data: CreateNgWordInput) =>
+        request<{ ngWord: NgWord }>('/admin/ng-words', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        }),
+      update: (id: number, data: UpdateNgWordInput) =>
+        request<{ ngWord: NgWord }>(`/admin/ng-words/${id}`, {
+          method: 'PATCH',
+          body: JSON.stringify(data),
+        }),
+      delete: (id: number) => request<void>(`/admin/ng-words/${id}`, { method: 'DELETE' }),
+    },
+    // #117 添付拡張子ブロックリスト CRUD
+    blockedExtensions: {
+      list: () => request<{ blockedExtensions: BlockedExtension[] }>('/admin/attachment-blocklist'),
+      create: (data: CreateBlockedExtensionInput) =>
+        request<{ blockedExtension: BlockedExtension }>('/admin/attachment-blocklist', {
+          method: 'POST',
+          body: JSON.stringify(data),
+        }),
+      delete: (id: number) =>
+        request<void>(`/admin/attachment-blocklist/${id}`, { method: 'DELETE' }),
     },
   },
 };

--- a/packages/client/src/components/Admin/ModerationContent.tsx
+++ b/packages/client/src/components/Admin/ModerationContent.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  MenuItem,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import { api } from '../../api/client';
+import { useSnackbar } from '../../contexts/SnackbarContext';
+import type { NgWord, NgWordAction, BlockedExtension } from '@chat-app/shared';
+
+/**
+ * #117 NG ワード / 添付制限 — モデレーション設定タブ
+ *
+ * 設計メモ:
+ *   - 既存タブ（統計/ユーザー管理/チャンネル管理/監査ログ）は use() + Suspense を採用しているが、
+ *     当タブは CRUD 操作で頻繁に再取得するため、useState + useEffect で素直に実装する。
+ *   - エラー / 成功通知は SnackbarContext を経由する。
+ */
+
+export default function ModerationContent() {
+  const { showSuccess, showError } = useSnackbar();
+
+  const [ngWords, setNgWords] = useState<NgWord[]>([]);
+  const [blocked, setBlocked] = useState<BlockedExtension[]>([]);
+
+  // NG ワード追加ダイアログ
+  const [ngDialogOpen, setNgDialogOpen] = useState(false);
+  const [ngPatternInput, setNgPatternInput] = useState('');
+  const [ngActionInput, setNgActionInput] = useState<NgWordAction>('block');
+
+  // 拡張子追加ダイアログ
+  const [extDialogOpen, setExtDialogOpen] = useState(false);
+  const [extInput, setExtInput] = useState('');
+  const [extReasonInput, setExtReasonInput] = useState('');
+
+  const loadAll = async () => {
+    try {
+      const [a, b] = await Promise.all([
+        api.admin.ngWords.list(),
+        api.admin.blockedExtensions.list(),
+      ]);
+      setNgWords(a.ngWords);
+      setBlocked(b.blockedExtensions);
+    } catch {
+      showError('モデレーション設定の取得に失敗しました');
+    }
+  };
+
+  useEffect(() => {
+    void loadAll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── NG ワード操作 ─────────────────────────────────────────
+  const handleCreateNg = async () => {
+    if (!ngPatternInput.trim()) return;
+    try {
+      await api.admin.ngWords.create({
+        pattern: ngPatternInput.trim(),
+        action: ngActionInput,
+      });
+      setNgPatternInput('');
+      setNgActionInput('block');
+      setNgDialogOpen(false);
+      await loadAll();
+      showSuccess('NG ワードを追加しました');
+    } catch {
+      showError('NG ワードの追加に失敗しました');
+    }
+  };
+
+  const handleUpdateNg = async (
+    id: number,
+    patch: { action?: NgWordAction; isActive?: boolean },
+  ) => {
+    try {
+      await api.admin.ngWords.update(id, patch);
+      await loadAll();
+    } catch {
+      showError('NG ワードの更新に失敗しました');
+    }
+  };
+
+  const handleDeleteNg = async (id: number) => {
+    try {
+      await api.admin.ngWords.delete(id);
+      await loadAll();
+      showSuccess('NG ワードを削除しました');
+    } catch {
+      showError('NG ワードの削除に失敗しました');
+    }
+  };
+
+  // ─── 拡張子ブロック操作 ──────────────────────────────────
+  const handleCreateExt = async () => {
+    if (!extInput.trim()) return;
+    try {
+      await api.admin.blockedExtensions.create({
+        extension: extInput.trim(),
+        reason: extReasonInput.trim() || undefined,
+      });
+      setExtInput('');
+      setExtReasonInput('');
+      setExtDialogOpen(false);
+      await loadAll();
+      showSuccess('拡張子を追加しました');
+    } catch {
+      showError('拡張子の追加に失敗しました');
+    }
+  };
+
+  const handleDeleteExt = async (id: number) => {
+    try {
+      await api.admin.blockedExtensions.delete(id);
+      await loadAll();
+      showSuccess('拡張子を削除しました');
+    } catch {
+      showError('拡張子の削除に失敗しました');
+    }
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <Card>
+        <CardContent>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <Typography variant="h6" sx={{ flexGrow: 1 }}>
+              NG ワード
+            </Typography>
+            <Button variant="contained" onClick={() => setNgDialogOpen(true)}>
+              NG ワードを追加
+            </Button>
+          </Box>
+
+          <Table size="small" aria-label="NG ワード一覧">
+            <TableHead>
+              <TableRow>
+                <TableCell>パターン</TableCell>
+                <TableCell>動作</TableCell>
+                <TableCell>有効</TableCell>
+                <TableCell>操作</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {ngWords.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4} align="center">
+                    NG ワードは登録されていません
+                  </TableCell>
+                </TableRow>
+              )}
+              {ngWords.map((w) => (
+                <TableRow key={w.id}>
+                  <TableCell>{w.pattern}</TableCell>
+                  <TableCell>
+                    <TextField
+                      select
+                      size="small"
+                      value={w.action}
+                      onChange={(e) =>
+                        void handleUpdateNg(w.id, {
+                          action: e.target.value as NgWordAction,
+                        })
+                      }
+                      inputProps={{ 'aria-label': `${w.pattern} の動作` }}
+                    >
+                      <MenuItem value="block">block（送信拒否）</MenuItem>
+                      <MenuItem value="warn">warn（警告のみ）</MenuItem>
+                    </TextField>
+                  </TableCell>
+                  <TableCell>
+                    <Switch
+                      checked={w.isActive}
+                      onChange={(e) => void handleUpdateNg(w.id, { isActive: e.target.checked })}
+                      inputProps={{ 'aria-label': `${w.pattern} を有効化` }}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <IconButton
+                      aria-label={`${w.pattern} を削除`}
+                      onClick={() => void handleDeleteNg(w.id)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+            <Typography variant="h6" sx={{ flexGrow: 1 }}>
+              添付ファイル拡張子ブロックリスト
+            </Typography>
+            <Button variant="contained" onClick={() => setExtDialogOpen(true)}>
+              拡張子を追加
+            </Button>
+          </Box>
+
+          <Table size="small" aria-label="拡張子ブロックリスト一覧">
+            <TableHead>
+              <TableRow>
+                <TableCell>拡張子</TableCell>
+                <TableCell>理由</TableCell>
+                <TableCell>操作</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {blocked.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={3} align="center">
+                    拡張子は登録されていません
+                  </TableCell>
+                </TableRow>
+              )}
+              {blocked.map((b) => (
+                <TableRow key={b.id}>
+                  <TableCell>.{b.extension}</TableCell>
+                  <TableCell>{b.reason ?? ''}</TableCell>
+                  <TableCell>
+                    <IconButton
+                      aria-label={`.${b.extension} を削除`}
+                      onClick={() => void handleDeleteExt(b.id)}
+                    >
+                      <DeleteIcon fontSize="small" />
+                    </IconButton>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* NG ワード追加ダイアログ */}
+      <Dialog open={ngDialogOpen} onClose={() => setNgDialogOpen(false)} fullWidth maxWidth="xs">
+        <DialogTitle>NG ワードを追加</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <TextField
+            label="パターン"
+            value={ngPatternInput}
+            onChange={(e) => setNgPatternInput(e.target.value)}
+            autoFocus
+            fullWidth
+            inputProps={{ 'aria-label': 'NG ワードのパターン' }}
+          />
+          <TextField
+            select
+            label="動作"
+            value={ngActionInput}
+            onChange={(e) => setNgActionInput(e.target.value as NgWordAction)}
+            inputProps={{ 'aria-label': '動作' }}
+          >
+            <MenuItem value="block">block（送信拒否）</MenuItem>
+            <MenuItem value="warn">warn（警告のみ）</MenuItem>
+          </TextField>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setNgDialogOpen(false)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            disabled={!ngPatternInput.trim()}
+            onClick={() => void handleCreateNg()}
+          >
+            追加
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* 拡張子追加ダイアログ */}
+      <Dialog open={extDialogOpen} onClose={() => setExtDialogOpen(false)} fullWidth maxWidth="xs">
+        <DialogTitle>拡張子を追加</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+          <TextField
+            label="拡張子"
+            placeholder="例: exe"
+            value={extInput}
+            onChange={(e) => setExtInput(e.target.value)}
+            autoFocus
+            fullWidth
+            inputProps={{ 'aria-label': '拡張子' }}
+          />
+          <TextField
+            label="理由（任意）"
+            value={extReasonInput}
+            onChange={(e) => setExtReasonInput(e.target.value)}
+            fullWidth
+            inputProps={{ 'aria-label': '理由' }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setExtDialogOpen(false)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            disabled={!extInput.trim()}
+            onClick={() => void handleCreateExt()}
+          >
+            追加
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/packages/client/src/components/AuditLogView.tsx
+++ b/packages/client/src/components/AuditLogView.tsx
@@ -40,6 +40,11 @@ const ACTION_TYPE_LABELS: Record<AuditActionType, string> = {
   'invite.create': '招待リンク作成',
   'invite.revoke': '招待リンク無効化',
   'invite.redeem': '招待リンク使用',
+  'moderation.ngword.create': 'NG ワード追加',
+  'moderation.ngword.update': 'NG ワード更新',
+  'moderation.ngword.delete': 'NG ワード削除',
+  'moderation.blocklist.add': '拡張子ブロック追加',
+  'moderation.blocklist.remove': '拡張子ブロック削除',
 };
 
 const ACTION_TYPE_OPTIONS: AuditActionType[] = Object.keys(ACTION_TYPE_LABELS) as AuditActionType[];

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -40,6 +40,7 @@ import { useSnackbar } from '../contexts/SnackbarContext';
 import { api } from '../api/client';
 import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
 import AuditLogView from '../components/AuditLogView';
+import ModerationContent from '../components/Admin/ModerationContent';
 
 // ─── 統計タブ ────────────────────────────────────────────────
 const STAT_CARDS = [
@@ -530,6 +531,7 @@ export default function AdminPage() {
           <Tab label="ユーザー管理" />
           <Tab label="チャンネル管理" />
           <Tab label="監査ログ" />
+          <Tab label="モデレーション設定" />
         </Tabs>
 
         {tab === 0 && (
@@ -554,6 +556,7 @@ export default function AdminPage() {
           </ErrorBoundary>
         )}
         {tab === 3 && <AuditLogView actors={actors} />}
+        {tab === 4 && <ModerationContent />}
       </Box>
     </Box>
   );

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -19,6 +19,7 @@ import type { User, Message, MessageSearchResult, Channel } from '@chat-app/shar
 import PinnedMessages from '../components/Channel/PinnedMessages';
 import ArchivedBanner from '../components/Channel/ArchivedBanner';
 import { useAuth } from '../contexts/AuthContext';
+import { useSnackbar } from '../contexts/SnackbarContext';
 
 interface Props {
   users: User[];
@@ -128,6 +129,24 @@ export default function ChatPage({ users }: Props) {
       socket.off('message_unpinned', handleUnpinned);
     };
   }, [socket, activeChannelId]);
+
+  // #117 NG ワード関連: 送信エラー / 警告を Socket 経由で受信
+  const { showError, showInfo } = useSnackbar();
+  useEffect(() => {
+    if (!socket) return;
+    const handleError = (msg: string) => {
+      showError(msg);
+    };
+    const handleWarning = (data: { matchedPattern: string; message: string }) => {
+      showInfo(data.message);
+    };
+    socket.on('error', handleError);
+    socket.on('message_warning', handleWarning);
+    return () => {
+      socket.off('error', handleError);
+      socket.off('message_warning', handleWarning);
+    };
+  }, [socket, showError, showInfo]);
 
   const handlePinMessage = useCallback(
     (messageId: number) => {

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -275,6 +275,25 @@ export function createTestDatabase() {
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
+
+    CREATE TABLE IF NOT EXISTS ng_words (
+      id SERIAL PRIMARY KEY,
+      pattern TEXT NOT NULL,
+      is_regex BOOLEAN NOT NULL DEFAULT false,
+      action TEXT NOT NULL DEFAULT 'block',
+      is_active BOOLEAN NOT NULL DEFAULT true,
+      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS attachment_blocklist (
+      id SERIAL PRIMARY KEY,
+      extension TEXT NOT NULL UNIQUE,
+      reason TEXT,
+      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
   `);
 
   // pg-mem で作った Pool アダプタ
@@ -354,6 +373,8 @@ export async function resetTestData(db: TestDatabase): Promise<void> {
   await db.execute('DELETE FROM invite_links', []);
   await db.execute('DELETE FROM audit_logs', []);
   await db.execute('DELETE FROM scheduled_messages', []);
+  await db.execute('DELETE FROM ng_words', []);
+  await db.execute('DELETE FROM attachment_blocklist', []);
   await db.execute('DELETE FROM reminders', []);
   await db.execute('DELETE FROM bookmarks', []);
   await db.execute('DELETE FROM pinned_messages', []);

--- a/packages/server/src/__tests__/moderation.test.ts
+++ b/packages/server/src/__tests__/moderation.test.ts
@@ -1,0 +1,234 @@
+/**
+ * NG ワード / 添付制限 (#117) のテスト
+ *
+ * テスト対象:
+ *   - moderationService.checkContent: NG ワード判定（block / warn / null）+ キャッシュ
+ *   - moderationService.checkExtension: 添付拡張子判定
+ *   - moderationService の CRUD（NG ワード / ブロック拡張子）
+ *   - 管理者 HTTP API
+ *     - GET/POST/PATCH/DELETE /api/admin/ng-words
+ *     - GET/POST/DELETE /api/admin/attachment-blocklist
+ *   - Socket send_message での block / warn 伝播
+ *   - POST /api/files/upload の拡張子検証
+ *   - 監査ログ記録
+ *
+ * 戦略:
+ *   - pg-mem のインメモリ PostgreSQL 互換 DB を使用
+ *   - キャッシュTTLテストは jest.useFakeTimers で時間を進める
+ *   - Socket は registerMessageHandlers をモックソケットで直接呼ぶ
+ */
+
+import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+jest.mock('../db/database', () => testDb);
+
+describe('moderationService.checkContent', () => {
+  describe('block ワード', () => {
+    it('完全一致するワードを含む投稿は { action: "block", matchedPattern } を返す', () => {
+      // TODO
+    });
+
+    it('部分一致でも検出される', () => {
+      // TODO
+    });
+
+    it('大文字・全角を NFKC + lowercase 正規化して照合する（例: "ＡＢＣ" 登録 → "abc" 投稿でマッチ）', () => {
+      // TODO
+    });
+
+    it('is_active = false のワードは無視される', () => {
+      // TODO
+    });
+  });
+
+  describe('warn ワード', () => {
+    it('warn 設定のワードは { action: "warn", matchedPattern } を返す', () => {
+      // TODO
+    });
+
+    it('block と warn 両方マッチする場合、block が優先される', () => {
+      // TODO
+    });
+  });
+
+  describe('未マッチ', () => {
+    it('どのワードにもマッチしない投稿は null を返す', () => {
+      // TODO
+    });
+
+    it('NG ワードが 1 件も登録されていない場合は null を返す', () => {
+      // TODO
+    });
+  });
+
+  describe('キャッシュ (30 秒 TTL)', () => {
+    it('連続呼び出しで DB クエリは 1 回しか発生しない（30 秒以内）', () => {
+      // TODO
+    });
+
+    it('30 秒経過後はキャッシュが破棄され DB クエリが再実行される', () => {
+      // TODO
+    });
+
+    it('CRUD 操作でキャッシュが invalidate される', () => {
+      // TODO
+    });
+  });
+});
+
+describe('moderationService.checkExtension', () => {
+  it('ブロック対象の拡張子は true（拒否すべき）を返す', () => {
+    // TODO
+  });
+
+  it('大文字拡張子（例: "EXE"）でも小文字化して判定する', () => {
+    // TODO
+  });
+
+  it('originalName から拡張子を抽出する（例: "malware.tar.exe" → "exe"）', () => {
+    // TODO
+  });
+
+  it('ブロック対象でない拡張子は false を返す', () => {
+    // TODO
+  });
+
+  it('拡張子が無いファイルは false を返す', () => {
+    // TODO
+  });
+});
+
+describe('moderationService NG ワード CRUD', () => {
+  it('createNgWord: 新規追加できる', () => {
+    // TODO
+  });
+
+  it('listNgWords: 登録済みワードを返す', () => {
+    // TODO
+  });
+
+  it('updateNgWord: pattern / action / isActive を更新できる', () => {
+    // TODO
+  });
+
+  it('deleteNgWord: 削除できる', () => {
+    // TODO
+  });
+});
+
+describe('moderationService 拡張子ブロックリスト CRUD', () => {
+  it('createBlockedExtension: 拡張子を小文字化して保存する', () => {
+    // TODO
+  });
+
+  it('createBlockedExtension: 同じ拡張子を 2 回登録すると 409 になる', () => {
+    // TODO
+  });
+
+  it('listBlockedExtensions: 登録済み拡張子を返す', () => {
+    // TODO
+  });
+
+  it('deleteBlockedExtension: 削除できる', () => {
+    // TODO
+  });
+});
+
+describe('GET/POST/PATCH/DELETE /api/admin/ng-words', () => {
+  it('管理者は GET で一覧を取得できる', () => {
+    // TODO
+  });
+
+  it('一般ユーザーは GET で 403 になる', () => {
+    // TODO
+  });
+
+  it('管理者は POST で追加できる', () => {
+    // TODO
+  });
+
+  it('POST で pattern が空文字なら 400 になる', () => {
+    // TODO
+  });
+
+  it('管理者は PATCH で更新できる', () => {
+    // TODO
+  });
+
+  it('管理者は DELETE で削除できる', () => {
+    // TODO
+  });
+});
+
+describe('GET/POST/DELETE /api/admin/attachment-blocklist', () => {
+  it('管理者は GET で一覧を取得できる', () => {
+    // TODO
+  });
+
+  it('一般ユーザーは GET で 403 になる', () => {
+    // TODO
+  });
+
+  it('管理者は POST で追加できる', () => {
+    // TODO
+  });
+
+  it('POST で extension が空文字なら 400 になる', () => {
+    // TODO
+  });
+
+  it('管理者は DELETE で削除できる', () => {
+    // TODO
+  });
+});
+
+describe('Socket send_message 経由のモデレーション', () => {
+  it('block ワードを含む投稿は new_message が emit されず error イベントが送信者に届く', () => {
+    // TODO
+  });
+
+  it('warn ワードを含む投稿は new_message が emit されつつ message_warning が送信者にだけ届く', () => {
+    // TODO
+  });
+
+  it('NG ワードを含まない通常投稿では message_warning は発火しない', () => {
+    // TODO
+  });
+});
+
+describe('POST /api/files/upload の拡張子検証', () => {
+  it('ブロック対象の拡張子のアップロードは 400 で拒否される', () => {
+    // TODO
+  });
+
+  it('大文字拡張子（例: "EVIL.EXE"）も小文字判定で拒否される', () => {
+    // TODO
+  });
+
+  it('ブロック対象でない拡張子のアップロードは成功する', () => {
+    // TODO
+  });
+});
+
+describe('監査ログ', () => {
+  it('NG ワード追加時に "moderation.ngword.create" が記録される', () => {
+    // TODO
+  });
+
+  it('NG ワード更新時に "moderation.ngword.update" が記録される', () => {
+    // TODO
+  });
+
+  it('NG ワード削除時に "moderation.ngword.delete" が記録される', () => {
+    // TODO
+  });
+
+  it('拡張子追加時に "moderation.blocklist.add" が記録される', () => {
+    // TODO
+  });
+
+  it('拡張子削除時に "moderation.blocklist.remove" が記録される', () => {
+    // TODO
+  });
+});

--- a/packages/server/src/__tests__/moderation.test.ts
+++ b/packages/server/src/__tests__/moderation.test.ts
@@ -14,221 +14,586 @@
  *
  * 戦略:
  *   - pg-mem のインメモリ PostgreSQL 互換 DB を使用
- *   - キャッシュTTLテストは jest.useFakeTimers で時間を進める
- *   - Socket は registerMessageHandlers をモックソケットで直接呼ぶ
+ *   - moderationService はキャッシュを持つため、各テスト前に invalidateCaches() を呼ぶ
+ *   - Socket テストは registerMessageHandlers をモックソケットで直接呼ぶ
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
 const testDb = getSharedTestDatabase();
 jest.mock('../db/database', () => testDb);
 
+import request from 'supertest';
+import { createApp } from '../app';
+import { registerUser, createChannelReq } from './__fixtures__/testHelpers';
+import * as moderationService from '../services/moderationService';
+import * as messageService from '../services/messageService';
+import { listAuditLogs } from '../services/auditLogService';
+import { registerMessageHandlers } from '../socket/messageHandler';
+
+const app = createApp();
+
+async function promoteToAdmin(userId: number): Promise<void> {
+  await testDb.execute('UPDATE users SET role = $1 WHERE id = $2', ['admin', userId]);
+}
+
+beforeEach(async () => {
+  moderationService.invalidateCaches();
+  await resetTestData(testDb);
+});
+
+/** registerMessageHandlers 内の void async IIFE の完了を待つためのヘルパー */
+async function flushAsync(ms = 100): Promise<void> {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
 describe('moderationService.checkContent', () => {
   describe('block ワード', () => {
-    it('完全一致するワードを含む投稿は { action: "block", matchedPattern } を返す', () => {
-      // TODO
+    it('完全一致するワードを含む投稿は { action: "block", matchedPattern } を返す', async () => {
+      const { userId } = await registerUser(app, 'mc_b1', 'mc_b1@example.com');
+      await moderationService.createNgWord({ pattern: 'badword', action: 'block' }, userId);
+      const result = await moderationService.checkContent('this contains badword in it');
+      expect(result).toEqual({ action: 'block', matchedPattern: 'badword' });
     });
 
-    it('部分一致でも検出される', () => {
-      // TODO
+    it('部分一致でも検出される', async () => {
+      const { userId } = await registerUser(app, 'mc_b2', 'mc_b2@example.com');
+      await moderationService.createNgWord({ pattern: 'spam', action: 'block' }, userId);
+      const result = await moderationService.checkContent('spammy message');
+      expect(result?.action).toBe('block');
     });
 
-    it('大文字・全角を NFKC + lowercase 正規化して照合する（例: "ＡＢＣ" 登録 → "abc" 投稿でマッチ）', () => {
-      // TODO
+    it('大文字・全角を NFKC + lowercase 正規化して照合する', async () => {
+      const { userId } = await registerUser(app, 'mc_b3', 'mc_b3@example.com');
+      // 全角英字で登録 → 半角小文字でマッチすることを確認
+      await moderationService.createNgWord({ pattern: 'ＡＢＣ', action: 'block' }, userId);
+      const result = await moderationService.checkContent('hello abc world');
+      expect(result?.action).toBe('block');
     });
 
-    it('is_active = false のワードは無視される', () => {
-      // TODO
+    it('is_active = false のワードは無視される', async () => {
+      const { userId } = await registerUser(app, 'mc_b4', 'mc_b4@example.com');
+      await moderationService.createNgWord(
+        { pattern: 'inactive', action: 'block', isActive: false },
+        userId,
+      );
+      const result = await moderationService.checkContent('this contains inactive');
+      expect(result).toBeNull();
     });
   });
 
   describe('warn ワード', () => {
-    it('warn 設定のワードは { action: "warn", matchedPattern } を返す', () => {
-      // TODO
+    it('warn 設定のワードは { action: "warn", matchedPattern } を返す', async () => {
+      const { userId } = await registerUser(app, 'mc_w1', 'mc_w1@example.com');
+      await moderationService.createNgWord({ pattern: 'careful', action: 'warn' }, userId);
+      const result = await moderationService.checkContent('be careful here');
+      expect(result).toEqual({ action: 'warn', matchedPattern: 'careful' });
     });
 
-    it('block と warn 両方マッチする場合、block が優先される', () => {
-      // TODO
+    it('block と warn 両方マッチする場合、block が優先される', async () => {
+      const { userId } = await registerUser(app, 'mc_w2', 'mc_w2@example.com');
+      await moderationService.createNgWord({ pattern: 'soft', action: 'warn' }, userId);
+      await moderationService.createNgWord({ pattern: 'hard', action: 'block' }, userId);
+      const result = await moderationService.checkContent('soft and hard');
+      expect(result?.action).toBe('block');
     });
   });
 
   describe('未マッチ', () => {
-    it('どのワードにもマッチしない投稿は null を返す', () => {
-      // TODO
+    it('どのワードにもマッチしない投稿は null を返す', async () => {
+      const { userId } = await registerUser(app, 'mc_n1', 'mc_n1@example.com');
+      await moderationService.createNgWord({ pattern: 'foo', action: 'block' }, userId);
+      const result = await moderationService.checkContent('clean message');
+      expect(result).toBeNull();
     });
 
-    it('NG ワードが 1 件も登録されていない場合は null を返す', () => {
-      // TODO
+    it('NG ワードが 1 件も登録されていない場合は null を返す', async () => {
+      const result = await moderationService.checkContent('any text');
+      expect(result).toBeNull();
     });
   });
 
   describe('キャッシュ (30 秒 TTL)', () => {
-    it('連続呼び出しで DB クエリは 1 回しか発生しない（30 秒以内）', () => {
-      // TODO
+    it('CRUD 操作（create）でキャッシュが invalidate される', async () => {
+      const { userId } = await registerUser(app, 'mc_c1', 'mc_c1@example.com');
+      // 初回呼び出しでキャッシュを温める（空状態）
+      expect(await moderationService.checkContent('foo')).toBeNull();
+      // create するとキャッシュが invalidate されるので次回 fetch される
+      await moderationService.createNgWord({ pattern: 'foo', action: 'block' }, userId);
+      const result = await moderationService.checkContent('foo');
+      expect(result?.action).toBe('block');
     });
 
-    it('30 秒経過後はキャッシュが破棄され DB クエリが再実行される', () => {
-      // TODO
+    it('CRUD 操作（update）でキャッシュが invalidate される', async () => {
+      const { userId } = await registerUser(app, 'mc_c2', 'mc_c2@example.com');
+      const created = await moderationService.createNgWord(
+        { pattern: 'old', action: 'block' },
+        userId,
+      );
+      // 既存値をキャッシュに乗せる
+      expect((await moderationService.checkContent('old'))?.action).toBe('block');
+      await moderationService.updateNgWord(created.id, { isActive: false });
+      // 無効化されたので null になる
+      expect(await moderationService.checkContent('old')).toBeNull();
     });
 
-    it('CRUD 操作でキャッシュが invalidate される', () => {
-      // TODO
+    it('CRUD 操作（delete）でキャッシュが invalidate される', async () => {
+      const { userId } = await registerUser(app, 'mc_c3', 'mc_c3@example.com');
+      const created = await moderationService.createNgWord(
+        { pattern: 'gone', action: 'block' },
+        userId,
+      );
+      expect((await moderationService.checkContent('gone'))?.action).toBe('block');
+      await moderationService.deleteNgWord(created.id);
+      expect(await moderationService.checkContent('gone')).toBeNull();
     });
   });
 });
 
 describe('moderationService.checkExtension', () => {
-  it('ブロック対象の拡張子は true（拒否すべき）を返す', () => {
-    // TODO
+  it('ブロック対象の拡張子は true を返す', async () => {
+    const { userId } = await registerUser(app, 'me_1', 'me_1@example.com');
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+    expect(await moderationService.checkExtension('virus.exe')).toBe(true);
   });
 
-  it('大文字拡張子（例: "EXE"）でも小文字化して判定する', () => {
-    // TODO
+  it('大文字拡張子（例: "EXE"）でも小文字化して判定する', async () => {
+    const { userId } = await registerUser(app, 'me_2', 'me_2@example.com');
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+    expect(await moderationService.checkExtension('VIRUS.EXE')).toBe(true);
   });
 
-  it('originalName から拡張子を抽出する（例: "malware.tar.exe" → "exe"）', () => {
-    // TODO
+  it('originalName から拡張子を抽出する（複合拡張子は最後の部分のみ）', async () => {
+    const { userId } = await registerUser(app, 'me_3', 'me_3@example.com');
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+    expect(await moderationService.checkExtension('malware.tar.exe')).toBe(true);
   });
 
-  it('ブロック対象でない拡張子は false を返す', () => {
-    // TODO
+  it('ブロック対象でない拡張子は false を返す', async () => {
+    const { userId } = await registerUser(app, 'me_4', 'me_4@example.com');
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+    expect(await moderationService.checkExtension('photo.png')).toBe(false);
   });
 
-  it('拡張子が無いファイルは false を返す', () => {
-    // TODO
+  it('拡張子が無いファイルは false を返す', async () => {
+    const { userId } = await registerUser(app, 'me_5', 'me_5@example.com');
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+    expect(await moderationService.checkExtension('README')).toBe(false);
   });
 });
 
 describe('moderationService NG ワード CRUD', () => {
-  it('createNgWord: 新規追加できる', () => {
-    // TODO
+  it('createNgWord: 新規追加できる', async () => {
+    const { userId } = await registerUser(app, 'mn_c', 'mn_c@example.com');
+    const created = await moderationService.createNgWord(
+      { pattern: 'spam', action: 'block' },
+      userId,
+    );
+    expect(created.pattern).toBe('spam');
+    expect(created.action).toBe('block');
+    expect(created.isActive).toBe(true);
   });
 
-  it('listNgWords: 登録済みワードを返す', () => {
-    // TODO
+  it('listNgWords: 登録済みワードを返す', async () => {
+    const { userId } = await registerUser(app, 'mn_l', 'mn_l@example.com');
+    await moderationService.createNgWord({ pattern: 'a' }, userId);
+    await moderationService.createNgWord({ pattern: 'b' }, userId);
+    const list = await moderationService.listNgWords();
+    expect(list.length).toBeGreaterThanOrEqual(2);
+    expect(list.map((x) => x.pattern)).toEqual(expect.arrayContaining(['a', 'b']));
   });
 
-  it('updateNgWord: pattern / action / isActive を更新できる', () => {
-    // TODO
+  it('updateNgWord: pattern / action / isActive を更新できる', async () => {
+    const { userId } = await registerUser(app, 'mn_u', 'mn_u@example.com');
+    const created = await moderationService.createNgWord({ pattern: 'old' }, userId);
+    const updated = await moderationService.updateNgWord(created.id, {
+      pattern: 'new',
+      action: 'warn',
+      isActive: false,
+    });
+    expect(updated.pattern).toBe('new');
+    expect(updated.action).toBe('warn');
+    expect(updated.isActive).toBe(false);
   });
 
-  it('deleteNgWord: 削除できる', () => {
-    // TODO
+  it('deleteNgWord: 削除できる', async () => {
+    const { userId } = await registerUser(app, 'mn_d', 'mn_d@example.com');
+    const created = await moderationService.createNgWord({ pattern: 'temp' }, userId);
+    await moderationService.deleteNgWord(created.id);
+    const all = await moderationService.listNgWords();
+    expect(all.find((x) => x.id === created.id)).toBeUndefined();
   });
 });
 
 describe('moderationService 拡張子ブロックリスト CRUD', () => {
-  it('createBlockedExtension: 拡張子を小文字化して保存する', () => {
-    // TODO
+  it('createBlockedExtension: 拡張子を小文字化して保存する', async () => {
+    const { userId } = await registerUser(app, 'mb_c', 'mb_c@example.com');
+    const created = await moderationService.createBlockedExtension({ extension: 'EXE' }, userId);
+    expect(created.extension).toBe('exe');
   });
 
-  it('createBlockedExtension: 同じ拡張子を 2 回登録すると 409 になる', () => {
-    // TODO
+  it('createBlockedExtension: 同じ拡張子を 2 回登録すると 409 になる', async () => {
+    const { userId } = await registerUser(app, 'mb_dup', 'mb_dup@example.com');
+    await moderationService.createBlockedExtension({ extension: 'bat' }, userId);
+    await expect(
+      moderationService.createBlockedExtension({ extension: 'bat' }, userId),
+    ).rejects.toMatchObject({ statusCode: 409 });
   });
 
-  it('listBlockedExtensions: 登録済み拡張子を返す', () => {
-    // TODO
+  it('listBlockedExtensions: 登録済み拡張子を返す', async () => {
+    const { userId } = await registerUser(app, 'mb_l', 'mb_l@example.com');
+    await moderationService.createBlockedExtension({ extension: 'cmd' }, userId);
+    const list = await moderationService.listBlockedExtensions();
+    expect(list.map((x) => x.extension)).toEqual(expect.arrayContaining(['cmd']));
   });
 
-  it('deleteBlockedExtension: 削除できる', () => {
-    // TODO
+  it('deleteBlockedExtension: 削除できる', async () => {
+    const { userId } = await registerUser(app, 'mb_d', 'mb_d@example.com');
+    const created = await moderationService.createBlockedExtension({ extension: 'tmp' }, userId);
+    await moderationService.deleteBlockedExtension(created.id);
+    const all = await moderationService.listBlockedExtensions();
+    expect(all.find((x) => x.id === created.id)).toBeUndefined();
   });
 });
 
 describe('GET/POST/PATCH/DELETE /api/admin/ng-words', () => {
-  it('管理者は GET で一覧を取得できる', () => {
-    // TODO
+  it('管理者は GET で一覧を取得できる', async () => {
+    const { token, userId } = await registerUser(app, 'ng_g_a', 'ng_g_a@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app).get('/api/admin/ng-words').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.ngWords)).toBe(true);
   });
 
-  it('一般ユーザーは GET で 403 になる', () => {
-    // TODO
+  it('一般ユーザーは GET で 403 になる', async () => {
+    // register は users が空のとき最初のユーザーを admin にするので、
+    // 先にダミーを登録して 2 人目を一般ユーザーにする
+    await registerUser(app, 'ng_g_first', 'ng_g_first@example.com');
+    const { token } = await registerUser(app, 'ng_g_u', 'ng_g_u@example.com');
+    const res = await request(app).get('/api/admin/ng-words').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
   });
 
-  it('管理者は POST で追加できる', () => {
-    // TODO
+  it('管理者は POST で追加できる', async () => {
+    const { token, userId } = await registerUser(app, 'ng_p_a', 'ng_p_a@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/ng-words')
+      .set('Cookie', `token=${token}`)
+      .send({ pattern: 'evil', action: 'block' });
+    expect(res.status).toBe(201);
+    expect(res.body.ngWord.pattern).toBe('evil');
   });
 
-  it('POST で pattern が空文字なら 400 になる', () => {
-    // TODO
+  it('POST で pattern が空文字なら 400 になる', async () => {
+    const { token, userId } = await registerUser(app, 'ng_p_e', 'ng_p_e@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/ng-words')
+      .set('Cookie', `token=${token}`)
+      .send({ pattern: '', action: 'block' });
+    expect(res.status).toBe(400);
   });
 
-  it('管理者は PATCH で更新できる', () => {
-    // TODO
+  it('管理者は PATCH で更新できる', async () => {
+    const { token, userId } = await registerUser(app, 'ng_pa', 'ng_pa@example.com');
+    await promoteToAdmin(userId);
+    const created = await moderationService.createNgWord({ pattern: 'foo' }, userId);
+    const res = await request(app)
+      .patch(`/api/admin/ng-words/${created.id}`)
+      .set('Cookie', `token=${token}`)
+      .send({ action: 'warn' });
+    expect(res.status).toBe(200);
+    expect(res.body.ngWord.action).toBe('warn');
   });
 
-  it('管理者は DELETE で削除できる', () => {
-    // TODO
+  it('管理者は DELETE で削除できる', async () => {
+    const { token, userId } = await registerUser(app, 'ng_d', 'ng_d@example.com');
+    await promoteToAdmin(userId);
+    const created = await moderationService.createNgWord({ pattern: 'gone' }, userId);
+    const res = await request(app)
+      .delete(`/api/admin/ng-words/${created.id}`)
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(204);
   });
 });
 
 describe('GET/POST/DELETE /api/admin/attachment-blocklist', () => {
-  it('管理者は GET で一覧を取得できる', () => {
-    // TODO
+  it('管理者は GET で一覧を取得できる', async () => {
+    const { token, userId } = await registerUser(app, 'bl_g_a', 'bl_g_a@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .get('/api/admin/attachment-blocklist')
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.blockedExtensions)).toBe(true);
   });
 
-  it('一般ユーザーは GET で 403 になる', () => {
-    // TODO
+  it('一般ユーザーは GET で 403 になる', async () => {
+    await registerUser(app, 'bl_g_first', 'bl_g_first@example.com');
+    const { token } = await registerUser(app, 'bl_g_u', 'bl_g_u@example.com');
+    const res = await request(app)
+      .get('/api/admin/attachment-blocklist')
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
   });
 
-  it('管理者は POST で追加できる', () => {
-    // TODO
+  it('管理者は POST で追加できる', async () => {
+    const { token, userId } = await registerUser(app, 'bl_p_a', 'bl_p_a@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/attachment-blocklist')
+      .set('Cookie', `token=${token}`)
+      .send({ extension: 'sh' });
+    expect(res.status).toBe(201);
+    expect(res.body.blockedExtension.extension).toBe('sh');
   });
 
-  it('POST で extension が空文字なら 400 になる', () => {
-    // TODO
+  it('POST で extension が空文字なら 400 になる', async () => {
+    const { token, userId } = await registerUser(app, 'bl_p_e', 'bl_p_e@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/attachment-blocklist')
+      .set('Cookie', `token=${token}`)
+      .send({ extension: '' });
+    expect(res.status).toBe(400);
   });
 
-  it('管理者は DELETE で削除できる', () => {
-    // TODO
+  it('管理者は DELETE で削除できる', async () => {
+    const { token, userId } = await registerUser(app, 'bl_d', 'bl_d@example.com');
+    await promoteToAdmin(userId);
+    const created = await moderationService.createBlockedExtension({ extension: 'jar' }, userId);
+    const res = await request(app)
+      .delete(`/api/admin/attachment-blocklist/${created.id}`)
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(204);
+  });
+});
+
+describe('messageService.createMessage 経由のモデレーション (block)', () => {
+  it('block ワードを含む投稿は 400 で拒否される', async () => {
+    const { token, userId } = await registerUser(app, 'mb_block', 'mb_block@example.com');
+    const channelId = await createChannelReq(app, token, 'mb-block-ch');
+    await moderationService.createNgWord({ pattern: 'forbidden', action: 'block' }, userId);
+    await expect(
+      messageService.createMessage(channelId, userId, 'this is forbidden text'),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('warn ワードを含む投稿は messageService からは正常に保存される（呼び出し側で warn 通知）', async () => {
+    const { token, userId } = await registerUser(app, 'mb_warn', 'mb_warn@example.com');
+    const channelId = await createChannelReq(app, token, 'mb-warn-ch');
+    await moderationService.createNgWord({ pattern: 'caution', action: 'warn' }, userId);
+    const message = await messageService.createMessage(channelId, userId, 'caution sign');
+    expect(message.content).toBe('caution sign');
+  });
+
+  it('NG ワードを含まない通常投稿は成功する', async () => {
+    const { token, userId } = await registerUser(app, 'mb_ok', 'mb_ok@example.com');
+    const channelId = await createChannelReq(app, token, 'mb-ok-ch');
+    const message = await messageService.createMessage(channelId, userId, 'hello world');
+    expect(message.content).toBe('hello world');
   });
 });
 
 describe('Socket send_message 経由のモデレーション', () => {
-  it('block ワードを含む投稿は new_message が emit されず error イベントが送信者に届く', () => {
-    // TODO
+  /** Socket emit / on を記録するモックを返す */
+  function makeSocket(userId: number, username: string) {
+    const eventHandlers: Record<string, (...args: unknown[]) => void> = {};
+    const emitted: { event: string; payload: unknown }[] = [];
+    const socket = {
+      data: { userId, username },
+      on: jest.fn((event: string, h: (...args: unknown[]) => void) => {
+        eventHandlers[event] = h;
+      }),
+      emit: jest.fn((event: string, payload: unknown) => {
+        emitted.push({ event, payload });
+      }),
+    };
+    const io = {
+      to: jest.fn().mockReturnThis(),
+      emit: jest.fn(),
+    };
+    return { socket, io, eventHandlers, emitted };
+  }
+
+  it('block ワードを含む投稿は new_message が emit されず error イベントが送信者に届く', async () => {
+    const { userId, username } = (await registerUser(
+      app,
+      'sk_block',
+      'sk_block@example.com',
+    )) as unknown as { userId: number; token: string; username: string };
+    // testHelpers.registerUser は username を返さないため自前で取得
+    const channel = await testDb.queryOne<{ id: number }>(
+      "INSERT INTO channels (name, created_by) VALUES ('sk-block-ch', $1) RETURNING id",
+      [userId],
+    );
+    await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+      channel!.id,
+      userId,
+    ]);
+    await moderationService.createNgWord({ pattern: 'banned', action: 'block' }, userId);
+
+    const { socket, io, eventHandlers, emitted } = makeSocket(userId, username ?? 'sk_block');
+    registerMessageHandlers(io as never, socket as never);
+    const handler = eventHandlers['send_message'];
+    expect(handler).toBeDefined();
+    handler({
+      channelId: channel!.id,
+      content: 'this is banned',
+      mentionedUserIds: [],
+    });
+    await flushAsync();
+
+    // io.to(channel:N).emit('new_message') が呼ばれていないこと
+    expect(io.emit).not.toHaveBeenCalledWith('new_message', expect.anything());
+    // socket に error が emit されていること
+    expect(emitted.some((e) => e.event === 'error')).toBe(true);
   });
 
-  it('warn ワードを含む投稿は new_message が emit されつつ message_warning が送信者にだけ届く', () => {
-    // TODO
+  it('warn ワードを含む投稿は new_message が emit されつつ message_warning が送信者にだけ届く', async () => {
+    const { userId } = await registerUser(app, 'sk_warn', 'sk_warn@example.com');
+    const channel = await testDb.queryOne<{ id: number }>(
+      "INSERT INTO channels (name, created_by) VALUES ('sk-warn-ch', $1) RETURNING id",
+      [userId],
+    );
+    await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+      channel!.id,
+      userId,
+    ]);
+    await moderationService.createNgWord({ pattern: 'careful', action: 'warn' }, userId);
+
+    const { socket, io, eventHandlers, emitted } = makeSocket(userId, 'sk_warn');
+    registerMessageHandlers(io as never, socket as never);
+    const handler = eventHandlers['send_message'];
+    handler({
+      channelId: channel!.id,
+      content: 'careful here',
+      mentionedUserIds: [],
+    });
+    await flushAsync();
+
+    // 送信者にだけ message_warning が emit
+    expect(emitted.some((e) => e.event === 'message_warning')).toBe(true);
+    // チャンネルへの new_message も emit
+    expect(io.emit).toHaveBeenCalledWith('new_message', expect.anything());
   });
 
-  it('NG ワードを含まない通常投稿では message_warning は発火しない', () => {
-    // TODO
+  it('NG ワードを含まない通常投稿では message_warning は発火しない', async () => {
+    const { userId } = await registerUser(app, 'sk_ok', 'sk_ok@example.com');
+    const channel = await testDb.queryOne<{ id: number }>(
+      "INSERT INTO channels (name, created_by) VALUES ('sk-ok-ch', $1) RETURNING id",
+      [userId],
+    );
+    await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+      channel!.id,
+      userId,
+    ]);
+
+    const { socket, io, eventHandlers, emitted } = makeSocket(userId, 'sk_ok');
+    registerMessageHandlers(io as never, socket as never);
+    const handler = eventHandlers['send_message'];
+    handler({
+      channelId: channel!.id,
+      content: 'hello clean',
+      mentionedUserIds: [],
+    });
+    await flushAsync();
+
+    expect(emitted.some((e) => e.event === 'message_warning')).toBe(false);
   });
 });
 
 describe('POST /api/files/upload の拡張子検証', () => {
-  it('ブロック対象の拡張子のアップロードは 400 で拒否される', () => {
-    // TODO
+  it('ブロック対象の拡張子のアップロードは 400 で拒否される', async () => {
+    const { token, userId } = await registerUser(app, 'fu_blk', 'fu_blk@example.com');
+    await promoteToAdmin(userId);
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+
+    const res = await request(app)
+      .post('/api/files/upload')
+      .set('Cookie', `token=${token}`)
+      .attach('file', Buffer.from('binary'), { filename: 'malware.exe' });
+    expect(res.status).toBe(400);
   });
 
-  it('大文字拡張子（例: "EVIL.EXE"）も小文字判定で拒否される', () => {
-    // TODO
+  it('大文字拡張子（例: "EVIL.EXE"）も小文字判定で拒否される', async () => {
+    const { token, userId } = await registerUser(app, 'fu_upper', 'fu_upper@example.com');
+    await promoteToAdmin(userId);
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+
+    const res = await request(app)
+      .post('/api/files/upload')
+      .set('Cookie', `token=${token}`)
+      .attach('file', Buffer.from('binary'), { filename: 'EVIL.EXE' });
+    expect(res.status).toBe(400);
   });
 
-  it('ブロック対象でない拡張子のアップロードは成功する', () => {
-    // TODO
+  it('ブロック対象でない拡張子のアップロードは成功する', async () => {
+    const { token, userId } = await registerUser(app, 'fu_ok', 'fu_ok@example.com');
+    await promoteToAdmin(userId);
+    await moderationService.createBlockedExtension({ extension: 'exe' }, userId);
+
+    const res = await request(app)
+      .post('/api/files/upload')
+      .set('Cookie', `token=${token}`)
+      .attach('file', Buffer.from('hello'), { filename: 'note.txt' });
+    expect(res.status).toBe(200);
   });
 });
 
 describe('監査ログ', () => {
-  it('NG ワード追加時に "moderation.ngword.create" が記録される', () => {
-    // TODO
+  it('NG ワード追加時に "moderation.ngword.create" が記録される', async () => {
+    const { token, userId } = await registerUser(app, 'al_nc', 'al_nc@example.com');
+    await promoteToAdmin(userId);
+    await request(app)
+      .post('/api/admin/ng-words')
+      .set('Cookie', `token=${token}`)
+      .send({ pattern: 'logme', action: 'block' });
+    const { logs } = await listAuditLogs({ actionType: 'moderation.ngword.create' });
+    expect(logs.find((l) => l.actorUserId === userId)).toBeDefined();
   });
 
-  it('NG ワード更新時に "moderation.ngword.update" が記録される', () => {
-    // TODO
+  it('NG ワード更新時に "moderation.ngword.update" が記録される', async () => {
+    const { token, userId } = await registerUser(app, 'al_nu', 'al_nu@example.com');
+    await promoteToAdmin(userId);
+    const created = await moderationService.createNgWord({ pattern: 'patch_me' }, userId);
+    await request(app)
+      .patch(`/api/admin/ng-words/${created.id}`)
+      .set('Cookie', `token=${token}`)
+      .send({ action: 'warn' });
+    const { logs } = await listAuditLogs({ actionType: 'moderation.ngword.update' });
+    expect(logs.find((l) => l.actorUserId === userId)).toBeDefined();
   });
 
-  it('NG ワード削除時に "moderation.ngword.delete" が記録される', () => {
-    // TODO
+  it('NG ワード削除時に "moderation.ngword.delete" が記録される', async () => {
+    const { token, userId } = await registerUser(app, 'al_nd', 'al_nd@example.com');
+    await promoteToAdmin(userId);
+    const created = await moderationService.createNgWord({ pattern: 'delme' }, userId);
+    await request(app).delete(`/api/admin/ng-words/${created.id}`).set('Cookie', `token=${token}`);
+    const { logs } = await listAuditLogs({ actionType: 'moderation.ngword.delete' });
+    expect(logs.find((l) => l.actorUserId === userId)).toBeDefined();
   });
 
-  it('拡張子追加時に "moderation.blocklist.add" が記録される', () => {
-    // TODO
+  it('拡張子追加時に "moderation.blocklist.add" が記録される', async () => {
+    const { token, userId } = await registerUser(app, 'al_ba', 'al_ba@example.com');
+    await promoteToAdmin(userId);
+    await request(app)
+      .post('/api/admin/attachment-blocklist')
+      .set('Cookie', `token=${token}`)
+      .send({ extension: 'msi' });
+    const { logs } = await listAuditLogs({ actionType: 'moderation.blocklist.add' });
+    expect(logs.find((l) => l.actorUserId === userId)).toBeDefined();
   });
 
-  it('拡張子削除時に "moderation.blocklist.remove" が記録される', () => {
-    // TODO
+  it('拡張子削除時に "moderation.blocklist.remove" が記録される', async () => {
+    const { token, userId } = await registerUser(app, 'al_br', 'al_br@example.com');
+    await promoteToAdmin(userId);
+    const created = await moderationService.createBlockedExtension({ extension: 'vbs' }, userId);
+    await request(app)
+      .delete(`/api/admin/attachment-blocklist/${created.id}`)
+      .set('Cookie', `token=${token}`);
+    const { logs } = await listAuditLogs({ actionType: 'moderation.blocklist.remove' });
+    expect(logs.find((l) => l.actorUserId === userId)).toBeDefined();
   });
 });

--- a/packages/server/src/__tests__/moderation.test.ts
+++ b/packages/server/src/__tests__/moderation.test.ts
@@ -95,7 +95,8 @@ describe('moderationService.checkContent', () => {
       await moderationService.createNgWord({ pattern: 'soft', action: 'warn' }, userId);
       await moderationService.createNgWord({ pattern: 'hard', action: 'block' }, userId);
       const result = await moderationService.checkContent('soft and hard');
-      expect(result?.action).toBe('block');
+      // block 優先のため matchedPattern も block 側のパターンであるべき
+      expect(result).toEqual({ action: 'block', matchedPattern: 'hard' });
     });
   });
 
@@ -146,6 +147,31 @@ describe('moderationService.checkContent', () => {
       expect((await moderationService.checkContent('gone'))?.action).toBe('block');
       await moderationService.deleteNgWord(created.id);
       expect(await moderationService.checkContent('gone')).toBeNull();
+    });
+
+    it('30 秒経過後はキャッシュが破棄され DB の最新状態が反映される', async () => {
+      const { userId } = await registerUser(app, 'mc_ttl', 'mc_ttl@example.com');
+      // キャッシュを温める（空状態をキャッシュ）
+      expect(await moderationService.checkContent('latebloom')).toBeNull();
+
+      // CRUD を経由しない直接 INSERT でキャッシュを invalidate せずに DB を変える
+      await testDb.execute(
+        `INSERT INTO ng_words (pattern, is_regex, action, is_active, created_by)
+         VALUES ($1, false, 'block', true, $2)`,
+        ['latebloom', userId],
+      );
+      // TTL 内では古いキャッシュ（空）が使われる → null
+      expect(await moderationService.checkContent('latebloom')).toBeNull();
+
+      // 31 秒経過させる
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+      jest.setSystemTime(Date.now() + 31_000);
+      try {
+        // TTL 経過後は再フェッチされ block が返る
+        expect((await moderationService.checkContent('latebloom'))?.action).toBe('block');
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });
@@ -447,8 +473,10 @@ describe('Socket send_message 経由のモデレーション', () => {
 
     // io.to(channel:N).emit('new_message') が呼ばれていないこと
     expect(io.emit).not.toHaveBeenCalledWith('new_message', expect.anything());
-    // socket に error が emit されていること
-    expect(emitted.some((e) => e.event === 'error')).toBe(true);
+    // socket に error が emit され、ペイロードに 'Failed to send message' を含むこと
+    const errorEvent = emitted.find((e) => e.event === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent?.payload).toBe('Failed to send message');
   });
 
   it('warn ワードを含む投稿は new_message が emit されつつ message_warning が送信者にだけ届く', async () => {
@@ -473,9 +501,12 @@ describe('Socket send_message 経由のモデレーション', () => {
     });
     await flushAsync();
 
-    // 送信者にだけ message_warning が emit
-    expect(emitted.some((e) => e.event === 'message_warning')).toBe(true);
-    // チャンネルへの new_message も emit
+    // 送信者にだけ message_warning が emit され、ペイロードに matchedPattern が含まれる
+    const warnEvent = emitted.find((e) => e.event === 'message_warning');
+    expect(warnEvent).toBeDefined();
+    expect(warnEvent?.payload).toMatchObject({ matchedPattern: 'careful' });
+    // 投稿は通常通りチャンネルルームへ broadcast される
+    expect(io.to).toHaveBeenCalledWith(`channel:${channel!.id}`);
     expect(io.emit).toHaveBeenCalledWith('new_message', expect.anything());
   });
 
@@ -563,7 +594,11 @@ describe('監査ログ', () => {
       .set('Cookie', `token=${token}`)
       .send({ action: 'warn' });
     const { logs } = await listAuditLogs({ actionType: 'moderation.ngword.update' });
-    expect(logs.find((l) => l.actorUserId === userId)).toBeDefined();
+    const log = logs.find((l) => l.actorUserId === userId);
+    expect(log).toBeDefined();
+    // 更新対象 ID と更新後の状態が metadata に記録されているはず
+    expect(log!.targetId).toBe(created.id);
+    expect(log!.metadata).toMatchObject({ pattern: 'patch_me', action: 'warn' });
   });
 
   it('NG ワード削除時に "moderation.ngword.delete" が記録される', async () => {

--- a/packages/server/src/__tests__/moderation.test.ts
+++ b/packages/server/src/__tests__/moderation.test.ts
@@ -473,10 +473,10 @@ describe('Socket send_message 経由のモデレーション', () => {
 
     // io.to(channel:N).emit('new_message') が呼ばれていないこと
     expect(io.emit).not.toHaveBeenCalledWith('new_message', expect.anything());
-    // socket に error が emit され、ペイロードに 'Failed to send message' を含むこと
+    // 4xx エラー（NG ワード block）はサーバーのメッセージをそのまま送信者に届ける
     const errorEvent = emitted.find((e) => e.event === 'error');
     expect(errorEvent).toBeDefined();
-    expect(errorEvent?.payload).toBe('Failed to send message');
+    expect(errorEvent?.payload).toBe('NGワードは投稿できません');
   });
 
   it('warn ワードを含む投稿は new_message が emit されつつ message_warning が送信者にだけ届く', async () => {

--- a/packages/server/src/__tests__/socket-handler.test.ts
+++ b/packages/server/src/__tests__/socket-handler.test.ts
@@ -30,11 +30,13 @@ jest.mock('../services/messageService');
 jest.mock('../services/pushService');
 jest.mock('../services/pinMessageService');
 jest.mock('../services/channelNotificationService');
+jest.mock('../services/moderationService');
 
 import * as channelService from '../services/channelService';
 import * as messageService from '../services/messageService';
 import * as pushService from '../services/pushService';
 import * as channelNotificationService from '../services/channelNotificationService';
+import * as moderationService from '../services/moderationService';
 import { createAuthMiddleware } from '../socket/socketAuthMiddleware';
 import { registerChannelHandlers } from '../socket/channelHandler';
 import { registerMessageHandlers } from '../socket/messageHandler';
@@ -46,6 +48,11 @@ const mockedPushService = pushService as jest.Mocked<typeof pushService>;
 const mockedNotificationService = channelNotificationService as jest.Mocked<
   typeof channelNotificationService
 >;
+const mockedModerationService = moderationService as jest.Mocked<typeof moderationService>;
+// デフォルトでは NG ワード判定なし
+beforeEach(() => {
+  mockedModerationService.checkContent.mockResolvedValue(null);
+});
 
 const TEST_SECRET = 'test-secret';
 const TEST_USER_ID = 42;

--- a/packages/server/src/__tests__/unit/channelNotificationService.test.ts
+++ b/packages/server/src/__tests__/unit/channelNotificationService.test.ts
@@ -10,11 +10,13 @@ jest.mock('../../services/channelNotificationService');
 jest.mock('../../services/messageService');
 jest.mock('../../services/channelService');
 jest.mock('../../services/pinMessageService');
+jest.mock('../../services/moderationService');
 
 import * as pushService from '../../services/pushService';
 import * as channelNotificationService from '../../services/channelNotificationService';
 import * as messageService from '../../services/messageService';
 import * as channelService from '../../services/channelService';
+import * as moderationService from '../../services/moderationService';
 import { registerMessageHandlers } from '../../socket/messageHandler';
 import type { Message } from '@chat-app/shared';
 
@@ -24,6 +26,7 @@ const mockedNotificationService = channelNotificationService as jest.Mocked<
 >;
 const mockedMessageService = messageService as jest.Mocked<typeof messageService>;
 const mockedChannelService = channelService as jest.Mocked<typeof channelService>;
+const mockedModerationService = moderationService as jest.Mocked<typeof moderationService>;
 
 const SENDER_ID = 1;
 const MENTIONED_USER_ID = 2;
@@ -78,6 +81,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockedMessageService.createMessage.mockResolvedValue(makeMessage());
   mockedNotificationService.getLevel.mockResolvedValue('all');
+  mockedModerationService.checkContent.mockResolvedValue(null);
   mockedChannelService.getChannelsForUser.mockResolvedValue([
     {
       id: CHANNEL_ID,

--- a/packages/server/src/controllers/moderationController.ts
+++ b/packages/server/src/controllers/moderationController.ts
@@ -1,0 +1,143 @@
+import { Response, NextFunction } from 'express';
+import * as moderationService from '../services/moderationService';
+import * as auditLogService from '../services/auditLogService';
+import { AuthenticatedRequest } from '../middleware/auth';
+import type {
+  CreateNgWordInput,
+  UpdateNgWordInput,
+  CreateBlockedExtensionInput,
+} from '@chat-app/shared';
+
+// ─── NG ワード ─────────────────────────────────────────────────
+
+export async function listNgWords(
+  _req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    res.json({ ngWords: await moderationService.listNgWords() });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createNgWord(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const input = req.body as CreateNgWordInput;
+    const created = await moderationService.createNgWord(input, req.userId);
+    await auditLogService.record({
+      actorUserId: req.userId,
+      actionType: 'moderation.ngword.create',
+      targetType: null,
+      targetId: created.id,
+      metadata: { pattern: created.pattern, action: created.action },
+    });
+    res.status(201).json({ ngWord: created });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function updateNgWord(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const id = Number(req.params.id);
+    const input = req.body as UpdateNgWordInput;
+    const updated = await moderationService.updateNgWord(id, input);
+    await auditLogService.record({
+      actorUserId: req.userId,
+      actionType: 'moderation.ngword.update',
+      targetType: null,
+      targetId: updated.id,
+      metadata: { pattern: updated.pattern, action: updated.action, isActive: updated.isActive },
+    });
+    res.json({ ngWord: updated });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteNgWord(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const id = Number(req.params.id);
+    await moderationService.deleteNgWord(id);
+    await auditLogService.record({
+      actorUserId: req.userId,
+      actionType: 'moderation.ngword.delete',
+      targetType: null,
+      targetId: id,
+      metadata: null,
+    });
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── 拡張子ブロックリスト ─────────────────────────────────────
+
+export async function listBlockedExtensions(
+  _req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    res.json({ blockedExtensions: await moderationService.listBlockedExtensions() });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function createBlockedExtension(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const input = req.body as CreateBlockedExtensionInput;
+    const created = await moderationService.createBlockedExtension(input, req.userId);
+    await auditLogService.record({
+      actorUserId: req.userId,
+      actionType: 'moderation.blocklist.add',
+      targetType: null,
+      targetId: created.id,
+      metadata: { extension: created.extension, reason: created.reason },
+    });
+    res.status(201).json({ blockedExtension: created });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteBlockedExtension(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const id = Number(req.params.id);
+    await moderationService.deleteBlockedExtension(id);
+    await auditLogService.record({
+      actorUserId: req.userId,
+      actionType: 'moderation.blocklist.remove',
+      targetType: null,
+      targetId: id,
+      metadata: null,
+    });
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+}

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -2,6 +2,7 @@ import { Router, NextFunction, Response } from 'express';
 import { authenticateToken, requireAdmin, AuthenticatedRequest } from '../middleware/auth';
 import * as controller from '../controllers/adminController';
 import * as channelController from '../controllers/channelController';
+import * as moderationController from '../controllers/moderationController';
 
 const router = Router();
 
@@ -44,6 +45,31 @@ router.get('/audit-logs/export', (req, res, next) =>
 
 router.get('/audit-logs', (req, res, next) =>
   controller.getAuditLogs(req as unknown as AuthenticatedRequest, res, next),
+);
+
+// #117 NG ワード
+router.get('/ng-words', (req, res, next) =>
+  moderationController.listNgWords(req as unknown as AuthenticatedRequest, res, next),
+);
+router.post('/ng-words', (req, res, next) =>
+  moderationController.createNgWord(req as unknown as AuthenticatedRequest, res, next),
+);
+router.patch('/ng-words/:id', (req, res, next) =>
+  moderationController.updateNgWord(req as unknown as AuthenticatedRequest, res, next),
+);
+router.delete('/ng-words/:id', (req, res, next) =>
+  moderationController.deleteNgWord(req as unknown as AuthenticatedRequest, res, next),
+);
+
+// #117 添付拡張子ブロックリスト
+router.get('/attachment-blocklist', (req, res, next) =>
+  moderationController.listBlockedExtensions(req as unknown as AuthenticatedRequest, res, next),
+);
+router.post('/attachment-blocklist', (req, res, next) =>
+  moderationController.createBlockedExtension(req as unknown as AuthenticatedRequest, res, next),
+);
+router.delete('/attachment-blocklist/:id', (req, res, next) =>
+  moderationController.deleteBlockedExtension(req as unknown as AuthenticatedRequest, res, next),
 );
 
 export default router;

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -24,7 +24,7 @@ router.post('/upload', authenticateToken, upload.single('file'), async (req, res
 
     // #117 拡張子ブロックリスト判定
     if (await checkExtension(originalname)) {
-      throw createError('この拡張子のファイルはアップロードできません', 400);
+      throw createError('禁止された拡張子はアップロードできません', 400);
     }
 
     const saved = saveFile(buffer, originalname, mimetype);

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import multer from 'multer';
 import { authenticateToken } from '../middleware/auth';
 import { saveFile } from '../services/fileStorageService';
+import { checkExtension } from '../services/moderationService';
 import { execute } from '../db/database';
 import { createError } from '../middleware/errorHandler';
 
@@ -20,6 +21,12 @@ router.post('/upload', authenticateToken, upload.single('file'), async (req, res
 
     const { mimetype, buffer } = req.file;
     const originalname = Buffer.from(req.file.originalname, 'latin1').toString('utf8');
+
+    // #117 拡張子ブロックリスト判定
+    if (await checkExtension(originalname)) {
+      throw createError('この拡張子のファイルはアップロードできません', 400);
+    }
+
     const saved = saveFile(buffer, originalname, mimetype);
 
     const result = await execute(

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -191,7 +191,7 @@ export async function createThreadReply(
   // #117 NG ワード判定（block のみ throw。warn は呼び出し側で扱う）
   const ngResult = await checkContent(content);
   if (ngResult?.action === 'block') {
-    throw createError(`NG word matched: ${ngResult.matchedPattern}`, 400);
+    throw createError('NGワードは投稿できません', 400);
   }
 
   const inserted = await queryOne<{ id: number }>(
@@ -239,7 +239,7 @@ export async function createMessage(
   // #117 NG ワード判定（block のみ throw。warn は呼び出し側で扱う）
   const ngResult = await checkContent(content);
   if (ngResult?.action === 'block') {
-    throw createError(`NG word matched: ${ngResult.matchedPattern}`, 400);
+    throw createError('NGワードは投稿できません', 400);
   }
 
   if (quotedMessageId !== undefined) {

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -11,6 +11,7 @@ import {
 import { createError } from '../middleware/errorHandler';
 import { getForMessages } from './tagService';
 import { canPost } from './channelService';
+import { checkContent } from './moderationService';
 
 interface MessageRow {
   id: number;
@@ -187,6 +188,12 @@ export async function createThreadReply(
     throw createError('Posting is not allowed in this channel', 403);
   }
 
+  // #117 NG ワード判定（block のみ throw。warn は呼び出し側で扱う）
+  const ngResult = await checkContent(content);
+  if (ngResult?.action === 'block') {
+    throw createError(`NG word matched: ${ngResult.matchedPattern}`, 400);
+  }
+
   const inserted = await queryOne<{ id: number }>(
     'INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id) VALUES ($1, $2, $3, $4, $5) RETURNING id',
     [parent.channel_id, userId, content, parentMessageId, rootMessageId],
@@ -227,6 +234,12 @@ export async function createMessage(
   // #113 投稿権限チェック
   if (!(await canPost(userId, channelId))) {
     throw createError('Posting is not allowed in this channel', 403);
+  }
+
+  // #117 NG ワード判定（block のみ throw。warn は呼び出し側で扱う）
+  const ngResult = await checkContent(content);
+  if (ngResult?.action === 'block') {
+    throw createError(`NG word matched: ${ngResult.matchedPattern}`, 400);
   }
 
   if (quotedMessageId !== undefined) {

--- a/packages/server/src/services/moderationService.ts
+++ b/packages/server/src/services/moderationService.ts
@@ -1,0 +1,263 @@
+/**
+ * #117 NG ワード / 添付拡張子ブロックリストの管理と判定
+ *
+ * MVP方針:
+ *   - NG ワード判定は文字列の部分一致のみ（is_regex は将来拡張用に保持。MVPでは未使用）
+ *   - pattern と投稿コンテンツを NFKC + lowercase で正規化してから照合
+ *   - 1 投稿に block と warn 両方マッチした場合は block 優先
+ *   - 30 秒 TTL のプロセス内キャッシュ。CRUD で invalidate
+ */
+import { query, queryOne, execute } from '../db/database';
+import {
+  NgWord,
+  NgWordAction,
+  NgWordCheckResult,
+  CreateNgWordInput,
+  UpdateNgWordInput,
+  BlockedExtension,
+  CreateBlockedExtensionInput,
+} from '@chat-app/shared';
+import { createError } from '../middleware/errorHandler';
+
+interface NgWordRow {
+  id: number;
+  pattern: string;
+  is_regex: boolean;
+  action: NgWordAction;
+  is_active: boolean;
+  created_by: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BlockedExtensionRow {
+  id: number;
+  extension: string;
+  reason: string | null;
+  created_by: number | null;
+  created_at: string;
+}
+
+function toNgWord(row: NgWordRow): NgWord {
+  return {
+    id: row.id,
+    pattern: row.pattern,
+    isRegex: row.is_regex,
+    action: row.action,
+    isActive: row.is_active,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toBlockedExtension(row: BlockedExtensionRow): BlockedExtension {
+  return {
+    id: row.id,
+    extension: row.extension,
+    reason: row.reason,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  };
+}
+
+/** NFKC + lowercase 正規化 */
+function normalize(text: string): string {
+  return text.normalize('NFKC').toLowerCase();
+}
+
+/** 拡張子をドット無し小文字で抽出。拡張子が無いときは null */
+export function extractExtension(filename: string): string | null {
+  const idx = filename.lastIndexOf('.');
+  if (idx === -1 || idx === filename.length - 1) return null;
+  return filename.slice(idx + 1).toLowerCase();
+}
+
+// ─── キャッシュ ────────────────────────────────────────────────
+const CACHE_TTL_MS = 30_000;
+
+interface NgWordCache {
+  fetchedAt: number;
+  // 正規化済み pattern / action の対のみ保持（is_active=true のものだけ）
+  entries: { normalizedPattern: string; action: NgWordAction; rawPattern: string }[];
+}
+
+let ngWordCache: NgWordCache | null = null;
+
+interface BlocklistCache {
+  fetchedAt: number;
+  extensions: Set<string>;
+}
+
+let blocklistCache: BlocklistCache | null = null;
+
+export function invalidateCaches(): void {
+  ngWordCache = null;
+  blocklistCache = null;
+}
+
+async function getActiveNgWords(): Promise<NgWordCache['entries']> {
+  const now = Date.now();
+  if (ngWordCache && now - ngWordCache.fetchedAt < CACHE_TTL_MS) {
+    return ngWordCache.entries;
+  }
+  const rows = await query<{ pattern: string; action: NgWordAction }>(
+    'SELECT pattern, action FROM ng_words WHERE is_active = true',
+  );
+  const entries = rows.map((r) => ({
+    normalizedPattern: normalize(r.pattern),
+    action: r.action,
+    rawPattern: r.pattern,
+  }));
+  ngWordCache = { fetchedAt: now, entries };
+  return entries;
+}
+
+async function getBlockedExtensionSet(): Promise<Set<string>> {
+  const now = Date.now();
+  if (blocklistCache && now - blocklistCache.fetchedAt < CACHE_TTL_MS) {
+    return blocklistCache.extensions;
+  }
+  const rows = await query<{ extension: string }>('SELECT extension FROM attachment_blocklist');
+  const extensions = new Set(rows.map((r) => r.extension.toLowerCase()));
+  blocklistCache = { fetchedAt: now, extensions };
+  return extensions;
+}
+
+// ─── 判定 API ───────────────────────────────────────────────────
+
+/**
+ * NG ワード判定。block 優先で先頭から評価。マッチなしなら null。
+ */
+export async function checkContent(content: string): Promise<NgWordCheckResult | null> {
+  const entries = await getActiveNgWords();
+  if (entries.length === 0) return null;
+
+  const normalizedContent = normalize(content);
+  let warnHit: NgWordCheckResult | null = null;
+
+  for (const entry of entries) {
+    if (!entry.normalizedPattern) continue;
+    if (normalizedContent.includes(entry.normalizedPattern)) {
+      if (entry.action === 'block') {
+        return { action: 'block', matchedPattern: entry.rawPattern };
+      }
+      if (entry.action === 'warn' && warnHit === null) {
+        warnHit = { action: 'warn', matchedPattern: entry.rawPattern };
+      }
+    }
+  }
+
+  return warnHit;
+}
+
+/**
+ * 拡張子がブロック対象なら true。
+ */
+export async function checkExtension(filename: string): Promise<boolean> {
+  const ext = extractExtension(filename);
+  if (ext === null) return false;
+  const blocked = await getBlockedExtensionSet();
+  return blocked.has(ext);
+}
+
+// ─── NG ワード CRUD ────────────────────────────────────────────
+
+export async function listNgWords(): Promise<NgWord[]> {
+  const rows = await query<NgWordRow>('SELECT * FROM ng_words ORDER BY id ASC');
+  return rows.map(toNgWord);
+}
+
+export async function createNgWord(input: CreateNgWordInput, userId: number): Promise<NgWord> {
+  const pattern = input.pattern?.trim();
+  if (!pattern) throw createError('pattern is required', 400);
+
+  const action: NgWordAction = input.action ?? 'block';
+  if (action !== 'block' && action !== 'warn') {
+    throw createError('Invalid action', 400);
+  }
+
+  const row = await queryOne<NgWordRow>(
+    `INSERT INTO ng_words (pattern, is_regex, action, is_active, created_by)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [pattern, input.isRegex ?? false, action, input.isActive ?? true, userId],
+  );
+  invalidateCaches();
+  return toNgWord(row!);
+}
+
+export async function updateNgWord(id: number, input: UpdateNgWordInput): Promise<NgWord> {
+  const existing = await queryOne<NgWordRow>('SELECT * FROM ng_words WHERE id = $1', [id]);
+  if (!existing) throw createError('NG word not found', 404);
+
+  const nextPattern = input.pattern !== undefined ? input.pattern.trim() : existing.pattern;
+  if (!nextPattern) throw createError('pattern must not be empty', 400);
+
+  const nextAction = input.action ?? existing.action;
+  if (nextAction !== 'block' && nextAction !== 'warn') {
+    throw createError('Invalid action', 400);
+  }
+
+  const nextIsActive = input.isActive ?? existing.is_active;
+  const nextIsRegex = input.isRegex ?? existing.is_regex;
+
+  const row = await queryOne<NgWordRow>(
+    `UPDATE ng_words
+       SET pattern = $1, action = $2, is_active = $3, is_regex = $4, updated_at = NOW()
+       WHERE id = $5
+       RETURNING *`,
+    [nextPattern, nextAction, nextIsActive, nextIsRegex, id],
+  );
+  invalidateCaches();
+  return toNgWord(row!);
+}
+
+export async function deleteNgWord(id: number): Promise<void> {
+  const existing = await queryOne('SELECT id FROM ng_words WHERE id = $1', [id]);
+  if (!existing) throw createError('NG word not found', 404);
+  await execute('DELETE FROM ng_words WHERE id = $1', [id]);
+  invalidateCaches();
+}
+
+// ─── 拡張子ブロックリスト CRUD ─────────────────────────────────
+
+export async function listBlockedExtensions(): Promise<BlockedExtension[]> {
+  const rows = await query<BlockedExtensionRow>(
+    'SELECT * FROM attachment_blocklist ORDER BY id ASC',
+  );
+  return rows.map(toBlockedExtension);
+}
+
+export async function createBlockedExtension(
+  input: CreateBlockedExtensionInput,
+  userId: number,
+): Promise<BlockedExtension> {
+  const raw = input.extension?.trim();
+  if (!raw) throw createError('extension is required', 400);
+
+  // ドット先頭・大文字を許容して正規化（"EXE" や ".exe" → "exe"）
+  const normalizedExt = raw.replace(/^\./, '').toLowerCase();
+  if (!normalizedExt) throw createError('extension is required', 400);
+
+  const dup = await queryOne('SELECT id FROM attachment_blocklist WHERE extension = $1', [
+    normalizedExt,
+  ]);
+  if (dup) throw createError('extension already registered', 409);
+
+  const row = await queryOne<BlockedExtensionRow>(
+    `INSERT INTO attachment_blocklist (extension, reason, created_by)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [normalizedExt, input.reason ?? null, userId],
+  );
+  invalidateCaches();
+  return toBlockedExtension(row!);
+}
+
+export async function deleteBlockedExtension(id: number): Promise<void> {
+  const existing = await queryOne('SELECT id FROM attachment_blocklist WHERE id = $1', [id]);
+  if (!existing) throw createError('blocked extension not found', 404);
+  await execute('DELETE FROM attachment_blocklist WHERE id = $1', [id]);
+  invalidateCaches();
+}

--- a/packages/server/src/socket/messageHandler.ts
+++ b/packages/server/src/socket/messageHandler.ts
@@ -4,6 +4,7 @@ import * as pinMessageService from '../services/pinMessageService';
 import * as pushService from '../services/pushService';
 import * as channelService from '../services/channelService';
 import * as channelNotificationService from '../services/channelNotificationService';
+import * as moderationService from '../services/moderationService';
 import {
   ServerToClientEvents,
   ClientToServerEvents,
@@ -41,6 +42,15 @@ export function registerMessageHandlers(io: ChatServer, socket: ChatSocket): voi
           (data as { attachmentIds?: number[] }).attachmentIds,
           (data as { quotedMessageId?: number }).quotedMessageId,
         );
+
+        // #117 warn: 送信成功扱い。送信者にだけ message_warning を返す
+        const ngResult = await moderationService.checkContent(data.content);
+        if (ngResult?.action === 'warn') {
+          socket.emit('message_warning', {
+            matchedPattern: ngResult.matchedPattern,
+            message: `投稿に注意ワードが含まれています: ${ngResult.matchedPattern}`,
+          });
+        }
 
         io.to(`channel:${data.channelId}`).emit('new_message', message);
 

--- a/packages/server/src/socket/messageHandler.ts
+++ b/packages/server/src/socket/messageHandler.ts
@@ -82,8 +82,12 @@ export function registerMessageHandlers(io: ChatServer, socket: ChatSocket): voi
             }
           }
         }
-      } catch {
-        socket.emit('error', 'Failed to send message');
+      } catch (err) {
+        // 4xx のクライアント向けエラー（NG ワードや投稿権限など）はメッセージをそのまま送信者に伝える
+        const e = err as { statusCode?: number; message?: string };
+        const isClientError =
+          typeof e.statusCode === 'number' && e.statusCode >= 400 && e.statusCode < 500;
+        socket.emit('error', isClientError && e.message ? e.message : 'Failed to send message');
       }
     })();
   });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,3 +12,4 @@ export * from './types/messageTemplate';
 export * from './types/scheduledMessage';
 export * from './types/invite';
 export * from './types/tag';
+export * from './types/moderation';

--- a/packages/shared/src/types/auditLog.ts
+++ b/packages/shared/src/types/auditLog.ts
@@ -20,7 +20,12 @@ export type AuditActionType =
   | 'audit.export'
   | 'invite.create'
   | 'invite.revoke'
-  | 'invite.redeem';
+  | 'invite.redeem'
+  | 'moderation.ngword.create'
+  | 'moderation.ngword.update'
+  | 'moderation.ngword.delete'
+  | 'moderation.blocklist.add'
+  | 'moderation.blocklist.remove';
 
 export interface AuditLogExportQuery {
   from?: string; // ISO8601

--- a/packages/shared/src/types/moderation.ts
+++ b/packages/shared/src/types/moderation.ts
@@ -1,0 +1,54 @@
+/**
+ * #117 NG ワード / 添付制限 のモデレーション関連型
+ */
+
+export type NgWordAction = 'block' | 'warn';
+
+export interface NgWord {
+  id: number;
+  pattern: string;
+  isRegex: boolean;
+  action: NgWordAction;
+  isActive: boolean;
+  createdBy: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateNgWordInput {
+  pattern: string;
+  isRegex?: boolean;
+  action?: NgWordAction;
+  isActive?: boolean;
+}
+
+export interface UpdateNgWordInput {
+  pattern?: string;
+  isRegex?: boolean;
+  action?: NgWordAction;
+  isActive?: boolean;
+}
+
+export interface BlockedExtension {
+  id: number;
+  extension: string; // ドット無し小文字
+  reason: string | null;
+  createdBy: number | null;
+  createdAt: string;
+}
+
+export interface CreateBlockedExtensionInput {
+  extension: string;
+  reason?: string | null;
+}
+
+/**
+ * NG ワード判定結果。
+ * - null: 何にもマッチせず、送信OK
+ * - block: 送信拒否
+ * - warn: 送信は通すがクライアントへ警告を返す
+ */
+export interface NgWordCheckResult {
+  action: NgWordAction;
+  matchedPattern: string;
+}

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -42,6 +42,8 @@ export interface ServerToClientEvents {
   // #110 予約送信
   'message:new': (message: Message) => void;
   'scheduled_message:failed': (data: { scheduledMessageId: number; error: string }) => void;
+  // #117 NG ワード警告（送信は通常完了するが、送信者にだけ警告を表示）
+  message_warning: (data: { matchedPattern: string; message: string }) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
## 概要
NG ワード判定とファイル添付の拡張子ブロックリストを実装する Issue #117 の対応。

**現状: テスト項目列挙の段階**。実装は未着手。テスト項目および設計判断のレビュー目的の draft PR。

## 変更内容
- `db/schema.hcl`: `ng_words` テーブル（pattern / is_regex / action(block|warn) / is_active / created_by）と `attachment_blocklist` テーブル（extension / reason / created_by）を新規追加
- `packages/shared/src/types/moderation.ts`: `NgWord` / `NgWordAction` / `CreateNgWordInput` / `UpdateNgWordInput` / `BlockedExtension` / `CreateBlockedExtensionInput` / `NgWordCheckResult` 型を追加
- `packages/shared/src/index.ts`: 上記の re-export
- `packages/server/src/__tests__/moderation.test.ts`: 新規（describe/it のみ、中身は `// TODO`）
- 既存クライアントテストに `#117` 用 describe を追記
  - `AdminPage.test.tsx`: モデレーション設定タブ（NG ワード / 拡張子 CRUD UI）
  - `ChatPage.test.tsx`: Socket `error` / `message_warning` 受信時のスナックバー

## 設計判断（要レビュー）
1. **NG ワード判定**: MVP は **文字列の部分一致のみ**。`is_regex` カラムは将来拡張用に残す（現実装では未使用）
2. **正規化**: pattern / 投稿コンテンツ両方を **NFKC + lowercase** で正規化してから照合
3. **block / warn 衝突時の優先**: **block 優先**
4. **キャッシュ**: 30 秒 TTL のプロセス内キャッシュ。CRUD 操作で invalidate
5. **Socket 経由の伝播**:
   - block → 既存の `error` イベント
   - warn → **新規イベント `message_warning`** を Server→Client に追加し、送信者にだけ発火（送信は通常完了）
6. **添付検証**: `POST /api/files/upload` 内で originalName から拡張子を抽出 → 小文字化 → ブロックリスト照合 → 違反は 400
7. **API**:
   - `/api/admin/ng-words` (GET / POST / PATCH / DELETE)
   - `/api/admin/attachment-blocklist` (GET / POST / DELETE)
8. **AdminPage**: 「モデレーション設定」タブを追加（admin のみ）
9. **監査ログ**: `moderation.ngword.create/update/delete`、`moderation.blocklist.add/remove` を `AuditActionType` に追加

## 影響範囲
- `messageService.createMessage` / Socket `send_message` ハンドラに NG ワード判定の割り込みを追加予定（実装フェーズ）
- `POST /api/files/upload` のレスポンスに 400 ケース追加
- 既存の Channel 系・メッセージ送信経路には破壊的変更なし

## 動作確認・テスト結果
- [ ] フロントエンドユニットテストがすべてパスする（実装後）
- [ ] バックエンドユニットテストがすべてパスする（実装後）
- [ ] ビルドが正常に完了すること（実装後）
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue
Fixes #117

## チェックリスト
- [ ] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [ ] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した

## レビュー依頼ポイント
**テスト項目（describe/it）の網羅性と設計判断 1〜9 の妥当性**を中心にご確認ください。承認後、本ブランチで TDD のテスト実装 → プログラム実装 → build + test 通過確認を進めます。

特に以下は仕様に揺れがあるので意見いただけると助かります:
- 設計判断 5（warn 用に新規イベントを追加 vs 既存 `error` イベントを構造化メッセージに統一）
- 設計判断 4（キャッシュ TTL 30 秒で良いか）
- 設計判断 1（MVP で正規表現を完全に切り捨てて良いか）