### PR TITLE
chore: 並列開発時のworkerテスト実行を高速化（A/B/C対策）

### DIFF
--- a/.claude/agents/feature-worker.md
+++ b/.claude/agents/feature-worker.md
@@ -24,6 +24,20 @@ Issue番号を省略した場合は、現在のコンテキスト（会話履歴
 
 ### Step 0: 事前調査
 
+#### 0-1. worktree環境のセットアップ（worktree内で実行している場合のみ）
+
+worktree環境では `node_modules` が空のため、テスト実行前に root から symlink を作成する。これにより約9秒の `npm install` を省略できる。
+
+```bash
+# pwd が /Users/shoma/Code/claude-code-test/ 配下でない（= worktree環境）の場合のみ symlink を作成
+[ ! -e node_modules ] && ln -s /Users/shoma/Code/claude-code-test/node_modules ./node_modules
+[ ! -e packages/client/node_modules ] && ln -s /Users/shoma/Code/claude-code-test/packages/client/node_modules ./packages/client/node_modules
+```
+
+**`npm install` の実行は禁止**（root の依存関係を壊す可能性がある）。新規依存追加が必要なら作業を中断してユーザーに報告する。
+
+#### 0-2. Issue調査
+
 以下を順に実行する。
 
 ```bash

--- a/.claude/agents/feature-worker.md
+++ b/.claude/agents/feature-worker.md
@@ -138,12 +138,46 @@ describe('ピン留め機能', () => {
 
 ### Step 5: テスト実行・確認
 
+#### 5-1. 実装中の動作確認（対象ファイルのみ）
+
+実装中は **必ず対象ファイルのみ** をフィルタ実行する。引数の渡し方を誤ると全テストが走るため以下の構文を厳守する。
+
 ```bash
-npm run build   # 型チェック・ビルド確認
-npm run test    # テスト全通過確認
+# server（jest）: --testPathPattern を使う
+npm run test --workspace=packages/server -- --testPathPattern={ファイル名}
+
+# client（vitest）: ファイルパターンを位置引数で渡す
+npm run test --workspace=packages/client -- {ファイル名}
 ```
 
-どちらかが失敗した場合は修正して再実行する。**両方が成功するまでPRを作成しない。**
+**禁止事項:**
+- `npm run test:server -- ...` / `npm run test:client -- ...` は引数が伝播せず全テストが走る（要 `--workspace=...`）
+- `npm run test -- ...` も同上の理由でフィルタ無効
+- 同じテストコマンドを grep の引数だけ変えて繰り返すこと
+- テスト失敗が3回試行で解決しない場合のループ継続（中断して報告すること）
+
+テスト結果はファイルに保存して Read/Grep で参照する（再実行しない）:
+```bash
+npm run test --workspace=packages/{server|client} -- {pattern} 2>&1 | tee /tmp/test-result.txt
+```
+
+#### 5-2. 最終確認（変更したワークスペースのみフルテスト）
+
+実装が完了した時点で、**変更したワークスペースのみ** フルテストを1回実行する。
+
+```bash
+npm run build  # 型チェック・ビルド確認
+
+# server を変更した場合のみ:
+npm run test --workspace=packages/server
+
+# client を変更した場合のみ:
+npm run test --workspace=packages/client
+```
+
+**root の `npm run test` は使わない**（変更していない側まで実行されて2倍以上の時間がかかる）。
+
+両方のワークスペースを変更した場合のみ両方を実行する。どちらかが失敗した場合は修正して再実行する。**ビルドと変更ワークスペースのテストが成功するまでPRを作成しない。**
 
 既存テストを変更した場合は理由を記録しておく（完了報告に含める）。
 

--- a/.claude/hooks/lint-format.sh
+++ b/.claude/hooks/lint-format.sh
@@ -28,12 +28,11 @@ fi
 
 cd "$REPO_ROOT" || exit 0
 
-# 自動整形・自動修正
+# 自動整形
 npx --no-install prettier --write "$FILE" > /dev/null 2>&1 || true
-npx --no-install eslint --fix "$FILE" > /dev/null 2>&1 || true
 
-# 残った lint エラーを確認
-LINT_OUTPUT=$(npx --no-install eslint "$FILE" 2>&1)
+# eslint --fix は exit code で残存エラーを判定できる（修正不能エラーがあれば非0）
+LINT_OUTPUT=$(npx --no-install eslint --fix "$FILE" 2>&1)
 LINT_EXIT=$?
 
 if [ "$LINT_EXIT" -ne 0 ]; then

--- a/.claude/skills/parallel-feature-dev/SKILL.md
+++ b/.claude/skills/parallel-feature-dev/SKILL.md
@@ -173,12 +173,19 @@ Draft PR: #{PR番号}
      `gh pr edit` がエラーになる場合は `gh api repos/{owner}/{repo}/pulls/#{PR番号} --method PATCH --field title="..." --field body="..."` で代替すること。
 - Step 7: 完了報告（AGENTS.mdフォーマット）
 
