### PR TITLE
feat: 通報/モデレーションキュー (#116)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -1650,5 +1650,90 @@ table "event_rsvps" {
   }
 }
 
+# #116 通報 / モデレーションキュー
+table "message_reports" {
+  schema  = schema.public
+  comment = "メッセージ通報"
+  column "id" {
+    null = false
+    type = serial
+  }
+  column "message_id" {
+    null    = false
+    type    = integer
+    comment = "通報対象メッセージID"
+  }
+  column "reporter_id" {
+    null    = true
+    type    = integer
+    comment = "通報者ユーザーID（ユーザー削除時 NULL）"
+  }
+  column "reason" {
+    null    = false
+    type    = text
+    comment = "通報理由（spam / harassment / other）"
+  }
+  column "comment" {
+    null    = true
+    type    = text
+    comment = "任意のコメント"
+  }
+  column "status" {
+    null    = false
+    type    = text
+    default = "pending"
+    comment = "ステータス（pending / dismissed / actioned）"
+  }
+  column "action_taken" {
+    null    = true
+    type    = text
+    comment = "実施したアクション（delete_message 等）"
+  }
+  column "handled_by" {
+    null    = true
+    type    = integer
+    comment = "対応した管理者ユーザーID"
+  }
+  column "handled_at" {
+    null    = true
+    type    = timestamptz
+    comment = "対応日時"
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "通報日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_rep_message" {
+    columns     = [column.message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_rep_reporter" {
+    columns     = [column.reporter_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  foreign_key "fk_rep_handler" {
+    columns     = [column.handled_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  index "idx_reports_status" {
+    columns = [column.status, column.created_at]
+  }
+  index "idx_reports_message_reporter" {
+    unique  = true
+    columns = [column.message_id, column.reporter_id]
+  }
+}
+
 schema "public" {
 }

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -104,6 +104,11 @@ vi.mock('../api/client', () => ({
         create: vi.fn(),
         delete: vi.fn(),
       },
+      reports: {
+        list: vi.fn(),
+        dismiss: vi.fn(),
+        action: vi.fn(),
+      },
     },
   },
 }));
@@ -147,6 +152,11 @@ const mockedApi = api as unknown as {
       list: ReturnType<typeof vi.fn>;
       create: ReturnType<typeof vi.fn>;
       delete: ReturnType<typeof vi.fn>;
+    };
+    reports: {
+      list: ReturnType<typeof vi.fn>;
+      dismiss: ReturnType<typeof vi.fn>;
+      action: ReturnType<typeof vi.fn>;
     };
   };
 };
@@ -218,6 +228,25 @@ beforeEach(() => {
     },
   });
   mockedApi.admin.blockedExtensions.delete.mockResolvedValue(undefined);
+  mockedApi.admin.reports.list.mockResolvedValue({
+    reports: [
+      {
+        id: 1,
+        messageId: 10,
+        reporterId: 2,
+        reporterUsername: 'bob',
+        reason: 'spam',
+        comment: null,
+        status: 'pending',
+        actionTaken: null,
+        handledBy: null,
+        handledAt: null,
+        createdAt: '2025-01-01T00:00:00Z',
+      },
+    ],
+  });
+  mockedApi.admin.reports.dismiss.mockResolvedValue({ report: {} });
+  mockedApi.admin.reports.action.mockResolvedValue({ report: {} });
 });
 
 describe('AdminPage: 統計タブ', () => {
@@ -663,5 +692,25 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
       // 既存仕様: 非管理者は「Forbidden」表示（タブ全体が非表示）
       expect(screen.queryByRole('tab', { name: /モデレーション設定/ })).not.toBeInTheDocument();
     });
