### PR TITLE
fix: MessageItem の presence.get() に null userId が渡る型エラーを修正

### DIFF
--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -73,7 +73,9 @@ export default function MessageItem({
   const author = users.find((u) => u.id === message.userId);
   const displayName = author?.displayName || message.username;
   // #146 プレゼンス状態: Socket 購読マップを優先し、なければ User.presenceState にフォールバック
-  const userState = presence.get(message.userId) ?? author?.presenceState;
+  // 会話イベント等で userId が null の場合はプレゼンス未指定（インジケータ非表示）
+  const userState =
+    message.userId !== null ? (presence.get(message.userId) ?? author?.presenceState) : undefined;
 
   const handleEditSend = (content: string, mentionedUserIds: number[], attachmentIds: number[]) => {
     socket?.emit('edit_message', {


### PR DESCRIPTION
## 概要

`MessageItem.tsx` で `message.userId`（型 `number | null`）をそのまま `presence.get()` に渡しており、`tsc` が型エラーを出してビルドが通らなくなっていた。会話イベント（システムメッセージ等）で `userId` が null の場合に発生する。

## 変更内容

`packages/client/src/components/Chat/MessageItem.tsx`
- `message.userId !== null` のときのみ `presence.get()` / `author?.presenceState` を参照
- `userId` が null の場合は `userState = undefined` とし、`PresenceIndicator` 側で何も描画しない（既存の `state` 未指定時の挙動と一致）

## 影響範囲

- `MessageItem` の表示のみ。会話イベント行ではアバター右下のプレゼンスドットが表示されなくなる（投稿者がいないため正しい挙動）
- 通常メッセージ（`userId` が number）の挙動は変更なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1020 passed）
- [x] バックエンドユニットテストがすべてパスする（1029 passed）
- [x] ビルドが正常に完了すること（`npm run build` 成功）
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue
Fixes #

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)