### PR TITLE
docs: README の DB 記述を PostgreSQL に修正 / parallel-feature-dev に atlas apply 並列注意書き追加

### DIFF
--- a/.claude/skills/parallel-feature-dev/SKILL.md
+++ b/.claude/skills/parallel-feature-dev/SKILL.md
@@ -222,5 +222,9 @@ Draft PR: #{PR番号}
 - **PRのマージはユーザーが実施する**。オーケストレーターもworkerもマージを実行しない
 - **オーケストレーターは直接コードを修正しない**。バグや不具合を発見した場合は内容をユーザーに報告し、該当ブランチのworkerエージェントを起動して修正を委譲する
 - workerが失敗した場合はエラー内容を報告し、再試行か手動対応かをユーザーに確認する
-- **DBスキーマ（`db/schema.hcl`）の競合**: 複数workerが同じスキーマ変更を含む場合は別Phaseに分ける。worktreeはファイルを隔離するが、SQLiteのDBファイル（`packages/server/data/chat.db`）は共有されるため、`atlas schema apply` は並列実行しない
+- **DBスキーマ（`db/schema.hcl`）の競合**: 複数workerが同じスキーマ変更を含む場合は別Phaseに分ける。本プロジェクトのDB（PostgreSQL: `claude-code-test-db-1` コンテナ）は全 worktree で共有されるため、`atlas schema apply` を並列で実行すると **後発の worker が先発の変更を上書きする**（atlas は宣言モードで `schema.hcl` を正として DB を書き換えるため、先発が追加した未マージのカラム・テーブルが消える）。
+  - **対策1**: スキーマ変更を含む worker は **Phase を分けて順次実行**する（最も安全）
+  - **対策2**: 各 worker に `atlas schema apply` を **実行させない**ようオーケストレーターから明示し、最終的なマージ後に main で 1 回だけ apply する（テストは worker の worktree で in-memory or 個別 DB を使う場合のみ可能）
+  - **検出方法**: 並列実装後に `atlas schema apply --env local --dry-run` を実行し、想定外の `DROP TABLE` / `DROP COLUMN` が出たら上書き事故が発生している
+  - **復旧方法**: `atlas schema apply` を実行すると失われたスキーマが破壊されるため、まず DB に直接 `ALTER TABLE` で不足分を追加して両ブランチが動作する状態を作り、PR マージ後にスキーマを統合する
 - workerが失敗した場合、そのworktreeのブランチは残るので次回再利用できる

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - **フロントエンド:** React + TypeScript + Vite
 - **バックエンド:** Node.js + Express + Socket.IO + TypeScript
-- **データベース:** SQLite (better-sqlite3)
+- **データベース:** PostgreSQL 16 (node-postgres / `pg`)
 - **DBマイグレーション:** [Atlas](https://atlasgo.io/)
 
 ## セットアップ


### PR DESCRIPTION
## 概要

並列実装中に判明したドキュメントの不整合を 2 件まとめて修正。

## 変更内容

### 1. README.md
- 行 9 の DB 記述を `SQLite (better-sqlite3)` → `PostgreSQL 16 (node-postgres / pg)` に修正
- 実装は `packages/server/package.json` で `pg ^8.20.0` を使用、`atlas.hcl` も `postgres://chatapp:chatapp@localhost:5432/chatapp` を指しているのに対し、README だけ古い SQLite 時代の記述が残っていた

### 2. .claude/skills/parallel-feature-dev/SKILL.md
- 「DBスキーマの競合」項目に **atlas schema apply の並列実行による上書き事故** の対策・検出・復旧手順を追記
- 旧記述では「SQLite の DB ファイルが共有されるため」と記載されていたが、実態は PostgreSQL コンテナが共有される構造であり原因記述自体が不正確だった
- 今回 #107 / #108 並列実装で実際に発生した事故（後発の #108 worker が先発 #107 のカラム追加を上書きし、`column m.forwarded_from_message_id does not exist` エラーが発生）を踏まえた更新

## 影響範囲

- ドキュメントのみ。プロダクションコードへの影響なし
- skill ファイルは将来の並列実装で参照される

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（変更なしのため非該当）
- [x] バックエンドユニットテストがすべてパスする（変更なしのため非該当）
- [x] ビルドが正常に完了すること（変更なしのため非該当）
- [x] (手動確認) README.md の表記と実装（`pg` パッケージ・`atlas.hcl`）の整合を目視確認

## 関連Issue
なし（並列実装で派生したドキュメント整合修正）

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した