+  });
+});
+
+// #116 通報キュータブ
+describe('AdminPage: 通報キュータブ (#116)', () => {
+  async function openReportQueueTab() {
+    await renderAdminPage();
+    await userEvent.click(screen.getByRole('tab', { name: /通報キュー/ }));
+    await act(async () => {});
+  }
+
+  it('「通報キュー」タブが存在する', async () => {
+    await renderAdminPage();
+    expect(screen.getByRole('tab', { name: /通報キュー/ })).toBeInTheDocument();
+  });
+
+  it('通報キュータブを開くと通報一覧が表示される', async () => {
+    await openReportQueueTab();
+    await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
+    expect(mockedApi.admin.reports.list).toHaveBeenCalled();
   });
 });

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -233,6 +233,7 @@ beforeEach(() => {
       {
         id: 1,
         messageId: 10,
+        channelId: 100,
         reporterId: 2,
         reporterUsername: 'bob',
         reason: 'spam',

--- a/packages/client/src/__tests__/MessageActions.test.tsx
+++ b/packages/client/src/__tests__/MessageActions.test.tsx
@@ -69,6 +69,16 @@ vi.mock('../components/Chat/ForwardMessageDialog', () => ({
     ) : null,
 }));
 
+// ReportMessageDialog モック
+vi.mock('../components/Chat/ReportMessageDialog', () => ({
+  default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="report-dialog">
+        <button onClick={onClose}>close-report</button>
+      </div>
+    ) : null,
+}));
+
 beforeEach(() => {
   vi.resetAllMocks();
   mockBookmarksAdd.mockResolvedValue(undefined);
@@ -306,6 +316,25 @@ describe('MessageActions', () => {
       render(<MessageActions message={makeMessage()} isOwn={false} />);
       await userEvent.click(screen.getByRole('button', { name: '転送' }));
       expect(screen.getByTestId('forward-dialog')).toBeInTheDocument();
+    });
+  });
+
+  // #116 通報
+  describe('通報 (#116)', () => {
+    it('isOwn=false のとき「通報」ボタンが表示される', () => {
+      render(<MessageActions message={makeMessage()} isOwn={false} />);
+      expect(screen.getByRole('button', { name: '通報' })).toBeInTheDocument();
+    });
+
+    it('isOwn=true のとき「通報」ボタンが表示されない（自分のメッセージは通報不可）', () => {
+      render(<MessageActions message={makeMessage()} isOwn={true} />);
+      expect(screen.queryByRole('button', { name: '通報' })).not.toBeInTheDocument();
+    });
+
+    it('「通報」ボタンをクリックすると ReportMessageDialog が開く', async () => {
+      render(<MessageActions message={makeMessage()} isOwn={false} />);
+      await userEvent.click(screen.getByRole('button', { name: '通報' }));
+      expect(screen.getByTestId('report-dialog')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/ModerationQueue.test.tsx
+++ b/packages/client/src/__tests__/ModerationQueue.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * テスト対象: components/Admin/ModerationQueue.tsx
+ *
+ * 戦略:
+ *   - vi.mock('../api/client') でAPIをモック化
+ *   - React 19 の use() + Suspense パターンを考慮してテストする
+ *   - 通報一覧の表示・却下・削除アクションを検証する
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MessageReport } from '@chat-app/shared';
+
+const mockListReports = vi.fn();
+const mockDismissReport = vi.fn();
+const mockActionReport = vi.fn();
+
+vi.mock('../api/client', () => ({
+  api: {
+    admin: {
+      reports: {
+        list: (params?: unknown) => mockListReports(params),
+        dismiss: (id: number) => mockDismissReport(id),
+        action: (id: number, actionType: string) => mockActionReport(id, actionType),
+      },
+    },
+  },
+}));
+
+const mockShowError = vi.hoisted(() => vi.fn());
+const mockShowSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({
+    showError: mockShowError,
+    showSuccess: mockShowSuccess,
+    showInfo: vi.fn(),
+  }),
+}));
+
+const mockReports: MessageReport[] = [
+  {
+    id: 1,
+    messageId: 10,
+    reporterId: 2,
+    reporterUsername: 'bob',
+    reason: 'spam',
+    comment: 'スパムです',
+    status: 'pending',
+    actionTaken: null,
+    handledBy: null,
+    handledAt: null,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    messageId: 20,
+    reporterId: 3,
+    reporterUsername: 'carol',
+    reason: 'harassment',
+    comment: null,
+    status: 'dismissed',
+    actionTaken: null,
+    handledBy: 1,
+    handledAt: '2025-01-02T00:00:00Z',
+    createdAt: '2025-01-01T12:00:00Z',
+  },
+];
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockListReports.mockResolvedValue({ reports: mockReports });
+  mockDismissReport.mockResolvedValue({ report: { ...mockReports[0], status: 'dismissed' } });
+  mockActionReport.mockResolvedValue({
+    report: { ...mockReports[0], status: 'actioned', actionTaken: 'delete_message' },
+  });
+});
+
+async function renderModerationQueue() {
+  const { default: ModerationQueue } = await import('../components/Admin/ModerationQueue');
+  await act(async () => {
+    render(<ModerationQueue />);
+  });
+}
+
+describe('ModerationQueue', () => {
+  describe('通報一覧の表示', () => {
+    it('通報の一覧が表示される', async () => {
+      await renderModerationQueue();
+      await waitFor(() => expect(screen.getByText('10')).toBeInTheDocument());
+      expect(screen.getByText('20')).toBeInTheDocument();
+    });
+
+    it('通報者のユーザー名が表示される', async () => {
+      await renderModerationQueue();
+      await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
+      expect(screen.getByText('carol')).toBeInTheDocument();
+    });
+
+    it('通報理由（spam / harassment / other）が表示される', async () => {
+      await renderModerationQueue();
+      await waitFor(() => expect(screen.getByText('スパム')).toBeInTheDocument());
+      expect(screen.getByText('ハラスメント')).toBeInTheDocument();
+    });
+
+    it('ステータスが pending の通報には対応ボタンが表示される', async () => {
+      await renderModerationQueue();
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /通報 1 を却下/ })).toBeInTheDocument(),
+      );
+      expect(screen.getByRole('button', { name: /通報 1 のメッセージを削除/ })).toBeInTheDocument();
+    });
+
+    it('ステータスが dismissed / actioned の通報には対応ボタンが非表示になる', async () => {
+      await renderModerationQueue();
+      await waitFor(() => expect(screen.getByText('carol')).toBeInTheDocument());
+      // report id=2 は dismissed なので対応ボタンが存在しない
+      expect(screen.queryByRole('button', { name: /通報 2 を却下/ })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /通報 2 のメッセージを削除/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('通報の却下', () => {
+    it('「却下」ボタンをクリックすると api.admin.reports.dismiss が呼ばれる', async () => {
+      await renderModerationQueue();
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /通報 1 を却下/ })).toBeInTheDocument(),
+      );
+      await userEvent.click(screen.getByRole('button', { name: /通報 1 を却下/ }));
+      await waitFor(() => expect(mockDismissReport).toHaveBeenCalledWith(1));
+    });
+
+    it('却下成功後に通報の status が dismissed に更新される', async () => {
+      await renderModerationQueue();
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /通報 1 を却下/ })).toBeInTheDocument(),
+      );
+      await userEvent.click(screen.getByRole('button', { name: /通報 1 を却下/ }));
+      await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledWith('通報を却下しました'));
+      // 却下後は対応ボタンが消える
+      expect(screen.queryByRole('button', { name: /通報 1 を却下/ })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('メッセージ削除アクション', () => {
+    it('「メッセージを削除」ボタンをクリックすると api.admin.reports.action が呼ばれる', async () => {
+      await renderModerationQueue();
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /通報 1 のメッセージを削除/ }),
+        ).toBeInTheDocument(),
+      );
+      await userEvent.click(screen.getByRole('button', { name: /通報 1 のメッセージを削除/ }));
+      await waitFor(() => expect(mockActionReport).toHaveBeenCalledWith(1, 'delete_message'));
+    });
+
+    it('削除アクション成功後に通報の status が actioned に更新される', async () => {
+      await renderModerationQueue();
+      await waitFor(() =>
+        expect(
+          screen.getByRole('button', { name: /通報 1 のメッセージを削除/ }),
+        ).toBeInTheDocument(),
+      );
+      await userEvent.click(screen.getByRole('button', { name: /通報 1 のメッセージを削除/ }));
+      await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledWith('メッセージを削除しました'));
+      // アクション後は対応ボタンが消える
+      expect(
+        screen.queryByRole('button', { name: /通報 1 のメッセージを削除/ }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('フィルタリング', () => {
+    it('「すべて表示」時は pending / dismissed / actioned すべてが表示される', async () => {
+      await renderModerationQueue();
+      await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
+      // pending (bob) と dismissed (carol) の両方が表示される
+      expect(screen.getByText('bob')).toBeInTheDocument();
+      expect(screen.getByText('carol')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/ModerationQueue.test.tsx
+++ b/packages/client/src/__tests__/ModerationQueue.test.tsx
@@ -43,6 +43,7 @@ const mockReports: MessageReport[] = [
   {
     id: 1,
     messageId: 10,
+    channelId: 100,
     reporterId: 2,
     reporterUsername: 'bob',
     reason: 'spam',
@@ -56,6 +57,7 @@ const mockReports: MessageReport[] = [
   {
     id: 2,
     messageId: 20,
+    channelId: 200,
     reporterId: 3,
     reporterUsername: 'carol',
     reason: 'harassment',
@@ -88,8 +90,22 @@ describe('ModerationQueue', () => {
   describe('通報一覧の表示', () => {
     it('通報の一覧が表示される', async () => {
       await renderModerationQueue();
-      await waitFor(() => expect(screen.getByText('10')).toBeInTheDocument());
-      expect(screen.getByText('20')).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByText('#10')).toBeInTheDocument());
+      expect(screen.getByText('#20')).toBeInTheDocument();
+    });
+
+    it('メッセージIDが該当投稿への外部リンクとして表示される', async () => {
+      await renderModerationQueue();
+      await waitFor(() =>
+        expect(
+          screen.getByRole('link', { name: /メッセージ 10 を別ウィンドウで開く/ }),
+        ).toBeInTheDocument(),
+      );
+      const link = screen.getByRole('link', { name: /メッセージ 10 を別ウィンドウで開く/ });
+      // ?channel=<channelId>#message-<messageId> 形式の URL を target=_blank で開く
+      expect(link).toHaveAttribute('href', '/?channel=100#message-10');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link.getAttribute('rel')).toMatch(/noopener/);
     });
 
     it('通報者のユーザー名が表示される', async () => {

--- a/packages/client/src/__tests__/ReportMessageDialog.test.tsx
+++ b/packages/client/src/__tests__/ReportMessageDialog.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * テスト対象: components/Chat/ReportMessageDialog.tsx
+ *
+ * 戦略:
+ *   - vi.mock('../api/client') でAPIをモック化
+ *   - 通報ダイアログの理由選択・コメント入力・送信フローを検証する
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import ReportMessageDialog from '../components/Chat/ReportMessageDialog';
+
+const mockReportMessage = vi.fn();
+
+vi.mock('../api/client', () => ({
+  api: {
+    messages: {
+      report: (id: number, input: unknown) => mockReportMessage(id, input),
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockReportMessage.mockResolvedValue({ report: { id: 1 } });
+});
+
+describe('ReportMessageDialog', () => {
+  describe('表示・非表示', () => {
+    it('open=true のときダイアログが表示される', () => {
+      render(<ReportMessageDialog open={true} messageId={1} onClose={vi.fn()} />);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('メッセージを通報')).toBeInTheDocument();
+    });
+
+    it('open=false のときダイアログが表示されない', () => {
+      render(<ReportMessageDialog open={false} messageId={1} onClose={vi.fn()} />);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('理由選択', () => {
+    it('spam / harassment / other の選択肢がある', () => {
+      render(<ReportMessageDialog open={true} messageId={1} onClose={vi.fn()} />);
+      expect(screen.getByRole('radio', { name: 'スパム' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'ハラスメント' })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: 'その他' })).toBeInTheDocument();
+    });
+
+    it('理由を選択できる', async () => {
+      render(<ReportMessageDialog open={true} messageId={1} onClose={vi.fn()} />);
+      await userEvent.click(screen.getByRole('radio', { name: 'スパム' }));
+      expect(screen.getByRole('radio', { name: 'スパム' })).toBeChecked();
+    });
+  });
+
+  describe('コメント入力', () => {
+    it('任意コメントの入力フィールドが存在する', () => {
+      render(<ReportMessageDialog open={true} messageId={1} onClose={vi.fn()} />);
+      expect(screen.getByLabelText('通報コメント')).toBeInTheDocument();
+    });
+  });
+
+  describe('送信', () => {
+    it('理由を選択して送信すると api.messages.report が呼ばれる', async () => {
+      render(<ReportMessageDialog open={true} messageId={5} onClose={vi.fn()} />);
+      await userEvent.click(screen.getByRole('radio', { name: 'スパム' }));
+      await userEvent.click(screen.getByRole('button', { name: '通報する' }));
+      await waitFor(() =>
+        expect(mockReportMessage).toHaveBeenCalledWith(
+          5,
+          expect.objectContaining({ reason: 'spam' }),
+        ),
+      );
+    });
+
+    it('送信成功後に onClose コールバックが呼ばれる', async () => {
+      const onClose = vi.fn();
+      render(<ReportMessageDialog open={true} messageId={1} onClose={onClose} />);
+      await userEvent.click(screen.getByRole('radio', { name: 'ハラスメント' }));
+      await userEvent.click(screen.getByRole('button', { name: '通報する' }));
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('理由未選択の状態では送信ボタンが無効化される', () => {
+      render(<ReportMessageDialog open={true} messageId={1} onClose={vi.fn()} />);
+      expect(screen.getByRole('button', { name: '通報する' })).toBeDisabled();
+    });
+
+    it('API エラー時はエラーメッセージが表示される', async () => {
+      mockReportMessage.mockRejectedValue(new Error('通報に失敗しました'));
+      render(<ReportMessageDialog open={true} messageId={1} onClose={vi.fn()} />);
+      await userEvent.click(screen.getByRole('radio', { name: 'その他' }));
+      await userEvent.click(screen.getByRole('button', { name: '通報する' }));
+      await waitFor(() => expect(screen.getByText('通報に失敗しました')).toBeInTheDocument());
+    });
+  });
+
+  describe('キャンセル', () => {
+    it('キャンセルボタンをクリックすると onClose が呼ばれる', async () => {
+      const onClose = vi.fn();
+      render(<ReportMessageDialog open={true} messageId={1} onClose={onClose} />);
+      await userEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -38,6 +38,9 @@ import type {
   UpdateEventInput,
   RsvpStatus,
   RsvpUser,
+  MessageReport,
+  ReportMessageInput,
+  ReportStatus,
 } from '@chat-app/shared';
 import type { AdminUser, AdminChannel, AdminStats, AuditLogListResponse } from '../types/admin';
 
@@ -179,6 +182,21 @@ export const api = {
       request<{ replies: Message[] }>(`/messages/${messageId}/replies`),
     forward: (messageId: number, input: ForwardMessageInput) =>
       request<{ message: Message }>(`/messages/${messageId}/forward`, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    // #116 通報
+    report: (messageId: number, input: ReportMessageInput) =>
+      request<{
+        report: {
+          id: number;
+          messageId: number;
+          reason: string;
+          comment: string | null;
+          status: string;
+          createdAt: string;
+        };
+      }>(`/messages/${messageId}/report`, {
         method: 'POST',
         body: JSON.stringify(input),
       }),
@@ -446,6 +464,22 @@ export const api = {
         }),
       delete: (id: number) =>
         request<void>(`/admin/attachment-blocklist/${id}`, { method: 'DELETE' }),
+    },
+    // #116 通報キュー
+    reports: {
+      list: (params?: { status?: ReportStatus }) => {
+        const q = new URLSearchParams();
+        if (params?.status) q.set('status', params.status);
+        const qs = q.toString();
+        return request<{ reports: MessageReport[] }>(`/admin/reports${qs ? `?${qs}` : ''}`);
+      },
+      dismiss: (id: number) =>
+        request<{ report: MessageReport }>(`/admin/reports/${id}/dismiss`, { method: 'POST' }),
+      action: (id: number, actionType: string) =>
+        request<{ report: MessageReport }>(`/admin/reports/${id}/action`, {
+          method: 'POST',
+          body: JSON.stringify({ actionType }),
+        }),
     },
   },
 };

--- a/packages/client/src/components/Admin/ModerationQueue.tsx
+++ b/packages/client/src/components/Admin/ModerationQueue.tsx
@@ -1,0 +1,238 @@
+/**
+ * #116 モデレーションキュー
+ * 管理者が通報一覧を確認し、却下またはメッセージ削除で対応するコンポーネント
+ */
+
+import { useState, useMemo, use, Suspense, Component, ReactNode } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import type { MessageReport, ReportStatus } from '@chat-app/shared';
+import { api } from '../../api/client';
+import { useSnackbar } from '../../contexts/SnackbarContext';
+
+// ─── ErrorBoundary ────────────────────────────────────────────
+
+class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean; msg: string }> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false, msg: '' };
+  }
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, msg: error instanceof Error ? error.message : 'エラー' };
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box sx={{ p: 2, color: 'error.main' }}>
+          <Typography>エラーが発生しました: {this.state.msg}</Typography>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// ─── ステータスラベル ──────────────────────────────────────────
+
+const STATUS_LABELS: Record<ReportStatus, string> = {
+  pending: '未対応',
+  dismissed: '却下',
+  actioned: '対応済み',
+};
+
+const STATUS_COLORS: Record<ReportStatus, 'warning' | 'default' | 'success'> = {
+  pending: 'warning',
+  dismissed: 'default',
+  actioned: 'success',
+};
+
+const REASON_LABELS: Record<string, string> = {
+  spam: 'スパム',
+  harassment: 'ハラスメント',
+  other: 'その他',
+};
+
+// ─── キューコンテンツ ──────────────────────────────────────────
+
+function QueueContent({
+  reportsPromise,
+}: {
+  reportsPromise: Promise<{ reports: MessageReport[] }>;
+}) {
+  const { reports: initial } = use(reportsPromise);
+  const [reports, setReports] = useState<MessageReport[]>(initial);
+  const { showError, showSuccess } = useSnackbar();
+
+  const handleDismiss = async (reportId: number) => {
+    try {
+      const result = await api.admin.reports.dismiss(reportId);
+      setReports((prev) => prev.map((r) => (r.id === reportId ? result.report : r)));
+      showSuccess('通報を却下しました');
+    } catch {
+      showError('却下に失敗しました');
+    }
+  };
+
+  const handleDeleteMessage = async (reportId: number) => {
+    try {
+      const result = await api.admin.reports.action(reportId, 'delete_message');
+      setReports((prev) => prev.map((r) => (r.id === reportId ? result.report : r)));
+      showSuccess('メッセージを削除しました');
+    } catch {
+      showError('削除に失敗しました');
+    }
+  };
+
+  if (reports.length === 0) {
+    return (
+      <Box sx={{ p: 3, textAlign: 'center' }}>
+        <Typography color="text.secondary">通報はありません</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, overflow: 'hidden' }}
+    >
+      <Table size="small">
+        <TableHead>
+          <TableRow sx={{ bgcolor: 'grey.50' }}>
+            <TableCell sx={{ fontWeight: 600 }}>ID</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>通報日時</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>通報者</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>メッセージID</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>理由</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>コメント</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>ステータス</TableCell>
+            <TableCell sx={{ fontWeight: 600 }}>操作</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {reports.map((report) => (
+            <TableRow key={report.id} sx={{ '&:hover': { bgcolor: 'action.hover' } }}>
+              <TableCell>{report.id}</TableCell>
+              <TableCell>
+                <Typography variant="body2" color="text.secondary">
+                  {new Date(report.createdAt).toLocaleString('ja-JP')}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Typography variant="body2">{report.reporterUsername ?? '—'}</Typography>
+              </TableCell>
+              <TableCell>{report.messageId}</TableCell>
+              <TableCell>
+                <Chip
+                  label={REASON_LABELS[report.reason] ?? report.reason}
+                  size="small"
+                  variant="outlined"
+                />
+              </TableCell>
+              <TableCell>
+                <Typography variant="body2" color="text.secondary" sx={{ maxWidth: 200 }}>
+                  {report.comment ?? '—'}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Chip
+                  label={STATUS_LABELS[report.status]}
+                  color={STATUS_COLORS[report.status]}
+                  size="small"
+                  sx={{ fontWeight: 500 }}
+                />
+              </TableCell>
+              <TableCell>
+                {report.status === 'pending' && (
+                  <Box sx={{ display: 'flex', gap: 0.5 }}>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      sx={{ fontSize: 11, whiteSpace: 'nowrap' }}
+                      onClick={() => void handleDismiss(report.id)}
+                      aria-label={`通報 ${report.id} を却下`}
+                    >
+                      却下
+                    </Button>
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      color="error"
+                      sx={{ fontSize: 11, whiteSpace: 'nowrap' }}
+                      onClick={() => void handleDeleteMessage(report.id)}
+                      aria-label={`通報 ${report.id} のメッセージを削除`}
+                    >
+                      メッセージを削除
+                    </Button>
+                  </Box>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+}
+
+// ─── メインコンポーネント ──────────────────────────────────────
+
+export default function ModerationQueue() {
+  const [statusFilter, setStatusFilter] = useState<ReportStatus | 'all'>('all');
+
+  const reportsPromise = useMemo(
+    () => api.admin.reports.list(statusFilter !== 'all' ? { status: statusFilter } : undefined),
+    [statusFilter],
+  );
+
+  return (
+    <Box>
+      <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Typography variant="h6" fontWeight={600}>
+          通報キュー
+        </Typography>
+        <FormControl size="small" sx={{ minWidth: 140 }}>
+          <InputLabel id="report-status-filter-label">ステータス</InputLabel>
+          <Select
+            labelId="report-status-filter-label"
+            value={statusFilter}
+            label="ステータス"
+            onChange={(e) => setStatusFilter(e.target.value as ReportStatus | 'all')}
+          >
+            <MenuItem value="all">すべて</MenuItem>
+            <MenuItem value="pending">未対応</MenuItem>
+            <MenuItem value="dismissed">却下</MenuItem>
+            <MenuItem value="actioned">対応済み</MenuItem>
+          </Select>
+        </FormControl>
+      </Box>
+
+      <ErrorBoundary>
+        <Suspense
+          fallback={
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+              <CircularProgress />
+            </Box>
+          }
+        >
+          <QueueContent reportsPromise={reportsPromise} />
+        </Suspense>
+      </ErrorBoundary>
+    </Box>
+  );
+}

--- a/packages/client/src/components/Admin/ModerationQueue.tsx
+++ b/packages/client/src/components/Admin/ModerationQueue.tsx
@@ -11,6 +11,7 @@ import {
   CircularProgress,
   FormControl,
   InputLabel,
+  Link,
   MenuItem,
   Paper,
   Select,
@@ -21,6 +22,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type { MessageReport, ReportStatus } from '@chat-app/shared';
 import { api } from '../../api/client';
 import { useSnackbar } from '../../contexts/SnackbarContext';
@@ -136,7 +138,19 @@ function QueueContent({
               <TableCell>
                 <Typography variant="body2">{report.reporterUsername ?? '—'}</Typography>
               </TableCell>
-              <TableCell>{report.messageId}</TableCell>
+              <TableCell>
+                <Link
+                  href={`/?channel=${report.channelId}#message-${report.messageId}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  underline="hover"
+                  sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                  aria-label={`メッセージ ${report.messageId} を別ウィンドウで開く`}
+                >
+                  #{report.messageId}
+                  <OpenInNewIcon sx={{ fontSize: 14 }} />
+                </Link>
+              </TableCell>
               <TableCell>
                 <Chip
                   label={REASON_LABELS[report.reason] ?? report.reason}

--- a/packages/client/src/components/AuditLogView.tsx
+++ b/packages/client/src/components/AuditLogView.tsx
@@ -45,6 +45,9 @@ const ACTION_TYPE_LABELS: Record<AuditActionType, string> = {
   'moderation.ngword.delete': 'NG ワード削除',
   'moderation.blocklist.add': '拡張子ブロック追加',
   'moderation.blocklist.remove': '拡張子ブロック削除',
+  'report.create': '通報作成',
+  'report.dismiss': '通報却下',
+  'report.action.delete_message': '通報対応（メッセージ削除）',
 };
 
 const ACTION_TYPE_OPTIONS: AuditActionType[] = Object.keys(ACTION_TYPE_LABELS) as AuditActionType[];

--- a/packages/client/src/components/Chat/MessageActions.tsx
+++ b/packages/client/src/components/Chat/MessageActions.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Box, IconButton, Tooltip } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
+import FlagIcon from '@mui/icons-material/Flag';
 import LabelIcon from '@mui/icons-material/Label';
 import LinkIcon from '@mui/icons-material/Link';
 import EmojiEmotionsIcon from '@mui/icons-material/EmojiEmotions';
@@ -16,6 +17,7 @@ import type { Message } from '@chat-app/shared';
 import EmojiPicker from './EmojiPicker';
 import ReminderDialog from '../Reminder/ReminderDialog';
 import ForwardMessageDialog from './ForwardMessageDialog';
+import ReportMessageDialog from './ReportMessageDialog';
 import { api } from '../../api/client';
 import { useSocket } from '../../contexts/SocketContext';
 
@@ -48,6 +50,7 @@ export default function MessageActions({
   const [bookmarked, setBookmarked] = useState(isBookmarked);
   const [reminderDialogOpen, setReminderDialogOpen] = useState(false);
   const [forwardDialogOpen, setForwardDialogOpen] = useState(false);
+  const [reportDialogOpen, setReportDialogOpen] = useState(false);
   const socket = useSocket();
 
   const handleDelete = () => {
@@ -155,6 +158,14 @@ export default function MessageActions({
             <LabelIcon fontSize="small" />
           </IconButton>
         </Tooltip>
+        {/* #116 通報: 自分のメッセージ以外に表示 */}
+        {!isOwn && (
+          <Tooltip title="通報">
+            <IconButton size="small" aria-label="通報" onClick={() => setReportDialogOpen(true)}>
+              <FlagIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        )}
         {isOwn && (
           <>
             <Tooltip title="Edit">
@@ -191,6 +202,13 @@ export default function MessageActions({
         open={forwardDialogOpen}
         messageId={message.id}
         onClose={() => setForwardDialogOpen(false)}
+      />
+
+      {/* #116 通報ダイアログ */}
+      <ReportMessageDialog
+        open={reportDialogOpen}
+        messageId={message.id}
+        onClose={() => setReportDialogOpen(false)}
       />
     </>
   );

--- a/packages/client/src/components/Chat/ReportMessageDialog.tsx
+++ b/packages/client/src/components/Chat/ReportMessageDialog.tsx
@@ -1,0 +1,108 @@
+/**
+ * #116 通報ダイアログ
+ * メッセージの通報理由を選択して送信するダイアログ
+ */
+
+import { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  TextField,
+  Typography,
+} from '@mui/material';
+import type { ReportReason } from '@chat-app/shared';
+import { api } from '../../api/client';
+
+interface Props {
+  open: boolean;
+  messageId: number;
+  onClose: () => void;
+}
+
+const REASON_LABELS: Record<ReportReason, string> = {
+  spam: 'スパム',
+  harassment: 'ハラスメント',
+  other: 'その他',
+};
+
+export default function ReportMessageDialog({ open, messageId, onClose }: Props) {
+  const [reason, setReason] = useState<ReportReason | ''>('');
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    setReason('');
+    setComment('');
+    setError(null);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!reason) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.messages.report(messageId, { reason, comment: comment || undefined });
+      handleClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '通報に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+      <DialogTitle>メッセージを通報</DialogTitle>
+      <DialogContent>
+        <FormControl component="fieldset" sx={{ width: '100%' }}>
+          <RadioGroup
+            aria-label="通報理由"
+            value={reason}
+            onChange={(e) => setReason(e.target.value as ReportReason)}
+          >
+            {(Object.keys(REASON_LABELS) as ReportReason[]).map((r) => (
+              <FormControlLabel key={r} value={r} control={<Radio />} label={REASON_LABELS[r]} />
+            ))}
+          </RadioGroup>
+        </FormControl>
+        <TextField
+          label="コメント（任意）"
+          multiline
+          rows={3}
+          fullWidth
+          sx={{ mt: 2 }}
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          inputProps={{ 'aria-label': '通報コメント' }}
+        />
+        {error && (
+          <Typography color="error" variant="body2" sx={{ mt: 1 }}>
+            {error}
+          </Typography>
+        )}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleClose} variant="outlined">
+          キャンセル
+        </Button>
+        <Button
+          onClick={() => void handleSubmit()}
+          variant="contained"
+          color="error"
+          disabled={!reason || submitting}
+        >
+          通報する
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -41,6 +41,7 @@ import { api } from '../api/client';
 import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
 import AuditLogView from '../components/AuditLogView';
 import ModerationContent from '../components/Admin/ModerationContent';
+import ModerationQueue from '../components/Admin/ModerationQueue';
 
 // ─── 統計タブ ────────────────────────────────────────────────
 const STAT_CARDS = [
@@ -532,6 +533,7 @@ export default function AdminPage() {
           <Tab label="チャンネル管理" />
           <Tab label="監査ログ" />
           <Tab label="モデレーション設定" />
+          <Tab label="通報キュー" />
         </Tabs>
 
         {tab === 0 && (
@@ -557,6 +559,7 @@ export default function AdminPage() {
         )}
         {tab === 3 && <AuditLogView actors={actors} />}
         {tab === 4 && <ModerationContent />}
+        {tab === 5 && <ModerationQueue />}
       </Box>
     </Box>
   );

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -315,6 +315,20 @@ export function createTestDatabase() {
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       PRIMARY KEY (event_id, user_id)
     );
+
+    CREATE TABLE IF NOT EXISTS message_reports (
+      id SERIAL PRIMARY KEY,
+      message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      reporter_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      reason TEXT NOT NULL,
+      comment TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      action_taken TEXT,
+      handled_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      handled_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (message_id, reporter_id)
+    );
   `);
 
   // pg-mem で作った Pool アダプタ
@@ -390,6 +404,7 @@ export function getSharedTestDatabase(): TestDatabase {
  */
 export async function resetTestData(db: TestDatabase): Promise<void> {
   // 外部キー参照の末端から順に削除する
+  await db.execute('DELETE FROM message_reports', []);
   await db.execute('DELETE FROM event_rsvps', []);
   await db.execute('DELETE FROM events', []);
   await db.execute('DELETE FROM invite_link_uses', []);

--- a/packages/server/src/__tests__/moderationReport.test.ts
+++ b/packages/server/src/__tests__/moderationReport.test.ts
@@ -69,6 +69,7 @@ describe('moderationReportService.report', () => {
     const msgId = await insertMessage(channelId, authorId, 'reportable');
     const result = await moderationReportService.report(reporterId, msgId, { reason: 'spam' });
     expect(result.messageId).toBe(msgId);
+    expect(result.channelId).toBe(channelId);
     expect(result.reporterId).toBe(reporterId);
     expect(result.reason).toBe('spam');
     expect(result.status).toBe('pending');

--- a/packages/server/src/__tests__/moderationReport.test.ts
+++ b/packages/server/src/__tests__/moderationReport.test.ts
@@ -1,0 +1,599 @@
+/**
+ * テスト対象: #116 通報 / モデレーションキュー
+ *
+ * 戦略:
+ *   - moderationReportService の単体テスト: 通報・却下・メッセージ削除アクションのビジネスロジック
+ *   - HTTP 統合テスト: POST /api/messages/:id/report, GET/POST /api/admin/reports/*
+ *   - 監査ログ記録の検証
+ *   - pg-mem のインメモリ PostgreSQL 互換 DB を使用
+ */
+
+import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+jest.mock('../db/database', () => testDb);
+
+import request from 'supertest';
+import { createApp } from '../app';
+import { registerUser, createChannelReq, insertMessage } from './__fixtures__/testHelpers';
+import * as moderationReportService from '../services/moderationReportService';
+import { listAuditLogs } from '../services/auditLogService';
+
+const app = createApp();
+
+async function promoteToAdmin(userId: number): Promise<void> {
+  await testDb.execute('UPDATE users SET role = $1 WHERE id = $2', ['admin', userId]);
+}
+
+/** テストデータ作成ヘルパー: ユーザー・チャンネル・メッセージを一括作成 */
+async function setupReportScenario() {
+  const { token: reporterToken, userId: reporterId } = await registerUser(
+    app,
+    'reporter',
+    'reporter@example.com',
+  );
+  const { token: authorToken, userId: authorId } = await registerUser(
+    app,
+    'author',
+    'author@example.com',
+  );
+  const channelId = await createChannelReq(app, authorToken, 'test-channel');
+  const messageId = await insertMessage(channelId, authorId, 'test message content');
+  return { reporterToken, reporterId, authorToken, authorId, channelId, messageId };
+}
+
+/** 通報レコードを直接 INSERT して ID を返す */
+async function insertReport(
+  messageId: number,
+  reporterId: number,
+  status = 'pending',
+  actionTaken: string | null = null,
+): Promise<number> {
+  const row = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO message_reports (message_id, reporter_id, reason, status, action_taken)
+     VALUES ($1, $2, 'spam', $3, $4) RETURNING id`,
+    [messageId, reporterId, status, actionTaken],
+  );
+  return row!.id;
+}
+
+beforeEach(async () => {
+  await resetTestData(testDb);
+});
+
+// ─── moderationReportService ユニットテスト ────────────────────
+
+describe('moderationReportService.report', () => {
+  it('メッセージを通報できる', async () => {
+    const { reporterId, authorId, channelId } = await setupReportScenario();
+    const msgId = await insertMessage(channelId, authorId, 'reportable');
+    const result = await moderationReportService.report(reporterId, msgId, { reason: 'spam' });
+    expect(result.messageId).toBe(msgId);
+    expect(result.reporterId).toBe(reporterId);
+    expect(result.reason).toBe('spam');
+    expect(result.status).toBe('pending');
+  });
+
+  it('自分のメッセージを通報すると 400 になる', async () => {
+    const { authorId, messageId } = await setupReportScenario();
+    await expect(
+      moderationReportService.report(authorId, messageId, { reason: 'spam' }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('同一ユーザーが同一メッセージを二重通報すると 409 になる', async () => {
+    const { reporterId, messageId } = await setupReportScenario();
+    await moderationReportService.report(reporterId, messageId, { reason: 'spam' });
+    await expect(
+      moderationReportService.report(reporterId, messageId, { reason: 'harassment' }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it('存在しないメッセージを通報すると 404 になる', async () => {
+    const { reporterId } = await setupReportScenario();
+    await expect(
+      moderationReportService.report(reporterId, 99999, { reason: 'spam' }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  // 追加仕様 1: 削除済みメッセージへの通報は不可
+  it('is_deleted = true のメッセージを通報すると 404 になる', async () => {
+    const { reporterId, messageId } = await setupReportScenario();
+    await testDb.execute('UPDATE messages SET is_deleted = true WHERE id = $1', [messageId]);
+    await expect(
+      moderationReportService.report(reporterId, messageId, { reason: 'spam' }),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('moderationReportService.listQueue', () => {
+  it('pending ステータスの通報一覧を返す', async () => {
+    const { reporterId, messageId } = await setupReportScenario();
+    await insertReport(messageId, reporterId, 'pending');
+    const reports = await moderationReportService.listQueue({ status: 'pending' });
+    expect(reports.length).toBeGreaterThanOrEqual(1);
+    expect(reports.every((r) => r.status === 'pending')).toBe(true);
+  });
+
+  it('status フィルタで dismissed も取得できる', async () => {
+    const { reporterId, messageId } = await setupReportScenario();
+    await insertReport(messageId, reporterId, 'dismissed');
+    const reports = await moderationReportService.listQueue({ status: 'dismissed' });
+    expect(reports.some((r) => r.status === 'dismissed')).toBe(true);
+  });
+});
+
+describe('moderationReportService.dismiss', () => {
+  it('pending の通報を dismissed にできる', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'pending');
+    const result = await moderationReportService.dismiss(reportId, authorId);
+    expect(result.status).toBe('dismissed');
+    expect(result.handledBy).toBe(authorId);
+  });
+
+  it('存在しない通報を却下すると 404 になる', async () => {
+    const { authorId } = await setupReportScenario();
+    await expect(moderationReportService.dismiss(99999, authorId)).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  // 追加仕様 3: 冪等
+  it('既に dismissed の通報を再度却下しても 200 で同じ結果を返す（冪等）', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'dismissed');
+    const result = await moderationReportService.dismiss(reportId, authorId);
+    expect(result.status).toBe('dismissed');
+  });
+
+  it('既に actioned の通報を却下しても 200 で同じ結果を返す（冪等）', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'actioned', 'delete_message');
+    const result = await moderationReportService.dismiss(reportId, authorId);
+    expect(result.status).toBe('actioned');
+  });
+
+  it('冪等ケースでは監査ログが重複記録されない', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'dismissed');
+    await moderationReportService.dismiss(reportId, authorId);
+    await moderationReportService.dismiss(reportId, authorId);
+    const { logs } = await listAuditLogs({ actionType: 'report.dismiss' });
+    // 冪等ケースなので新規ログは記録されない（0件）
+    expect(logs.length).toBe(0);
+  });
+});
+
+describe('moderationReportService.actionDeleteMessage', () => {
+  it('通報に対して delete_message アクションを取るとメッセージが is_deleted = true になる', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'pending');
+    await moderationReportService.actionDeleteMessage(reportId, authorId);
+    const msg = await testDb.queryOne<{ is_deleted: boolean }>(
+      'SELECT is_deleted FROM messages WHERE id = $1',
+      [messageId],
+    );
+    expect(msg!.is_deleted).toBe(true);
+  });
+
+  it('通報の status が actioned、action_taken が delete_message になる', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'pending');
+    const result = await moderationReportService.actionDeleteMessage(reportId, authorId);
+    expect(result.status).toBe('actioned');
+    expect(result.actionTaken).toBe('delete_message');
+  });
+
+  it('存在しない通報に対してアクションを取ると 404 になる', async () => {
+    const { authorId } = await setupReportScenario();
+    await expect(
+      moderationReportService.actionDeleteMessage(99999, authorId),
+    ).rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  // 追加仕様 3: 冪等
+  it('既に actioned の通報に再度アクションを取っても 200 で同じ結果を返す（冪等）', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'actioned', 'delete_message');
+    const result = await moderationReportService.actionDeleteMessage(reportId, authorId);
+    expect(result.status).toBe('actioned');
+  });
+
+  it('冪等ケースでは監査ログが重複記録されない', async () => {
+    const { reporterId, authorId, messageId } = await setupReportScenario();
+    const reportId = await insertReport(messageId, reporterId, 'actioned', 'delete_message');
+    await moderationReportService.actionDeleteMessage(reportId, authorId);
+    await moderationReportService.actionDeleteMessage(reportId, authorId);
+    const { logs } = await listAuditLogs({ actionType: 'report.action.delete_message' });
+    // 冪等ケースなので新規ログは記録されない（0件）
+    expect(logs.length).toBe(0);
+  });
+});
+
+// ─── POST /api/messages/:id/report ───────────────────────────
+
+describe('POST /api/messages/:id/report', () => {
+  it('認証ユーザーがメッセージを通報できる（201）', async () => {
+    const { reporterToken, messageId } = await setupReportScenario();
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'spam' });
+    expect(res.status).toBe(201);
+    expect(res.body.report).toBeDefined();
+    expect(res.body.report.reason).toBe('spam');
+  });
+
+  it('未認証のリクエストは 401 を返す', async () => {
+    const { messageId } = await setupReportScenario();
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .send({ reason: 'spam' });
+    expect(res.status).toBe(401);
+  });
+
+  it('自分のメッセージを通報すると 400 を返す', async () => {
+    const { authorToken, messageId } = await setupReportScenario();
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${authorToken}`)
+      .send({ reason: 'spam' });
+    expect(res.status).toBe(400);
+  });
+
+  it('同一メッセージへの二重通報は 409 を返す', async () => {
+    const { reporterToken, messageId } = await setupReportScenario();
+    await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'spam' });
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'harassment' });
+    expect(res.status).toBe(409);
+  });
+
+  it('reason が不正値の場合は 400 を返す', async () => {
+    const { reporterToken, messageId } = await setupReportScenario();
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'invalid_reason' });
+    expect(res.status).toBe(400);
+  });
+
+  // 追加仕様 1: 削除済みメッセージへの通報は不可
+  it('is_deleted = true のメッセージを通報すると 404 を返す', async () => {
+    const { reporterToken, messageId } = await setupReportScenario();
+    await testDb.execute('UPDATE messages SET is_deleted = true WHERE id = $1', [messageId]);
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'spam' });
+    expect(res.status).toBe(404);
+  });
+
+  // 追加仕様 2: 通報完了レスポンスには通報者情報を含めない
+  it('201 レスポンスに reporterId / reporterUsername が含まれない', async () => {
+    const { reporterToken, messageId } = await setupReportScenario();
+    const res = await request(app)
+      .post(`/api/messages/${messageId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'spam' });
+    expect(res.status).toBe(201);
+    expect(res.body.report.reporterId).toBeUndefined();
+    expect(res.body.report.reporterUsername).toBeUndefined();
+  });
+});
+
+// ─── GET /api/admin/reports ───────────────────────────────────
+
+describe('GET /api/admin/reports', () => {
+  it('管理者は通報一覧を取得できる（200）', async () => {
+    const { token, userId } = await registerUser(app, 'admin1', 'admin1@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app).get('/api/admin/reports').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.reports)).toBe(true);
+  });
+
+  it('一般ユーザーは 403 を返す', async () => {
+    // 先にダミー admin を作って 2 人目は一般ユーザーになるようにする
+    await registerUser(app, 'dummy_admin', 'dummy_admin@example.com');
+    const { token } = await registerUser(app, 'user1', 'user1@example.com');
+    const res = await request(app).get('/api/admin/reports').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('status クエリで絞り込みができる', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'admin2',
+      'admin2@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'author2',
+      'author2@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'reporter2', 'reporter2@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-filter');
+    const msgId = await insertMessage(channelId, authorId, 'filter test');
+    await insertReport(msgId, reporterId, 'dismissed');
+
+    const res = await request(app)
+      .get('/api/admin/reports?status=dismissed')
+      .set('Cookie', `token=${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.reports.every((r: { status: string }) => r.status === 'dismissed')).toBe(true);
+  });
+
+  // 追加仕様 2: 管理者レスポンスには通報者情報が含まれる
+  it('管理者向けレスポンスには reporterId と reporterUsername が含まれる', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'admin3',
+      'admin3@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'author3',
+      'author3@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'reporter3', 'reporter3@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-privacy');
+    const msgId = await insertMessage(channelId, authorId, 'privacy test');
+    await insertReport(msgId, reporterId, 'pending');
+
+    const res = await request(app).get('/api/admin/reports').set('Cookie', `token=${adminToken}`);
+    expect(res.status).toBe(200);
+    const rep = res.body.reports.find((r: { reporterId: number }) => r.reporterId === reporterId);
+    expect(rep).toBeDefined();
+    expect(rep.reporterId).toBe(reporterId);
+    expect(rep.reporterUsername).toBe('reporter3');
+  });
+});
+
+// ─── POST /api/admin/reports/:id/dismiss ──────────────────────
+
+describe('POST /api/admin/reports/:id/dismiss', () => {
+  it('管理者が通報を却下できる（200）', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'adm_d1',
+      'adm_d1@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'aut_d1',
+      'aut_d1@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'rep_d1', 'rep_d1@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-dismiss1');
+    const msgId = await insertMessage(channelId, authorId, 'msg-dismiss');
+    const reportId = await insertReport(msgId, reporterId, 'pending');
+
+    const res = await request(app)
+      .post(`/api/admin/reports/${reportId}/dismiss`)
+      .set('Cookie', `token=${adminToken}`);
+    expect(res.status).toBe(200);
+    expect(res.body.report.status).toBe('dismissed');
+  });
+
+  it('一般ユーザーは 403 を返す', async () => {
+    await registerUser(app, 'dummy_adm_d', 'dummy_adm_d@example.com');
+    const { token } = await registerUser(app, 'usr_d1', 'usr_d1@example.com');
+    const res = await request(app)
+      .post('/api/admin/reports/1/dismiss')
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('存在しない通報は 404 を返す', async () => {
+    const { token, userId } = await registerUser(app, 'adm_d2', 'adm_d2@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/reports/99999/dismiss')
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  // 追加仕様 3: 冪等
+  it('既に dismissed の通報への再却下は 200 で冪等に成功する', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'adm_d3',
+      'adm_d3@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'aut_d3',
+      'aut_d3@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'rep_d3', 'rep_d3@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-idem-d');
+    const msgId = await insertMessage(channelId, authorId, 'idem-dismiss');
+    const reportId = await insertReport(msgId, reporterId, 'dismissed');
+
+    const res = await request(app)
+      .post(`/api/admin/reports/${reportId}/dismiss`)
+      .set('Cookie', `token=${adminToken}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── POST /api/admin/reports/:id/action ──────────────────────
+
+describe('POST /api/admin/reports/:id/action', () => {
+  it('管理者が delete_message アクションを実行できる（200）', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'adm_a1',
+      'adm_a1@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'aut_a1',
+      'aut_a1@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'rep_a1', 'rep_a1@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-action1');
+    const msgId = await insertMessage(channelId, authorId, 'action msg');
+    const reportId = await insertReport(msgId, reporterId, 'pending');
+
+    const res = await request(app)
+      .post(`/api/admin/reports/${reportId}/action`)
+      .set('Cookie', `token=${adminToken}`)
+      .send({ actionType: 'delete_message' });
+    expect(res.status).toBe(200);
+    expect(res.body.report.status).toBe('actioned');
+    expect(res.body.report.actionTaken).toBe('delete_message');
+  });
+
+  it('一般ユーザーは 403 を返す', async () => {
+    await registerUser(app, 'dummy_adm_a', 'dummy_adm_a@example.com');
+    const { token } = await registerUser(app, 'usr_a1', 'usr_a1@example.com');
+    const res = await request(app)
+      .post('/api/admin/reports/1/action')
+      .set('Cookie', `token=${token}`)
+      .send({ actionType: 'delete_message' });
+    expect(res.status).toBe(403);
+  });
+
+  it('不正なアクション種別は 400 を返す', async () => {
+    const { token, userId } = await registerUser(app, 'adm_a2', 'adm_a2@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/reports/1/action')
+      .set('Cookie', `token=${token}`)
+      .send({ actionType: 'warn_user' });
+    expect(res.status).toBe(400);
+  });
+
+  it('存在しない通報は 404 を返す', async () => {
+    const { token, userId } = await registerUser(app, 'adm_a3', 'adm_a3@example.com');
+    await promoteToAdmin(userId);
+    const res = await request(app)
+      .post('/api/admin/reports/99999/action')
+      .set('Cookie', `token=${token}`)
+      .send({ actionType: 'delete_message' });
+    expect(res.status).toBe(404);
+  });
+
+  // 追加仕様 3: 冪等
+  it('既に actioned の通報への再アクションは 200 で冪等に成功する', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'adm_a4',
+      'adm_a4@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'aut_a4',
+      'aut_a4@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'rep_a4', 'rep_a4@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-idem-a');
+    const msgId = await insertMessage(channelId, authorId, 'idem-action');
+    const reportId = await insertReport(msgId, reporterId, 'actioned', 'delete_message');
+
+    const res = await request(app)
+      .post(`/api/admin/reports/${reportId}/action`)
+      .set('Cookie', `token=${adminToken}`)
+      .send({ actionType: 'delete_message' });
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── 監査ログ ─────────────────────────────────────────────────
+
+describe('監査ログ', () => {
+  it('通報作成時に "report.create" が記録される', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'al_rc',
+      'al_rc@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'al_aut_rc',
+      'al_aut_rc@example.com',
+    );
+    const { token: reporterToken, userId: reporterId } = await registerUser(
+      app,
+      'al_rep_rc',
+      'al_rep_rc@example.com',
+    );
+    void adminToken;
+    const channelId = await createChannelReq(app, authorToken, 'ch-al-rc');
+    const msgId = await insertMessage(channelId, authorId, 'audit msg');
+
+    await request(app)
+      .post(`/api/messages/${msgId}/report`)
+      .set('Cookie', `token=${reporterToken}`)
+      .send({ reason: 'spam' });
+
+    const { logs } = await listAuditLogs({ actionType: 'report.create' });
+    expect(logs.find((l) => l.actorUserId === reporterId)).toBeDefined();
+  });
+
+  it('通報却下時に "report.dismiss" が記録される', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'al_rd',
+      'al_rd@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'al_aut_rd',
+      'al_aut_rd@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'al_rep_rd', 'al_rep_rd@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-al-rd');
+    const msgId = await insertMessage(channelId, authorId, 'dismiss msg');
+    const reportId = await insertReport(msgId, reporterId, 'pending');
+
+    await request(app)
+      .post(`/api/admin/reports/${reportId}/dismiss`)
+      .set('Cookie', `token=${adminToken}`);
+
+    const { logs } = await listAuditLogs({ actionType: 'report.dismiss' });
+    expect(logs.find((l) => l.actorUserId === adminId)).toBeDefined();
+  });
+
+  it('delete_message アクション実行時に "report.action.delete_message" が記録される', async () => {
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'al_ra',
+      'al_ra@example.com',
+    );
+    await promoteToAdmin(adminId);
+    const { token: authorToken, userId: authorId } = await registerUser(
+      app,
+      'al_aut_ra',
+      'al_aut_ra@example.com',
+    );
+    const { userId: reporterId } = await registerUser(app, 'al_rep_ra', 'al_rep_ra@example.com');
+    const channelId = await createChannelReq(app, authorToken, 'ch-al-ra');
+    const msgId = await insertMessage(channelId, authorId, 'action msg');
+    const reportId = await insertReport(msgId, reporterId, 'pending');
+
+    await request(app)
+      .post(`/api/admin/reports/${reportId}/action`)
+      .set('Cookie', `token=${adminToken}`)
+      .send({ actionType: 'delete_message' });
+
+    const { logs } = await listAuditLogs({ actionType: 'report.action.delete_message' });
+    expect(logs.find((l) => l.actorUserId === adminId)).toBeDefined();
+  });
+});

--- a/packages/server/src/controllers/moderationReportController.ts
+++ b/packages/server/src/controllers/moderationReportController.ts
@@ -1,0 +1,89 @@
+/**
+ * #116 通報 / モデレーションキュー コントローラー
+ */
+
+import { Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../middleware/auth';
+import * as moderationReportService from '../services/moderationReportService';
+import type { ReportMessageInput, ReportStatus } from '@chat-app/shared';
+
+// ─── POST /api/messages/:id/report ───────────────────────────
+
+export async function reportMessage(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const messageId = Number(req.params.id);
+    const input = req.body as ReportMessageInput;
+    const created = await moderationReportService.report(req.userId, messageId, input);
+    // 通報者情報を一般ユーザーに返さない（自分の通報IDのみ返す）
+    res.status(201).json({
+      report: {
+        id: created.id,
+        messageId: created.messageId,
+        reason: created.reason,
+        comment: created.comment,
+        status: created.status,
+        createdAt: created.createdAt,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── GET /api/admin/reports ───────────────────────────────────
+
+export async function listReports(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const status = req.query.status as ReportStatus | undefined;
+    const reports = await moderationReportService.listQueue(status ? { status } : undefined);
+    res.json({ reports });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── POST /api/admin/reports/:id/dismiss ─────────────────────
+
+export async function dismissReport(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const reportId = Number(req.params.id);
+    const updated = await moderationReportService.dismiss(reportId, req.userId);
+    res.json({ report: updated });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// ─── POST /api/admin/reports/:id/action ──────────────────────
+
+export async function actionReport(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const reportId = Number(req.params.id);
+    const { actionType } = req.body as { actionType: string };
+
+    if (actionType === 'delete_message') {
+      const updated = await moderationReportService.actionDeleteMessage(reportId, req.userId);
+      res.json({ report: updated });
+    } else {
+      res.status(400).json({ error: 'Invalid action type' });
+    }
+  } catch (err) {
+    next(err);
+  }
+}

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -3,6 +3,7 @@ import { authenticateToken, requireAdmin, AuthenticatedRequest } from '../middle
 import * as controller from '../controllers/adminController';
 import * as channelController from '../controllers/channelController';
 import * as moderationController from '../controllers/moderationController';
+import * as moderationReportController from '../controllers/moderationReportController';
 
 const router = Router();
 
@@ -70,6 +71,17 @@ router.post('/attachment-blocklist', (req, res, next) =>
 );
 router.delete('/attachment-blocklist/:id', (req, res, next) =>
   moderationController.deleteBlockedExtension(req as unknown as AuthenticatedRequest, res, next),
+);
+
+// #116 通報キュー
+router.get('/reports', (req, res, next) =>
+  moderationReportController.listReports(req as unknown as AuthenticatedRequest, res, next),
+);
+router.post('/reports/:id/dismiss', (req, res, next) =>
+  moderationReportController.dismissReport(req as unknown as AuthenticatedRequest, res, next),
+);
+router.post('/reports/:id/action', (req, res, next) =>
+  moderationReportController.actionReport(req as unknown as AuthenticatedRequest, res, next),
 );
 
 export default router;

--- a/packages/server/src/routes/messages.ts
+++ b/packages/server/src/routes/messages.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import * as controller from '../controllers/messageController';
-import { authenticateToken } from '../middleware/auth';
+import * as moderationReportController from '../controllers/moderationReportController';
+import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 
 const router = Router();
 
@@ -154,5 +155,10 @@ router.put('/:id', authenticateToken, controller.editMessage);
  *         $ref: '#/components/responses/NotFound'
  */
 router.delete('/:id', authenticateToken, controller.deleteMessage);
+
+// #116 通報
+router.post('/:id/report', authenticateToken, (req, res, next) =>
+  moderationReportController.reportMessage(req as unknown as AuthenticatedRequest, res, next),
+);
 
 export default router;

--- a/packages/server/src/services/moderationReportService.ts
+++ b/packages/server/src/services/moderationReportService.ts
@@ -23,6 +23,7 @@ import * as auditLogService from './auditLogService';
 interface MessageReportRow {
   id: number;
   message_id: number;
+  channel_id: number;
   reporter_id: number | null;
   reporter_username: string | null;
   reason: string;
@@ -38,6 +39,7 @@ function toMessageReport(row: MessageReportRow): MessageReport {
   return {
     id: row.id,
     messageId: row.message_id,
+    channelId: row.channel_id,
     reporterId: row.reporter_id,
     reporterUsername: row.reporter_username,
     reason: row.reason as ReportReason,
@@ -100,8 +102,9 @@ export async function report(
 
   // reporter_username を JOIN して取得
   const inserted = await queryOne<MessageReportRow>(
-    `SELECT mr.*, u.username AS reporter_username
+    `SELECT mr.*, m.channel_id, u.username AS reporter_username
      FROM message_reports mr
+     INNER JOIN messages m ON m.id = mr.message_id
      LEFT JOIN users u ON u.id = mr.reporter_id
      WHERE mr.id = $1`,
     [newRow!.id],
@@ -133,8 +136,9 @@ export async function listQueue(filter?: { status?: ReportStatus }): Promise<Mes
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
   const rows = await query<MessageReportRow>(
-    `SELECT mr.*, u.username AS reporter_username
+    `SELECT mr.*, m.channel_id, u.username AS reporter_username
      FROM message_reports mr
+     INNER JOIN messages m ON m.id = mr.message_id
      LEFT JOIN users u ON u.id = mr.reporter_id
      ${whereClause}
      ORDER BY mr.created_at DESC`,
@@ -150,8 +154,9 @@ export async function listQueue(filter?: { status?: ReportStatus }): Promise<Mes
  */
 export async function dismiss(reportId: number, handlerUserId: number): Promise<MessageReport> {
   const existing = await queryOne<MessageReportRow>(
-    `SELECT mr.*, u.username AS reporter_username
+    `SELECT mr.*, m.channel_id, u.username AS reporter_username
      FROM message_reports mr
+     INNER JOIN messages m ON m.id = mr.message_id
      LEFT JOIN users u ON u.id = mr.reporter_id
      WHERE mr.id = $1`,
     [reportId],
@@ -176,8 +181,9 @@ export async function dismiss(reportId: number, handlerUserId: number): Promise<
 
   // reporter_username を JOIN して取得
   const result = await queryOne<MessageReportRow>(
-    `SELECT mr.*, u.username AS reporter_username
+    `SELECT mr.*, m.channel_id, u.username AS reporter_username
      FROM message_reports mr
+     INNER JOIN messages m ON m.id = mr.message_id
      LEFT JOIN users u ON u.id = mr.reporter_id
      WHERE mr.id = $1`,
     [reportId],
@@ -204,8 +210,9 @@ export async function actionDeleteMessage(
   handlerUserId: number,
 ): Promise<MessageReport> {
   const existing = await queryOne<MessageReportRow>(
-    `SELECT mr.*, u.username AS reporter_username
+    `SELECT mr.*, m.channel_id, u.username AS reporter_username
      FROM message_reports mr
+     INNER JOIN messages m ON m.id = mr.message_id
      LEFT JOIN users u ON u.id = mr.reporter_id
      WHERE mr.id = $1`,
     [reportId],
@@ -233,8 +240,9 @@ export async function actionDeleteMessage(
   );
 
   const result = await queryOne<MessageReportRow>(
-    `SELECT mr.*, u.username AS reporter_username
+    `SELECT mr.*, m.channel_id, u.username AS reporter_username
      FROM message_reports mr
+     INNER JOIN messages m ON m.id = mr.message_id
      LEFT JOIN users u ON u.id = mr.reporter_id
      WHERE mr.id = $1`,
     [reportId],

--- a/packages/server/src/services/moderationReportService.ts
+++ b/packages/server/src/services/moderationReportService.ts
@@ -1,0 +1,252 @@
+/**
+ * #116 通報 / モデレーションキュー サービス層
+ *
+ * MVP仕様:
+ *   - 通報作成: 自分のメッセージへの通報は 400, 削除済みメッセージは 404,
+ *     二重通報（同一reporter×message）は 409
+ *   - 対応アクション: dismiss / delete_message の 2 つのみ
+ *   - 既に対応済み（dismissed / actioned）への再アクションは冪等（200で現状返却）
+ *   - 監査ログは新規処理時のみ記録（冪等ケースでは記録しない）
+ *   - 通報者情報（reporterId / reporterUsername）は管理者向け API のみ返却
+ */
+
+import { query, queryOne, execute } from '../db/database';
+import type {
+  MessageReport,
+  ReportReason,
+  ReportStatus,
+  ReportMessageInput,
+} from '@chat-app/shared';
+import { createError } from '../middleware/errorHandler';
+import * as auditLogService from './auditLogService';
+
+interface MessageReportRow {
+  id: number;
+  message_id: number;
+  reporter_id: number | null;
+  reporter_username: string | null;
+  reason: string;
+  comment: string | null;
+  status: string;
+  action_taken: string | null;
+  handled_by: number | null;
+  handled_at: string | null;
+  created_at: string;
+}
+
+function toMessageReport(row: MessageReportRow): MessageReport {
+  return {
+    id: row.id,
+    messageId: row.message_id,
+    reporterId: row.reporter_id,
+    reporterUsername: row.reporter_username,
+    reason: row.reason as ReportReason,
+    comment: row.comment,
+    status: row.status as ReportStatus,
+    actionTaken: row.action_taken,
+    handledBy: row.handled_by,
+    handledAt: row.handled_at,
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * メッセージを通報する
+ */
+export async function report(
+  reporterId: number,
+  messageId: number,
+  input: ReportMessageInput,
+): Promise<MessageReport> {
+  // 通報理由バリデーション
+  const validReasons: ReportReason[] = ['spam', 'harassment', 'other'];
+  if (!validReasons.includes(input.reason)) {
+    throw createError('Invalid reason', 400);
+  }
+
+  // メッセージ存在確認（削除済み含む）
+  const msg = await queryOne<{ id: number; user_id: number | null; is_deleted: boolean }>(
+    'SELECT id, user_id, is_deleted FROM messages WHERE id = $1',
+    [messageId],
+  );
+  if (!msg) {
+    throw createError('Message not found', 404);
+  }
+  // 削除済みメッセージは通報不可
+  if (msg.is_deleted) {
+    throw createError('Message not found', 404);
+  }
+  // 自分のメッセージは通報不可
+  if (msg.user_id === reporterId) {
+    throw createError('Cannot report your own message', 400);
+  }
+
+  // 重複通報チェック
+  const existing = await queryOne<{ id: number }>(
+    'SELECT id FROM message_reports WHERE message_id = $1 AND reporter_id = $2',
+    [messageId, reporterId],
+  );
+  if (existing) {
+    throw createError('Already reported', 409);
+  }
+
+  // INSERT して id を取得
+  const newRow = await queryOne<{ id: number }>(
+    `INSERT INTO message_reports (message_id, reporter_id, reason, comment)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id`,
+    [messageId, reporterId, input.reason, input.comment ?? null],
+  );
+
+  // reporter_username を JOIN して取得
+  const inserted = await queryOne<MessageReportRow>(
+    `SELECT mr.*, u.username AS reporter_username
+     FROM message_reports mr
+     LEFT JOIN users u ON u.id = mr.reporter_id
+     WHERE mr.id = $1`,
+    [newRow!.id],
+  );
+
+  await auditLogService.record({
+    actorUserId: reporterId,
+    actionType: 'report.create',
+    targetType: 'message',
+    targetId: messageId,
+    metadata: { reason: input.reason, reportId: inserted!.id },
+  });
+
+  return toMessageReport(inserted!);
+}
+
+/**
+ * 通報キューを取得する（管理者向け）
+ */
+export async function listQueue(filter?: { status?: ReportStatus }): Promise<MessageReport[]> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (filter?.status) {
+    params.push(filter.status);
+    conditions.push(`mr.status = $${params.length}`);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const rows = await query<MessageReportRow>(
+    `SELECT mr.*, u.username AS reporter_username
+     FROM message_reports mr
+     LEFT JOIN users u ON u.id = mr.reporter_id
+     ${whereClause}
+     ORDER BY mr.created_at DESC`,
+    params,
+  );
+
+  return rows.map(toMessageReport);
+}
+
+/**
+ * 通報を却下する（冪等）
+ * 既に dismissed / actioned の場合はそのまま現状を返す（監査ログは記録しない）
+ */
+export async function dismiss(reportId: number, handlerUserId: number): Promise<MessageReport> {
+  const existing = await queryOne<MessageReportRow>(
+    `SELECT mr.*, u.username AS reporter_username
+     FROM message_reports mr
+     LEFT JOIN users u ON u.id = mr.reporter_id
+     WHERE mr.id = $1`,
+    [reportId],
+  );
+  if (!existing) {
+    throw createError('Report not found', 404);
+  }
+
+  // 冪等: 既に処理済みなら現状返却（監査ログなし）
+  if (existing.status === 'dismissed' || existing.status === 'actioned') {
+    return toMessageReport(existing);
+  }
+
+  const updated = await queryOne<MessageReportRow>(
+    `UPDATE message_reports
+     SET status = 'dismissed', handled_by = $1, handled_at = NOW()
+     WHERE id = $2
+     RETURNING id, message_id, reporter_id, reason, comment, status, action_taken,
+               handled_by, handled_at, created_at`,
+    [handlerUserId, reportId],
+  );
+
+  // reporter_username を JOIN して取得
+  const result = await queryOne<MessageReportRow>(
+    `SELECT mr.*, u.username AS reporter_username
+     FROM message_reports mr
+     LEFT JOIN users u ON u.id = mr.reporter_id
+     WHERE mr.id = $1`,
+    [reportId],
+  );
+  void updated;
+
+  await auditLogService.record({
+    actorUserId: handlerUserId,
+    actionType: 'report.dismiss',
+    targetType: 'message',
+    targetId: existing.message_id,
+    metadata: { reportId },
+  });
+
+  return toMessageReport(result!);
+}
+
+/**
+ * 通報に対して delete_message アクションを実行する（冪等）
+ * 既に actioned / dismissed の場合はそのまま現状を返す（監査ログなし）
+ */
+export async function actionDeleteMessage(
+  reportId: number,
+  handlerUserId: number,
+): Promise<MessageReport> {
+  const existing = await queryOne<MessageReportRow>(
+    `SELECT mr.*, u.username AS reporter_username
+     FROM message_reports mr
+     LEFT JOIN users u ON u.id = mr.reporter_id
+     WHERE mr.id = $1`,
+    [reportId],
+  );
+  if (!existing) {
+    throw createError('Report not found', 404);
+  }
+
+  // 冪等: 既に処理済みなら現状返却（監査ログなし）
+  if (existing.status === 'actioned' || existing.status === 'dismissed') {
+    return toMessageReport(existing);
+  }
+
+  // メッセージをソフトデリート
+  await execute('UPDATE messages SET is_deleted = true, updated_at = NOW() WHERE id = $1', [
+    existing.message_id,
+  ]);
+
+  // レポートを actioned に更新
+  await execute(
+    `UPDATE message_reports
+     SET status = 'actioned', action_taken = 'delete_message', handled_by = $1, handled_at = NOW()
+     WHERE id = $2`,
+    [handlerUserId, reportId],
+  );
+
+  const result = await queryOne<MessageReportRow>(
+    `SELECT mr.*, u.username AS reporter_username
+     FROM message_reports mr
+     LEFT JOIN users u ON u.id = mr.reporter_id
+     WHERE mr.id = $1`,
+    [reportId],
+  );
+
+  await auditLogService.record({
+    actorUserId: handlerUserId,
+    actionType: 'report.action.delete_message',
+    targetType: 'message',
+    targetId: existing.message_id,
+    metadata: { reportId },
+  });
+
+  return toMessageReport(result!);
+}

--- a/packages/shared/src/types/auditLog.ts
+++ b/packages/shared/src/types/auditLog.ts
@@ -25,7 +25,10 @@ export type AuditActionType =
   | 'moderation.ngword.update'
   | 'moderation.ngword.delete'
   | 'moderation.blocklist.add'
-  | 'moderation.blocklist.remove';
+  | 'moderation.blocklist.remove'
+  | 'report.create'
+  | 'report.dismiss'
+  | 'report.action.delete_message';
 
 export interface AuditLogExportQuery {
   from?: string; // ISO8601

--- a/packages/shared/src/types/moderation.ts
+++ b/packages/shared/src/types/moderation.ts
@@ -13,6 +13,8 @@ export type ReportStatus = 'pending' | 'dismissed' | 'actioned';
 export interface MessageReport {
   id: number;
   messageId: number;
+  /** 該当メッセージが属するチャンネル ID（管理者画面から該当投稿へ遷移する際に使用） */
+  channelId: number;
   reporterId: number | null;
   reporterUsername: string | null;
   reason: ReportReason;

--- a/packages/shared/src/types/moderation.ts
+++ b/packages/shared/src/types/moderation.ts
@@ -1,6 +1,36 @@
 /**
- * #117 NG ワード / 添付制限 のモデレーション関連型
+ * モデレーション関連型
+ * - #116 通報 / モデレーションキュー
+ * - #117 NG ワード / 添付制限
  */
+
+// ─── #116 通報 / モデレーションキュー ───────────────────────────
+
+export type ReportReason = 'spam' | 'harassment' | 'other';
+export type ReportStatus = 'pending' | 'dismissed' | 'actioned';
+
+/** 通報レコード（管理者向け・通報者情報含む） */
+export interface MessageReport {
+  id: number;
+  messageId: number;
+  reporterId: number | null;
+  reporterUsername: string | null;
+  reason: ReportReason;
+  comment: string | null;
+  status: ReportStatus;
+  actionTaken: string | null;
+  handledBy: number | null;
+  handledAt: string | null;
+  createdAt: string;
+}
+
+/** 通報作成の入力 */
+export interface ReportMessageInput {
+  reason: ReportReason;
+  comment?: string;
+}
+
+// ─── #117 NG ワード / 添付制限 ──────────────────────────────────
 
 export type NgWordAction = 'block' | 'warn';
 


### PR DESCRIPTION
## 概要

メッセージ通報機能とモデレーションキュー（管理者向け通報管理）を実装する。

- ユーザーは他のユーザーのメッセージを通報できる（スパム・ハラスメント・その他）
- 管理者は通報キューを確認し、却下またはメッセージ削除で対応できる
- 重複通報を防止（同一ユーザー×メッセージで 409）、削除済みメッセージは 404
- 通報者情報はユーザー向けレスポンスから除外（プライバシー保護）
- 却下・対応済みの通報に再アクションしても冪等（監査ログ重複なし）

## 変更内容

### DB / 共有型
- `db/schema.hcl`: `message_reports` テーブルを追加（ユニーク制約・カスケード削除付き）
- `packages/shared/src/types/moderation.ts`: `ReportReason`・`ReportStatus`・`MessageReport`・`ReportMessageInput` 型を追加
- `packages/shared/src/types/auditLog.ts`: `report.create`・`report.dismiss`・`report.action.delete_message` アクション種別を追加

### バックエンド
- `packages/server/src/services/moderationReportService.ts`: 通報サービス（投稿・一覧・却下・削除アクション）を新規作成
- `packages/server/src/controllers/moderationReportController.ts`: コントローラーを新規作成（プライバシーのため 201 レスポンスから通報者情報を除去）
- `packages/server/src/routes/messages.ts`: `POST /:id/report` ルートを追加
- `packages/server/src/routes/admin.ts`: `GET /reports`・`POST /reports/:id/dismiss`・`POST /reports/:id/action` ルートを追加

### フロントエンド
- `packages/client/src/components/Chat/ReportMessageDialog.tsx`: 通報ダイアログコンポーネントを新規作成
- `packages/client/src/components/Admin/ModerationQueue.tsx`: 通報キューコンポーネントを新規作成（React 19 `use()` + `<Suspense>` パターン）
- `packages/client/src/components/Chat/MessageActions.tsx`: 通報ボタン（他人のメッセージのみ）と `ReportMessageDialog` を追加
- `packages/client/src/pages/AdminPage.tsx`: 「通報キュー」タブ（タブ5）を追加
- `packages/client/src/api/client.ts`: `messages.report()`・`admin.reports.list()`・`admin.reports.dismiss()`・`admin.reports.action()` を追加
- `packages/client/src/components/AuditLogView.tsx`: 新しい監査ログ種別のラベルを追加

## 影響範囲

- メッセージ操作（MessageActions → 通報ボタン追加）
- 管理画面（新しいタブが追加）
- 監査ログ一覧（新しい操作種別が表示される）

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（944件）
- [x] バックエンドユニットテストがすべてパスする（987件）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #116

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した