### PR TITLE
chore: テストコード自体の高速化（bcrypt rounds・grace_ms 等）

### DIFF
--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -9,6 +9,8 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let user: ReturnType<typeof userEvent.setup>;
 import { MemoryRouter } from 'react-router-dom';
 import AdminPage from '../pages/AdminPage';
 import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
@@ -175,6 +177,7 @@ async function renderAdminPage() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
   mockedUseAuth.mockReturnValue({
     user: { id: 1, username: 'alice', role: 'admin', isActive: true },
   });
@@ -262,7 +265,7 @@ describe('AdminPage: 統計タブ', () => {
 describe('AdminPage: ユーザー管理タブ', () => {
   async function openUsersTab() {
     await renderAdminPage();
-    await userEvent.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
+    await user.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
     await act(async () => {});
     await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
   }
@@ -278,7 +281,7 @@ describe('AdminPage: ユーザー管理タブ', () => {
     await openUsersTab();
     // bob (id=2, role='user') の「admin に変更」ボタン
     const roleButtons = screen.getAllByRole('button', { name: 'admin に変更' });
-    await userEvent.click(roleButtons[0]);
+    await user.click(roleButtons[0]);
     expect(mockedApi.admin.updateUserRole).toHaveBeenCalledWith(2, 'admin');
   });
 
@@ -286,24 +289,24 @@ describe('AdminPage: ユーザー管理タブ', () => {
     await openUsersTab();
     // alice は自分自身のため停止ボタンが最初に出るのは bob (id=2)
     const suspendButtons = screen.getAllByRole('button', { name: '停止' });
-    await userEvent.click(suspendButtons[0]);
+    await user.click(suspendButtons[0]);
     expect(mockedApi.admin.updateUserStatus).toHaveBeenCalledWith(2, false);
   });
 
   it('削除ボタンを押すと確認ダイアログが表示される', async () => {
     await openUsersTab();
     const deleteButtons = screen.getAllByRole('button', { name: '削除' });
-    await userEvent.click(deleteButtons[0]);
+    await user.click(deleteButtons[0]);
     expect(screen.getByText('ユーザーを削除しますか？')).toBeInTheDocument();
   });
 
   it('確認ダイアログで「削除」を押すと deleteUser が呼ばれる', async () => {
     await openUsersTab();
     const deleteButtons = screen.getAllByRole('button', { name: '削除' });
-    await userEvent.click(deleteButtons[0]);
+    await user.click(deleteButtons[0]);
     // ダイアログ内の「削除」ボタンをクリック
     const confirmButtons = screen.getAllByRole('button', { name: '削除' });
-    await userEvent.click(confirmButtons[confirmButtons.length - 1]);
+    await user.click(confirmButtons[confirmButtons.length - 1]);
     expect(mockedApi.admin.deleteUser).toHaveBeenCalled();
   });
 
@@ -325,7 +328,7 @@ describe('AdminPage: ユーザー管理タブ', () => {
 describe('AdminPage: チャンネル管理タブ', () => {
   async function openChannelsTab() {
     await renderAdminPage();
-    await userEvent.click(screen.getByRole('tab', { name: 'チャンネル管理' }));
+    await user.click(screen.getByRole('tab', { name: 'チャンネル管理' }));
     await act(async () => {});
     await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
   }
@@ -344,17 +347,17 @@ describe('AdminPage: チャンネル管理タブ', () => {
   it('アーカイブ済みチャンネルの「アーカイブ解除」ボタンを押すと unarchiveChannel が呼ばれる', async () => {
     await openChannelsTab();
     const unarchiveButton = screen.getByRole('button', { name: 'アーカイブ解除' });
-    await userEvent.click(unarchiveButton);
+    await user.click(unarchiveButton);
     expect(mockedApi.admin.unarchiveChannel).toHaveBeenCalledWith(2);
   });
 
   it('削除ボタンを押すと確認ダイアログ → deleteChannel が呼ばれる', async () => {
     await openChannelsTab();
     const deleteButtons = screen.getAllByRole('button', { name: '削除' });
-    await userEvent.click(deleteButtons[0]);
+    await user.click(deleteButtons[0]);
     expect(screen.getByText('チャンネルを削除しますか？')).toBeInTheDocument();
     const confirmButtons = screen.getAllByRole('button', { name: '削除' });
-    await userEvent.click(confirmButtons[confirmButtons.length - 1]);
+    await user.click(confirmButtons[confirmButtons.length - 1]);
     expect(mockedApi.admin.deleteChannel).toHaveBeenCalled();
   });
 });
@@ -372,13 +375,13 @@ describe('AdminPage: エラーハンドリング', () => {
   it('updateUserRole が reject してもユーザーリストの状態は変化しない', async () => {
     mockedApi.admin.updateUserRole.mockRejectedValue(new Error('権限エラー'));
     await renderAdminPage();
-    await userEvent.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
+    await user.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
     await act(async () => {});
     await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
 
     // bob のロール変更を試みる（API は reject）
     const roleButtons = screen.getAllByRole('button', { name: 'admin に変更' });
-    await userEvent.click(roleButtons[0]);
+    await user.click(roleButtons[0]);
 
     // setUsers が呼ばれないため bob のロールは 'user' のまま
     await waitFor(() => {
@@ -405,7 +408,7 @@ describe('AdminPage: 非管理者アクセス', () => {
 describe('AdminPage: おすすめチャンネル設定', () => {
   async function openChannelsTabForRecommend() {
     await renderAdminPage();
-    await userEvent.click(screen.getByRole('tab', { name: 'チャンネル管理' }));
+    await user.click(screen.getByRole('tab', { name: 'チャンネル管理' }));
     await act(async () => {});
     await waitFor(() => expect(screen.getByText('general')).toBeInTheDocument());
   }
@@ -426,7 +429,7 @@ describe('AdminPage: おすすめチャンネル設定', () => {
     const unchecked = screen
       .getAllByRole('checkbox', { name: /おすすめ/ })
       .filter((el) => !(el as HTMLInputElement).checked);
-    await userEvent.click(unchecked[0]);
+    await user.click(unchecked[0]);
     await waitFor(() =>
       expect(mockedApi.admin.setChannelRecommended).toHaveBeenCalledWith(1, true),
     );
@@ -441,7 +444,7 @@ describe('AdminPage: おすすめチャンネル設定', () => {
     const checked = screen
       .getAllByRole('checkbox', { name: /おすすめ/ })
       .filter((el) => (el as HTMLInputElement).checked);
-    await userEvent.click(checked[0]);
+    await user.click(checked[0]);
     await waitFor(() =>
       expect(mockedApi.admin.setChannelRecommended).toHaveBeenCalledWith(2, false),
     );
@@ -455,7 +458,7 @@ describe('AdminPage: おすすめチャンネル設定', () => {
     const unchecked = screen
       .getAllByRole('checkbox', { name: /おすすめ/ })
       .filter((el) => !(el as HTMLInputElement).checked);
-    await userEvent.click(unchecked[0]);
+    await user.click(unchecked[0]);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole('checkbox', { name: /おすすめ/ });
       const checkedCount = checkboxes.filter((el) => (el as HTMLInputElement).checked).length;
@@ -470,7 +473,7 @@ describe('AdminPage: おすすめチャンネル設定', () => {
     const unchecked = screen
       .getAllByRole('checkbox', { name: /おすすめ/ })
       .filter((el) => !(el as HTMLInputElement).checked);
-    await userEvent.click(unchecked[0]);
+    await user.click(unchecked[0]);
     await waitFor(() => expect(mockShowError).toHaveBeenCalled());
   });
 });
@@ -480,7 +483,7 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
   /** モデレーションタブを開くヘルパー */
   async function openModerationTab() {
     await renderAdminPage();
-    await userEvent.click(screen.getByRole('tab', { name: /モデレーション設定/ }));
+    await user.click(screen.getByRole('tab', { name: /モデレーション設定/ }));
   }
 
   describe('NG ワード管理', () => {
@@ -507,9 +510,9 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
       await openModerationTab();
       await waitFor(() => expect(mockedApi.admin.ngWords.list).toHaveBeenCalled());
 
-      await userEvent.click(screen.getByRole('button', { name: /NG ワードを追加/ }));
-      await userEvent.type(screen.getByLabelText('NG ワードのパターン'), 'badword');
-      await userEvent.click(screen.getByRole('button', { name: /^追加$/ }));
+      await user.click(screen.getByRole('button', { name: /NG ワードを追加/ }));
+      await user.type(screen.getByLabelText('NG ワードのパターン'), 'badword');
+      await user.click(screen.getByRole('button', { name: /^追加$/ }));
 
       await waitFor(() =>
         expect(mockedApi.admin.ngWords.create).toHaveBeenCalledWith(
@@ -534,9 +537,9 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
         ],
       });
       await openModerationTab();
-      await userEvent.click(screen.getByRole('button', { name: /NG ワードを追加/ }));
-      await userEvent.type(screen.getByLabelText('NG ワードのパターン'), 'fresh');
-      await userEvent.click(screen.getByRole('button', { name: /^追加$/ }));
+      await user.click(screen.getByRole('button', { name: /NG ワードを追加/ }));
+      await user.type(screen.getByLabelText('NG ワードのパターン'), 'fresh');
+      await user.click(screen.getByRole('button', { name: /^追加$/ }));
 
       await waitFor(() => expect(screen.getByText('fresh')).toBeInTheDocument());
     });
@@ -561,8 +564,8 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
 
       // テーブル行内のアクション select を変更
       const select = screen.getByLabelText('sw の動作');
-      await userEvent.click(select);
-      await userEvent.click(await screen.findByRole('option', { name: /warn/ }));
+      await user.click(select);
+      await user.click(await screen.findByRole('option', { name: /warn/ }));
 
       await waitFor(() =>
         expect(mockedApi.admin.ngWords.update).toHaveBeenCalledWith(
@@ -591,7 +594,7 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
       await waitFor(() => screen.getByText('tg'));
 
       const switchEl = screen.getByLabelText('tg を有効化');
-      await userEvent.click(switchEl);
+      await user.click(switchEl);
 
       await waitFor(() =>
         expect(mockedApi.admin.ngWords.update).toHaveBeenCalledWith(
@@ -619,7 +622,7 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
       await openModerationTab();
       await waitFor(() => screen.getByText('rm'));
 
-      await userEvent.click(screen.getByRole('button', { name: 'rm を削除' }));
+      await user.click(screen.getByRole('button', { name: 'rm を削除' }));
 
       await waitFor(() => expect(mockedApi.admin.ngWords.delete).toHaveBeenCalledWith(9));
     });
@@ -652,9 +655,9 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
       await openModerationTab();
       await waitFor(() => expect(mockedApi.admin.blockedExtensions.list).toHaveBeenCalled());
 
-      await userEvent.click(screen.getByRole('button', { name: /拡張子を追加/ }));
-      await userEvent.type(screen.getByLabelText('拡張子'), 'bat');
-      await userEvent.click(screen.getByRole('button', { name: /^追加$/ }));
+      await user.click(screen.getByRole('button', { name: /拡張子を追加/ }));
+      await user.type(screen.getByLabelText('拡張子'), 'bat');
+      await user.click(screen.getByRole('button', { name: /^追加$/ }));
 
       await waitFor(() =>
         expect(mockedApi.admin.blockedExtensions.create).toHaveBeenCalledWith(
@@ -678,7 +681,7 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
       await openModerationTab();
       await waitFor(() => screen.getByText('.cmd'));
 
-      await userEvent.click(screen.getByRole('button', { name: '.cmd を削除' }));
+      await user.click(screen.getByRole('button', { name: '.cmd を削除' }));
 
       await waitFor(() => expect(mockedApi.admin.blockedExtensions.delete).toHaveBeenCalledWith(5));
     });
@@ -700,7 +703,7 @@ describe('AdminPage: モデレーション設定タブ (#117)', () => {
 describe('AdminPage: 通報キュータブ (#116)', () => {
   async function openReportQueueTab() {
     await renderAdminPage();
-    await userEvent.click(screen.getByRole('tab', { name: /通報キュー/ }));
+    await user.click(screen.getByRole('tab', { name: /通報キュー/ }));
     await act(async () => {});
   }
 

--- a/packages/client/src/__tests__/CreateChannelDialog.test.tsx
+++ b/packages/client/src/__tests__/CreateChannelDialog.test.tsx
@@ -34,6 +34,8 @@ import { api } from '../api/client';
 const mockCreate = api.channels.create as ReturnType<typeof vi.fn>;
 const mockUsers = api.auth.users as ReturnType<typeof vi.fn>;
 
+let user: ReturnType<typeof userEvent.setup>;
+
 function makeChannel(id: number, name: string, isPrivate = false): Channel {
   return {
     id,
@@ -56,6 +58,7 @@ const defaultProps = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
 });
 
 describe('CreateChannelDialog', () => {
@@ -83,7 +86,7 @@ describe('CreateChannelDialog', () => {
     it('チャンネル名を入力すると Create ボタンが有効になる', async () => {
       render(<CreateChannelDialog {...defaultProps} />);
 
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'general');
+      await user.type(screen.getByLabelText(/channel name/i), 'general');
 
       expect(screen.getByRole('button', { name: /^create$/i })).toBeEnabled();
     });
@@ -101,11 +104,11 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockResolvedValue({ channel: { ...makeChannel(1, 'secret'), isPrivate: true } });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'secret');
-      await userEvent.click(screen.getByLabelText(/private/i));
+      await user.type(screen.getByLabelText(/channel name/i), 'secret');
+      await user.click(screen.getByLabelText(/private/i));
       // use() の Suspense が解決するまで待つ
       await screen.findByRole('list', { name: /members/i });
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(
@@ -118,8 +121,8 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockResolvedValue({ channel: makeChannel(1, 'public') });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'public');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'public');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(
@@ -134,8 +137,8 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockResolvedValue({ channel: makeChannel(1, 'general') });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'general');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'general');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ name: 'general' })),
@@ -146,8 +149,8 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockReturnValue(new Promise(() => {}));
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'general');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'general');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       expect(screen.getByRole('button', { name: /^create$/i })).toBeDisabled();
     });
@@ -158,8 +161,8 @@ describe('CreateChannelDialog', () => {
       const onCreate = vi.fn();
 
       render(<CreateChannelDialog open={true} onClose={vi.fn()} onCreate={onCreate} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'general');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'general');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => expect(onCreate).toHaveBeenCalledWith(created));
     });
@@ -169,8 +172,8 @@ describe('CreateChannelDialog', () => {
       const onClose = vi.fn();
 
       render(<CreateChannelDialog open={true} onClose={onClose} onCreate={vi.fn()} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'general');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'general');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() => expect(onClose).toHaveBeenCalled());
     });
@@ -179,8 +182,8 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockRejectedValue(new Error('Channel name already taken'));
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'duplicate');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'duplicate');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(screen.getByText('Channel name already taken')).toBeInTheDocument(),
@@ -199,7 +202,7 @@ describe('CreateChannelDialog', () => {
       mockUsers.mockResolvedValue({ users: [] });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.click(screen.getByLabelText(/private/i));
+      await user.click(screen.getByLabelText(/private/i));
       // use() の Suspense が解決するまで待つ
       await screen.findByRole('list', { name: /members/i });
 
@@ -215,7 +218,7 @@ describe('CreateChannelDialog', () => {
       });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.click(screen.getByLabelText(/private/i));
+      await user.click(screen.getByLabelText(/private/i));
       // use() の Suspense が解決するまで待つ
       await screen.findByText('alice');
 
@@ -231,14 +234,14 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockResolvedValue({ channel: makeChannel(1, 'secret', true) });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'secret');
-      await userEvent.click(screen.getByLabelText(/private/i));
+      await user.type(screen.getByLabelText(/channel name/i), 'secret');
+      await user.click(screen.getByLabelText(/private/i));
       // use() の Suspense が解決するまで待つ
       await screen.findByText('alice');
 
       // alice を選択
-      await userEvent.click(screen.getByText('alice'));
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.click(screen.getByText('alice'));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(
@@ -252,11 +255,11 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockResolvedValue({ channel: makeChannel(1, 'secret', true) });
 
       render(<CreateChannelDialog {...defaultProps} />);
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'secret');
-      await userEvent.click(screen.getByLabelText(/private/i));
+      await user.type(screen.getByLabelText(/channel name/i), 'secret');
+      await user.click(screen.getByLabelText(/private/i));
       // use() の Suspense が解決するまで待つ
       await screen.findByRole('list', { name: /members/i });
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(
@@ -301,9 +304,9 @@ describe('CreateChannelDialog', () => {
       });
       render(<CreateChannelDialog {...defaultProps} />);
 
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'admins-only');
-      await userEvent.click(screen.getByRole('radio', { name: /管理者のみ/ }));
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'admins-only');
+      await user.click(screen.getByRole('radio', { name: /管理者のみ/ }));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(
@@ -318,9 +321,9 @@ describe('CreateChannelDialog', () => {
       });
       render(<CreateChannelDialog {...defaultProps} />);
 
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'readonly');
-      await userEvent.click(screen.getByRole('radio', { name: /閲覧専用/ }));
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'readonly');
+      await user.click(screen.getByRole('radio', { name: /閲覧専用/ }));
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(
@@ -333,8 +336,8 @@ describe('CreateChannelDialog', () => {
       mockCreate.mockResolvedValue({ channel: makeChannel(1, 'public') });
       render(<CreateChannelDialog {...defaultProps} />);
 
-      await userEvent.type(screen.getByLabelText(/channel name/i), 'public');
-      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+      await user.type(screen.getByLabelText(/channel name/i), 'public');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
 
       await waitFor(() =>
         expect(mockCreate).toHaveBeenCalledWith(

--- a/packages/client/src/__tests__/ForwardMessageDialog.test.tsx
+++ b/packages/client/src/__tests__/ForwardMessageDialog.test.tsx
@@ -57,8 +57,11 @@ const mockChannels: Channel[] = [
   },
 ];
 
+let user: ReturnType<typeof userEvent.setup>;
+
 beforeEach(() => {
   vi.resetAllMocks();
+  user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
   mockForward.mockResolvedValue({ message: { id: 99 } });
   mockChannelsList.mockResolvedValue({ channels: mockChannels });
 });
@@ -101,7 +104,7 @@ describe('ForwardMessageDialog', () => {
           <ForwardMessageDialog open={true} messageId={1} onClose={vi.fn()} />
         </Suspense>,
       );
-      await userEvent.click(await screen.findByTestId('channel-item-10'));
+      await user.click(await screen.findByTestId('channel-item-10'));
       // 選択後は送信ボタンが有効になる
       expect(screen.getByTestId('forward-submit')).not.toBeDisabled();
     });
@@ -113,7 +116,7 @@ describe('ForwardMessageDialog', () => {
         </Suspense>,
       );
       const channelItem = await screen.findByTestId('channel-item-10');
-      await userEvent.click(channelItem);
+      await user.click(channelItem);
       // MUI ListItemButton は selected 時に Mui-selected クラスが付与される
       expect(channelItem).toHaveClass('Mui-selected');
     });
@@ -129,7 +132,7 @@ describe('ForwardMessageDialog', () => {
       // チャンネル一覧が表示されるまで待つ（Suspense 解決を確認）
       await screen.findByText('#general');
       const commentInput = screen.getByRole('textbox', { name: 'コメント' });
-      await userEvent.type(commentInput, 'テストコメント');
+      await user.type(commentInput, 'テストコメント');
       expect(commentInput).toHaveValue('テストコメント');
     });
   });
@@ -141,8 +144,8 @@ describe('ForwardMessageDialog', () => {
           <ForwardMessageDialog open={true} messageId={5} onClose={vi.fn()} />
         </Suspense>,
       );
-      await userEvent.click(await screen.findByTestId('channel-item-10'));
-      await userEvent.click(screen.getByTestId('forward-submit'));
+      await user.click(await screen.findByTestId('channel-item-10'));
+      await user.click(screen.getByTestId('forward-submit'));
       await waitFor(() => {
         expect(mockForward).toHaveBeenCalledWith(5, {
           targetChannelId: 10,
@@ -157,10 +160,10 @@ describe('ForwardMessageDialog', () => {
           <ForwardMessageDialog open={true} messageId={5} onClose={vi.fn()} />
         </Suspense>,
       );
-      await userEvent.click(await screen.findByTestId('channel-item-10'));
+      await user.click(await screen.findByTestId('channel-item-10'));
       const commentInput = screen.getByRole('textbox', { name: 'コメント' });
-      await userEvent.type(commentInput, 'コメントです');
-      await userEvent.click(screen.getByTestId('forward-submit'));
+      await user.type(commentInput, 'コメントです');
+      await user.click(screen.getByTestId('forward-submit'));
       await waitFor(() => {
         expect(mockForward).toHaveBeenCalledWith(5, {
           targetChannelId: 10,
@@ -187,8 +190,8 @@ describe('ForwardMessageDialog', () => {
           <ForwardMessageDialog open={true} messageId={1} onClose={onClose} />
         </Suspense>,
       );
-      await userEvent.click(await screen.findByTestId('channel-item-10'));
-      await userEvent.click(screen.getByTestId('forward-submit'));
+      await user.click(await screen.findByTestId('channel-item-10'));
+      await user.click(screen.getByTestId('forward-submit'));
       await waitFor(() => {
         expect(onClose).toHaveBeenCalledTimes(1);
       });
@@ -201,8 +204,8 @@ describe('ForwardMessageDialog', () => {
           <ForwardMessageDialog open={true} messageId={1} onClose={vi.fn()} />
         </Suspense>,
       );
-      await userEvent.click(await screen.findByTestId('channel-item-10'));
-      await userEvent.click(screen.getByTestId('forward-submit'));
+      await user.click(await screen.findByTestId('channel-item-10'));
+      await user.click(screen.getByTestId('forward-submit'));
       await waitFor(() => {
         expect(screen.getByTestId('forward-error')).toBeInTheDocument();
         expect(screen.getByTestId('forward-error')).toHaveTextContent('転送に失敗しました');
@@ -220,7 +223,7 @@ describe('ForwardMessageDialog', () => {
       );
       // チャンネル一覧が表示されるまで待つ
       await screen.findByText('#general');
-      await userEvent.click(screen.getByRole('button', { name: 'キャンセル' }));
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }));
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/client/src/__tests__/TemplatesPage.test.tsx
+++ b/packages/client/src/__tests__/TemplatesPage.test.tsx
@@ -114,7 +114,7 @@ describe('TemplatesPage', () => {
 
   describe('テンプレート作成', () => {
     it('タイトルと本文を入力して保存するとテンプレートが追加される', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const titleInput = screen.getByPlaceholderText('タイトルを入力');
@@ -132,7 +132,7 @@ describe('TemplatesPage', () => {
     });
 
     it('タイトルが空の状態では保存ボタンが無効化される', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const bodyInput = screen.getByPlaceholderText('本文を入力');
@@ -143,7 +143,7 @@ describe('TemplatesPage', () => {
     });
 
     it('本文が空の状態では保存ボタンが無効化される', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const titleInput = screen.getByPlaceholderText('タイトルを入力');
@@ -154,7 +154,7 @@ describe('TemplatesPage', () => {
     });
 
     it('作成 API 呼び出し後に一覧がリフレッシュされる', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const titleInput = screen.getByPlaceholderText('タイトルを入力');
@@ -172,7 +172,7 @@ describe('TemplatesPage', () => {
 
   describe('テンプレート編集', () => {
     it('編集ボタンを押すとタイトル・本文の編集フォームが表示される', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const editButtons = screen.getAllByRole('button', { name: '編集' });
@@ -183,7 +183,7 @@ describe('TemplatesPage', () => {
     });
 
     it('内容を変更して保存すると update API が呼ばれる', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const editButtons = screen.getAllByRole('button', { name: '編集' });
@@ -202,7 +202,7 @@ describe('TemplatesPage', () => {
     });
 
     it('キャンセルすると変更が破棄される', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const editButtons = screen.getAllByRole('button', { name: '編集' });
@@ -221,7 +221,7 @@ describe('TemplatesPage', () => {
 
   describe('テンプレート削除', () => {
     it('削除ボタンを押すと確認なしに即時削除 API が呼ばれる', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const deleteButtons = screen.getAllByRole('button', { name: '削除' });
@@ -231,7 +231,7 @@ describe('TemplatesPage', () => {
     });
 
     it('削除後に一覧からそのテンプレートが消える', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const deleteButtons = screen.getAllByRole('button', { name: '削除' });
@@ -245,7 +245,7 @@ describe('TemplatesPage', () => {
 
   describe('並び替え', () => {
     it('↑ボタンを押すと対象テンプレートの position が1つ前に移動し reorder API が呼ばれる', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       // 2番目のテンプレートの ↑ボタンをクリック（index 1 が最初の enabled なボタン）
@@ -259,7 +259,7 @@ describe('TemplatesPage', () => {
     });
 
     it('↓ボタンを押すと対象テンプレートの position が1つ後に移動し reorder API が呼ばれる', async () => {
-      const user = userEvent.setup();
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
       const downButtons = screen.getAllByRole('button', { name: '下に移動' });

--- a/packages/server/jest.config.ts
+++ b/packages/server/jest.config.ts
@@ -4,6 +4,8 @@ const config: Config = {
   testEnvironment: 'node',
   roots: ['<rootDir>/src'],
   testMatch: ['**/__tests__/**/*.test.ts'],
+  // テスト用の環境変数（BCRYPT_ROUNDS, OFFLINE_GRACE_MS 等）を設定する
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.tsx?$': ['ts-jest', {
       tsconfig: {

--- a/packages/server/jest.setup.ts
+++ b/packages/server/jest.setup.ts
@@ -1,0 +1,11 @@
+// テスト実行時の環境変数設定（高速化用）
+// production 値のままだとテスト時間が極端に長くなるため、テスト時のみ短縮値を使う
+
+// bcrypt のソルトラウンド数
+// production: 12 (約 200-300ms/hash) → test: 4 (約 5-10ms/hash)
+process.env.BCRYPT_ROUNDS = process.env.BCRYPT_ROUNDS ?? '4';
+
+// presence サービスのオフライン猶予時間
+// production: 8000ms → test: 1500ms（オフライン化テストで実時間待機を短縮）
+// 1500ms 未満にすると presenceService.test.ts の `OFFLINE_GRACE_MS - 1000` が負数になり失敗するため
+process.env.OFFLINE_GRACE_MS = process.env.OFFLINE_GRACE_MS ?? '1500';

--- a/packages/server/src/services/authService.ts
+++ b/packages/server/src/services/authService.ts
@@ -4,6 +4,9 @@ import { query, queryOne, execute } from '../db/database';
 import { User } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
 
+// production 既定は 12 ラウンド。テスト環境では BCRYPT_ROUNDS=4 などに下げて高速化する
+const BCRYPT_ROUNDS = process.env.BCRYPT_ROUNDS ? parseInt(process.env.BCRYPT_ROUNDS, 10) : 12;
+
 interface UserRow {
   id: number;
   username: string;
@@ -41,7 +44,7 @@ export async function register(username: string, email: string, password: string
   ]);
   if (existing) throw createError('Username or email already taken', 409);
 
-  const passwordHash = await bcrypt.hash(password, 12);
+  const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
 
   const countRow = await queryOne<{ cnt: string }>('SELECT COUNT(*) as cnt FROM users');
   const role = Number(countRow?.cnt) === 0 ? 'admin' : 'user';
@@ -116,7 +119,7 @@ export async function changePassword(
   const valid = await bcrypt.compare(currentPassword, row.password_hash);
   if (!valid) throw createError('現在のパスワードが正しくありません', 401);
 
-  const newHash = await bcrypt.hash(newPassword, 12);
+  const newHash = await bcrypt.hash(newPassword, BCRYPT_ROUNDS);
   await execute('UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2', [
     newHash,
     userId,

--- a/packages/server/src/services/presenceService.ts
+++ b/packages/server/src/services/presenceService.ts
@@ -18,8 +18,10 @@ import type { PresenceState } from '@chat-app/shared';
 /** 離席判定閾値: 最終アクティビティから 5 分（300_000ms） */
 export const AWAY_TIMEOUT_MS = 5 * 60 * 1000;
 
-/** オフライン判定の disconnect 猶予期間: 8 秒 */
-export const OFFLINE_GRACE_MS = 8 * 1000;
+/** オフライン判定の disconnect 猶予期間: 8 秒（テスト環境では OFFLINE_GRACE_MS=500 などに短縮可） */
+export const OFFLINE_GRACE_MS = process.env.OFFLINE_GRACE_MS
+  ? parseInt(process.env.OFFLINE_GRACE_MS, 10)
+  : 8 * 1000;
 
 /** 単一ユーザーの内部状態 */
 interface UserPresence {


### PR DESCRIPTION
## 概要

テストコード自体の高速化余地を計測・分析し、環境変数による設定値短縮と userEvent 設定最適化を実装する。

**主効果**: server フルテストが PR #161 適用後の 56s から **9.34s（更に約6倍速、元の 202s 比で 22倍速）** に短縮。

## 変更内容

### 対策1: bcrypt rounds を環境変数化（最大効果）
- `authService.ts` の `bcrypt.hash(password, 12)` を環境変数 `BCRYPT_ROUNDS` で読み替え（既定12、テスト時4 = 約30倍速）
- 1回 200-300ms かかっていた bcrypt が 5-10ms に → integration テスト群で大幅短縮

### 対策2: OFFLINE_GRACE_MS を環境変数化
- `presenceService.ts` の `OFFLINE_GRACE_MS` を環境変数で読み替え（既定 8000、テスト時 1500）
- `presence-socket.test.ts` の実時間待機 8秒×2件 が大幅短縮
- 1500ms 未満にすると既存の `presenceService.test.ts` で `OFFLINE_GRACE_MS - 1000` が負数になり失敗するため下限を 1500 に設定

### 対策3: テスト用環境変数のセットアップ
- `packages/server/jest.setup.ts` を新規作成（`BCRYPT_ROUNDS=4`, `OFFLINE_GRACE_MS=1500`）
- `jest.config.ts` に `setupFiles: ['<rootDir>/jest.setup.ts']` を追加

### 対策4: client 上位ファイルの userEvent 設定
- AdminPage / CreateChannelDialog / TemplatesPage / ForwardMessageDialog の `userEvent.setup()` に `{ delay: null, pointerEventsCheck: 0 }` を指定
- AdminPage 単独で 16.2s → 14.2s（-12%）
- ただし vitest の並列実行で AdminPage が long pole となるため client 全体への効果は誤差範囲（30s→33s）
- 設定としては妥当（pointer events 検証スキップで誤検知も減る）ため残す

## 影響範囲

- `packages/server/src/services/authService.ts`: bcrypt rounds 環境変数化
- `packages/server/src/services/presenceService.ts`: OFFLINE_GRACE_MS 環境変数化
- `packages/server/jest.config.ts` / `jest.setup.ts`: テスト用 env セットアップ
- `packages/client/src/__tests__/{AdminPage,CreateChannelDialog,TemplatesPage,ForwardMessageDialog}.test.tsx`: userEvent 設定

production の挙動には**変更なし**（環境変数未設定時は元の値）。テストファイルは中身のロジック変更なしで設定のみ調整。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（71ファイル/1020テスト、33.57s）
- [x] バックエンドユニットテストがすべてパスする（51ファイル/1029テスト、9.34s）
- [x] ビルドが正常に完了すること（テスト実行時に型チェック含む）

## 計測サマリー

| 項目 | 改善前（PR #161適用） | 改善後 |
|---|---|---|
| server フルテスト | 56s | **9.34s** |
| client フルテスト | 30.79s | 33s（誤差） |
| ワークフロー全体（server+client 直列） | 86s | **42s** |

元の `--runInBand` 時（202秒）と比較すれば server は **193秒削減（96%減）**。

## 関連Issue

なし（並列開発の運用改善）

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（テストヘルパー周辺のため文書変更は不要と判断）

## 既知の副次事項

- `moderation.test.ts` に **並列実行時のみ発現する flaky 失敗** が観測（単独実行では全50テストパス）。本対策のスコープ外（既存の flaky 問題）

## 残課題（マージ後）

- `moderation.test.ts` の flaky 失敗の根本調査
- client 側の AdminPage 等の更なる高速化（`waitFor` チューニング・MUI 軽量化）
- `ts-jest` → `@swc/jest` 移行（transform 時間削減）
- server openHandle の根本調査（現状 forceExit 対症療法）