-【テスト実行ルール】
-- 実装中の動作確認は対象ファイルのみを指定して実行する:
-  `npm run test -- --testPathPattern="{対象ファイル名}" --watchAll=false`
+【テスト実行ルール】（feature-worker.md Step 5 と必ず整合させること）
+- 実装中の動作確認は **対象ファイルのみ** を以下の構文で実行する:
+  - server: `npm run test --workspace=packages/server -- --testPathPattern={ファイル名}`
+  - client: `npm run test --workspace=packages/client -- {ファイル名}`
+- 以下のコマンドは引数が伝播せず全テストが走るため **使用禁止**:
+  - `npm run test -- ...`（root）
+  - `npm run test:server -- ...` / `npm run test:client -- ...`（`--workspace=` 必須）
 - テスト結果はファイルに保存してRead/Grepで確認する（再実行しない）:
-  `npm run test -- --watchAll=false 2>&1 | tee /tmp/test-result.txt`
-- フルテストスイートは実装が全ファイル完了してから1回のみ実行する
+  `... 2>&1 | tee /tmp/test-result.txt`
+- 最終確認のフルテストは **変更したワークスペースのみ** 1回実行する:
+  - `npm run test --workspace=packages/server`（serverを変更した場合のみ）
+  - `npm run test --workspace=packages/client`（clientを変更した場合のみ）
+  - root の `npm run test` は使わない（変更していない側まで実行される）
 - 同じテストコマンドをgrepの引数だけ変えて繰り返すことを禁止する
 - テスト失敗が3回試行しても解決しない場合はループせず中断して報告する
 

--- a/.claude/skills/parallel-feature-dev/SKILL.md
+++ b/.claude/skills/parallel-feature-dev/SKILL.md
@@ -111,6 +111,11 @@ Issue A が MessageItem.tsx、Issue B が ChannelList.tsx → 並列実行可能
 Issue: #{番号}
 ブランチ名: feature/{機能名}/#{番号}
 
+【セットアップ】（最初に必ず実行。約9秒の npm install を省略できる）
+worktree環境では node_modules が空なため、root から symlink を作成する:
+[ ! -e node_modules ] && ln -s /Users/shoma/Code/claude-code-test/node_modules ./node_modules
+[ ! -e packages/client/node_modules ] && ln -s /Users/shoma/Code/claude-code-test/packages/client/node_modules ./packages/client/node_modules
+
 【実行内容】以下のステップのみ実行して停止してください:
 - Step 0: 事前調査（Issue詳細・関連ファイルの把握）
 - Step 1: ブランチ feature/{機能名}/#{番号} を作成
@@ -122,6 +127,7 @@ Issue: #{番号}
 - テストロジック（アサーション）の実装
 - プログラムの実装
 - PRのマージ
+- `npm install` の実行（symlinkで代替済み。依存追加が必要なら報告して中断）
 
 【報告】draft PRのURLと番号を返答してください。
 ```
@@ -160,11 +166,16 @@ Issue: #{番号}
 ブランチ名: feature/{機能名}/#{番号}
 Draft PR: #{PR番号}
 
+【セットアップ】（最初に必ず実行。約9秒の npm install を省略できる）
+worktree環境では node_modules が空なため、root から symlink を作成する:
+[ ! -e node_modules ] && ln -s /Users/shoma/Code/claude-code-test/node_modules ./node_modules
+[ ! -e packages/client/node_modules ] && ln -s /Users/shoma/Code/claude-code-test/packages/client/node_modules ./packages/client/node_modules
+
 ブランチはすでに存在し、テストファイルの構造（TODO構造）も作成済みです。
 以下のステップを実行してください:
 - Step 3: テストロジックの実装（アサーションを書く）
 - Step 4: プログラム実装（DB→型定義→バックエンド→フロントエンドの順）
-- Step 5: npm run build と npm run test を両方パスさせる
+- Step 5: npm run build と 変更したワークスペースのテストを両方パスさせる（root の npm run test は使わない）
 - Step 6: 全変更をcommitしてpushし、draft PRを通常PRに変換する
   1. `gh pr ready #{PR番号}` でdraftを解除する
   2. `gh pr edit #{PR番号} --title "..." --body "..."` でタイトルと本文を実装内容に合わせて更新する

--- a/packages/server/jest.config.ts
+++ b/packages/server/jest.config.ts
@@ -14,6 +14,9 @@ const config: Config = {
   moduleNameMapper: {
     '^@chat-app/shared$': '<rootDir>/../shared/src/index.ts',
   },
+  // pg-mem の Pool は close できない（closeDatabase: noop）ため、テスト完了後に open handle が残り
+  // worker が gracefully exit できない。テスト自体は全パスしているので強制終了で問題ない。
+  forceExit: true,
 };
 
 export default config;

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,8 +6,8 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "jest --runInBand",
-    "test:watch": "jest --watch --runInBand"
+    "test": "jest --maxWorkers=50%",
+    "test:watch": "jest --watch --maxWorkers=50%"
   },
   "dependencies": {
     "@chat-app/shared": "*",


### PR DESCRIPTION
## 概要

並列開発時にworkerサブエージェントのテスト実行が直接ターミナル実行と比較して約2倍以上遅い問題を計測・原因分析し、A/B/C の3対策を実装する。

直接計測値ベースで **client変更ケース 254s → 51s（-80%）、両方変更ケース 254s → 107s（-58%）** の高速化を見込む。

## 変更内容

### A. server テスト並列化（最大効果: -146秒）
- `packages/server/package.json`: `jest --runInBand` → `jest --maxWorkers=50%`
- pgTestHelper の `_sharedInstance` はモジュールスコープのシングルトンで、Jest の各 worker プロセス内で独立した DB が作られるため worker 間は完全分離。並列実行しても安全。
- 8コア環境で 4 並列実行となり 202s → 56s（72%削減）

### B. Jest テスト後ハング解消（-1秒）
- `packages/server/jest.config.ts` に `forceExit: true` を追加
- pg-mem の Pool は close できない（`closeDatabase: noop`）ため、テスト完了後に open handle が残り worker が gracefully exit できず1秒待たされていた
- `Jest did not exit one second after the test run` 警告も解消

### C. worktree 起動時の `npm install` 省略（-9秒/worker）
- `.claude/agents/feature-worker.md` Step 0 に worktree 環境用 symlink 手順を追加
- `.claude/skills/parallel-feature-dev/SKILL.md` の Phase 1/2 worker指示プロンプトに symlink セットアップを追加
- root の `node_modules` を symlink して `npm install`（9.3秒）を完全省略
- npm workspaces とも互換、client/server 両方で動作確認済み
- `npm install` 実行は禁止（root 依存を壊す可能性があるため）

### 過去コミット（d2f1f1c）の B-1/B-2
- `lint-format.sh`: PostToolUseフックの npx 起動を 3回 → 2回に削減（30%短縮）
- `feature-worker.md` Step 5: 「変更ワークスペースのみフルテスト」+ 正しいフィルタ構文を明記
- `parallel-feature-dev` SKILL.md: 誤った `--testPathPattern` 構文を修正、feature-worker と整合

## 影響範囲

- `packages/server/package.json`: テストスクリプト
- `packages/server/jest.config.ts`: jest設定
- `.claude/agents/feature-worker.md`: workerエージェント指示書
- `.claude/skills/parallel-feature-dev/SKILL.md`: 並列開発オーケストレーター
- `.claude/hooks/lint-format.sh`: PostToolUse フック

ビジネスロジック・テストコード・DBスキーマには変更なし。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（71ファイル/1020テスト、30.79s）
- [x] バックエンドユニットテストがすべてパスする（51ファイル/1029テスト、56.16s = 並列実行確認）
- [x] ビルドが正常に完了すること（テスト実行時に型チェック含む）
- [x] (手動確認) PostToolUseフック動作確認: 1Edit 1.83s（改善前 2.63s）
- [x] (手動確認) worktree symlink でテスト実行: client/server 両方パス

## 計測サマリー

| 項目 | 改善前 | 改善後 |
|---|---|---|
| server フルテスト | 202s | 56s |
| Jest 終了ハング | 1s | 0s |
| worktree 起動 (npm install) | 9.3s | 0s（symlink） |
| PostToolUseフック / 1Edit | 2.63s | 1.83s |

ワークフロー全体（client変更のみ）: **254s → 51s（-80%）**

## 関連Issue

なし（並列開発の運用改善）

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（feature-worker.md / parallel-feature-dev SKILL.md を更新）

## 残課題（マージ後に実施）

- **D: 並列worker競合の実測**: 複数worker同時起動時のCPU/Disk競合の影響を計測（2-3エージェント並列起動でserverテストを走らせる）。改善が main にマージされた後でないと意味のある計測にならない（worker は main から worktree を作る仕様のため）
- **server テストの open handle 根本調査**: 現状 forceExit で対症療法。pg-mem Pool / 未closeのDB connection / setInterval の特定は別タスク