### PR TITLE
feat: 保存ビュー (#150)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -1813,5 +1813,65 @@ table "message_reports" {
   }
 }
 
+table "saved_views" {
+  schema  = schema.public
+  comment = "保存ビュー（検索条件の保存 / #150）"
+  column "id" {
+    null    = false
+    type    = serial
+    comment = "保存ビューID"
+  }
+  column "user_id" {
+    null    = false
+    type    = integer
+    comment = "オーナーユーザーID"
+  }
+  column "name" {
+    null    = false
+    type    = text
+    comment = "保存ビュー名"
+  }
+  column "query" {
+    null    = false
+    type    = jsonb
+    default = sql("'{}'")
+    comment = "検索条件 JSON"
+  }
+  column "position" {
+    null    = false
+    type    = integer
+    default = 0
+    comment = "並び順"
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "作成日時"
+  }
+  column "updated_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "更新日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_saved_views_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  index "idx_saved_views_user_name" {
+    unique  = true
+    columns = [column.user_id, column.name]
+  }
+  index "idx_saved_views_user_position" {
+    columns = [column.user_id, column.position]
+  }
+}
+
 schema "public" {
 }

--- a/packages/client/src/__tests__/ChannelList.test.tsx
+++ b/packages/client/src/__tests__/ChannelList.test.tsx
@@ -530,4 +530,15 @@ describe('ChannelList', () => {
       });
     });
   });
+
+  // #150 保存ビュー — ChannelList への SavedViewSection 差し込み
+  describe('保存ビューセクション (#150)', () => {
+    it('保存ビューセクション（SavedViewSection）がサイドバーに描画される', () => {
+      // TODO
+    });
+
+    it('SavedViewSection の onSelectView が呼ばれると検索フィルタを復元して検索ページへ遷移する', () => {
+      // TODO
+    });
+  });
 });

--- a/packages/client/src/__tests__/ChannelList.test.tsx
+++ b/packages/client/src/__tests__/ChannelList.test.tsx
@@ -38,6 +38,13 @@ vi.mock('../api/client', () => ({
       assignChannel: vi.fn(),
       unassignChannel: vi.fn(),
     },
+    savedViews: {
+      list: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(),
+    },
   },
 }));
 
@@ -80,6 +87,7 @@ const mockCreate = mockChannels.create;
 const mockRead = mockChannels.read;
 const mockCategoryList = (api.channelCategories as unknown as { list: ReturnType<typeof vi.fn> })
   .list;
+const mockSavedViewList = (api.savedViews as unknown as { list: ReturnType<typeof vi.fn> }).list;
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -92,6 +100,8 @@ beforeEach(() => {
   mockRead.mockResolvedValue(undefined);
   // カテゴリリストはデフォルト空配列を返す
   mockCategoryList.mockResolvedValue({ categories: [] });
+  // 保存ビューリストはデフォルト空配列を返す
+  mockSavedViewList.mockResolvedValue({ savedViews: [] });
 });
 
 /**
@@ -533,12 +543,65 @@ describe('ChannelList', () => {
 
   // #150 保存ビュー — ChannelList への SavedViewSection 差し込み
   describe('保存ビューセクション (#150)', () => {
-    it('保存ビューセクション（SavedViewSection）がサイドバーに描画される', () => {
-      // TODO
+    it('保存ビューセクション（SavedViewSection）がサイドバーに描画される', async () => {
+      mockList.mockResolvedValue({ channels: [] });
+      mockSavedViewList.mockResolvedValue({
+        savedViews: [
+          {
+            id: 1,
+            userId: 1,
+            name: '今週のバグ',
+            query: { keyword: 'bug' },
+            position: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      await renderChannelList({ activeChannelId: null, onSelect: vi.fn() });
+
+      // SavedViewSection が描画されて保存ビュー名が表示されることを確認
+      expect(await screen.findByText('今週のバグ')).toBeInTheDocument();
     });
 
-    it('SavedViewSection の onSelectView が呼ばれると検索フィルタを復元して検索ページへ遷移する', () => {
-      // TODO
+    it('保存ビューをクリックすると onSelectSavedView コールバックが query を引数として呼ばれる', async () => {
+      mockList.mockResolvedValue({ channels: [] });
+      mockSavedViewList.mockResolvedValue({
+        savedViews: [
+          {
+            id: 1,
+            userId: 1,
+            name: '添付あり検索',
+            query: { hasAttachment: true },
+            position: 0,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const onSelectSavedView = vi.fn();
+
+      await act(async () => {
+        render(
+          <ChannelList
+            activeChannelId={null}
+            onSelect={vi.fn()}
+            onSelectSavedView={onSelectSavedView}
+          />,
+        );
+      });
+
+      // 保存ビューをクリックすると onSelectSavedView が query 付きで呼ばれる
+      const viewItem = await screen.findByText('添付あり検索');
+      await userEvent.click(viewItem);
+
+      await waitFor(() => {
+        expect(onSelectSavedView).toHaveBeenCalledWith(
+          expect.objectContaining({ hasAttachment: true }),
+        );
+      });
     });
   });
 });

--- a/packages/client/src/__tests__/PinChannel.test.tsx
+++ b/packages/client/src/__tests__/PinChannel.test.tsx
@@ -41,6 +41,13 @@ vi.mock('../api/client', () => ({
       assignChannel: vi.fn(),
       unassignChannel: vi.fn(),
     },
+    savedViews: {
+      list: vi.fn().mockResolvedValue({ savedViews: [] }),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(),
+    },
   },
 }));
 
@@ -69,6 +76,7 @@ const mockChannels = api.channels as unknown as {
 };
 const mockCategoryList = (api.channelCategories as unknown as { list: ReturnType<typeof vi.fn> })
   .list;
+const mockSavedViewList = (api.savedViews as unknown as { list: ReturnType<typeof vi.fn> }).list;
 
 // ユーザーIDを変更するためにAuthContextをモック化可能にする
 const mockUser = { id: 1, role: 'user', isActive: true };
@@ -109,6 +117,8 @@ beforeEach(() => {
   mockUser.id = 1;
   // カテゴリリストはデフォルト空配列を返す
   mockCategoryList.mockResolvedValue({ categories: [] });
+  // 保存ビューリストもデフォルト空配列を返す
+  mockSavedViewList.mockResolvedValue({ savedViews: [] });
 });
 
 describe('ChannelList: ピン留めチャンネルのUI表示', () => {

--- a/packages/client/src/__tests__/SavedViewSection.test.tsx
+++ b/packages/client/src/__tests__/SavedViewSection.test.tsx
@@ -7,13 +7,12 @@
  *   - ユーザー操作（クリック・入力）は userEvent でシミュレートする
  *   - 並べ替えは「上ボタン / 下ボタン」の操作に対して API 呼び出しが正しく行われるかを検証
  *   - 「画面を見ればわかる」UI 状態は省略し、ロジック・コールバックを中心にテストする
- *   - React 19: use() + Suspense を使うため render は await act(async () => render(...)) でラップ
+ *   - SavedViewSection は props で savedViews 配列を受け取る（use() + Suspense は ChannelList 側で管理）
  */
 
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Suspense } from 'react';
 
 vi.mock('../api/client', () => ({
   api: {
@@ -27,77 +26,226 @@ vi.mock('../api/client', () => ({
   },
 }));
 
+import { api } from '../api/client';
+import SavedViewSection from '../components/Channel/SavedViewSection';
+import type { SavedView } from '@chat-app/shared';
+
+const mockApi = api as unknown as {
+  savedViews: {
+    list: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    reorder: ReturnType<typeof vi.fn>;
+  };
+};
+
 // --- フィクスチャ ---
-const SAVED_VIEW_FIXTURES = [
-  { id: 1, name: '今週のバグ', query: { dateFrom: '2024-01-01', tagIds: [10] }, position: 0 },
-  { id: 2, name: '未読メンション', query: { userId: 5 }, position: 1 },
-  { id: 3, name: '添付あり', query: { hasAttachment: true }, position: 2 },
+const SAVED_VIEW_FIXTURES: SavedView[] = [
+  {
+    id: 1,
+    userId: 1,
+    name: '今週のバグ',
+    query: { dateFrom: '2024-01-01', tagIds: [10] },
+    position: 0,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 2,
+    userId: 1,
+    name: '未読メンション',
+    query: { userId: 5 },
+    position: 1,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
+  {
+    id: 3,
+    userId: 1,
+    name: '添付あり',
+    query: { hasAttachment: true },
+    position: 2,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+  },
 ];
+
+async function renderSection(
+  savedViews: SavedView[] = SAVED_VIEW_FIXTURES,
+  onSelectView = vi.fn(),
+) {
+  await act(async () => {
+    render(<SavedViewSection savedViews={savedViews} onSelectView={onSelectView} />);
+  });
+  return { onSelectView };
+}
 
 describe('SavedViewSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockApi.savedViews.update.mockResolvedValue({ savedView: { ...SAVED_VIEW_FIXTURES[0] } });
+    mockApi.savedViews.delete.mockResolvedValue(undefined);
+    mockApi.savedViews.reorder.mockResolvedValue({ success: true });
   });
 
   describe('保存ビュー一覧表示', () => {
-    it('保存ビューの名前が一覧に表示される', () => {
-      // TODO
+    it('保存ビューの名前が一覧に表示される', async () => {
+      await renderSection();
+
+      expect(screen.getByText('今週のバグ')).toBeInTheDocument();
+      expect(screen.getByText('未読メンション')).toBeInTheDocument();
+      expect(screen.getByText('添付あり')).toBeInTheDocument();
     });
 
-    it('保存ビューが 0 件のときセクションは空（またはプレースホルダーを表示）', () => {
-      // TODO
+    it('保存ビューが 0 件のときセクションは空（またはプレースホルダーを表示）', async () => {
+      await renderSection([]);
+
+      // アイテムが存在しないこと
+      expect(screen.queryByText('今週のバグ')).toBeNull();
     });
   });
 
   describe('保存ビュークリック', () => {
-    it('保存ビューをクリックすると onSelectView コールバックが query を引数として呼ばれる', () => {
-      // TODO
+    it('保存ビューをクリックすると onSelectView コールバックが query を引数として呼ばれる', async () => {
+      const { onSelectView } = await renderSection();
+
+      await userEvent.click(screen.getByText('今週のバグ'));
+
+      expect(onSelectView).toHaveBeenCalledWith(
+        expect.objectContaining({ dateFrom: '2024-01-01', tagIds: [10] }),
+      );
     });
   });
 
   describe('編集ダイアログ', () => {
-    it('編集ボタンをクリックすると編集ダイアログが開く', () => {
-      // TODO
+    it('編集ボタンをクリックすると編集ダイアログが開く', async () => {
+      await renderSection();
+
+      // 最初のビューの編集ボタンをクリック
+      const editButtons = screen.getAllByRole('button', { name: /編集/ });
+      await userEvent.click(editButtons[0]);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
-    it('ダイアログで名前を変更して保存すると api.savedViews.update が呼ばれる', () => {
-      // TODO
+    it('ダイアログで名前を変更して保存すると api.savedViews.update が呼ばれる', async () => {
+      mockApi.savedViews.update.mockResolvedValue({
+        savedView: { ...SAVED_VIEW_FIXTURES[0], name: '新しい名前' },
+      });
+      await renderSection();
+
+      const editButtons = screen.getAllByRole('button', { name: /編集/ });
+      await userEvent.click(editButtons[0]);
+
+      const nameInput = screen.getByRole('textbox', { name: /ビュー名/ });
+      await userEvent.clear(nameInput);
+      await userEvent.type(nameInput, '新しい名前');
+
+      const saveBtn = screen.getByRole('button', { name: /保存|確定/ });
+      await userEvent.click(saveBtn);
+
+      await waitFor(() => {
+        expect(mockApi.savedViews.update).toHaveBeenCalledWith(
+          SAVED_VIEW_FIXTURES[0].id,
+          expect.objectContaining({ name: '新しい名前' }),
+        );
+      });
     });
 
-    it('ダイアログをキャンセルすると api.savedViews.update が呼ばれない', () => {
-      // TODO
+    it('ダイアログをキャンセルすると api.savedViews.update が呼ばれない', async () => {
+      await renderSection();
+
+      const editButtons = screen.getAllByRole('button', { name: /編集/ });
+      await userEvent.click(editButtons[0]);
+
+      const cancelBtn = screen.getByRole('button', { name: /キャンセル/ });
+      await userEvent.click(cancelBtn);
+
+      expect(mockApi.savedViews.update).not.toHaveBeenCalled();
     });
   });
 
   describe('削除', () => {
-    it('削除ボタンをクリックすると api.savedViews.delete が呼ばれる', () => {
-      // TODO
+    it('削除ボタンをクリックすると api.savedViews.delete が呼ばれる', async () => {
+      await renderSection();
+
+      const deleteButtons = screen.getAllByRole('button', { name: /削除/ });
+      await userEvent.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(mockApi.savedViews.delete).toHaveBeenCalledWith(SAVED_VIEW_FIXTURES[0].id);
+      });
     });
 
-    it('削除後に保存ビューが一覧から消える', () => {
-      // TODO
+    it('削除後に保存ビューが一覧から消える', async () => {
+      await renderSection();
+
+      const deleteButtons = screen.getAllByRole('button', { name: /削除/ });
+      await userEvent.click(deleteButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.queryByText('今週のバグ')).toBeNull();
+      });
     });
   });
 
   describe('並べ替え（上下ボタン）', () => {
-    it('「上に移動」ボタンをクリックすると api.savedViews.reorder が新順序で呼ばれる', () => {
-      // TODO
+    it('「上に移動」ボタンをクリックすると api.savedViews.reorder が新順序で呼ばれる', async () => {
+      await renderSection();
+
+      // 2番目のビュー（未読メンション）の「上に移動」ボタンをクリック
+      const upButtons = screen.getAllByRole('button', { name: /上に移動/ });
+      await userEvent.click(upButtons[1]); // index 1 = 2番目のビュー
+
+      await waitFor(() => {
+        expect(mockApi.savedViews.reorder).toHaveBeenCalledWith(
+          expect.arrayContaining([2, 1]), // 2が先頭に来る
+        );
+      });
     });
 
-    it('「下に移動」ボタンをクリックすると api.savedViews.reorder が新順序で呼ばれる', () => {
-      // TODO
+    it('「下に移動」ボタンをクリックすると api.savedViews.reorder が新順序で呼ばれる', async () => {
+      await renderSection();
+
+      // 1番目のビュー（今週のバグ）の「下に移動」ボタンをクリック
+      const downButtons = screen.getAllByRole('button', { name: /下に移動/ });
+      await userEvent.click(downButtons[0]);
+
+      await waitFor(() => {
+        expect(mockApi.savedViews.reorder).toHaveBeenCalledWith(
+          expect.arrayContaining([2, 1]), // 2が先頭に来る
+        );
+      });
     });
 
-    it('先頭の保存ビューの「上に移動」ボタンは無効（disabled）になっている', () => {
-      // TODO
+    it('先頭の保存ビューの「上に移動」ボタンは無効（disabled）になっている', async () => {
+      await renderSection();
+
+      const upButtons = screen.getAllByRole('button', { name: /上に移動/ });
+      // 最初のビューの「上に移動」ボタンは disabled
+      expect(upButtons[0]).toBeDisabled();
     });
 
-    it('末尾の保存ビューの「下に移動」ボタンは無効（disabled）になっている', () => {
-      // TODO
+    it('末尾の保存ビューの「下に移動」ボタンは無効（disabled）になっている', async () => {
+      await renderSection();
+
+      const downButtons = screen.getAllByRole('button', { name: /下に移動/ });
+      // 最後のビューの「下に移動」ボタンは disabled
+      expect(downButtons[downButtons.length - 1]).toBeDisabled();
     });
 
-    it('並べ替え後に一覧の表示順が更新される', () => {
-      // TODO
+    it('並べ替え後に一覧の表示順が更新される', async () => {
+      await renderSection();
+
+      const downButtons = screen.getAllByRole('button', { name: /下に移動/ });
+      await userEvent.click(downButtons[0]); // 「今週のバグ」を1つ下に
+
+      await waitFor(() => {
+        const items = screen.getAllByRole('listitem');
+        // 「未読メンション」が先頭になる
+        expect(items[0]).toHaveTextContent('未読メンション');
+      });
     });
   });
 });

--- a/packages/client/src/__tests__/SavedViewSection.test.tsx
+++ b/packages/client/src/__tests__/SavedViewSection.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * テスト対象: SavedViewSection コンポーネント（新規）
+ *   + SavedViewEditDialog（保存ビューの編集・並べ替えダイアログ）
+ *
+ * 戦略:
+ *   - api.savedViews.* を vi.mock('../api/client') で差し替えてネットワーク通信を排除
+ *   - ユーザー操作（クリック・入力）は userEvent でシミュレートする
+ *   - 並べ替えは「上ボタン / 下ボタン」の操作に対して API 呼び出しが正しく行われるかを検証
+ *   - 「画面を見ればわかる」UI 状態は省略し、ロジック・コールバックを中心にテストする
+ *   - React 19: use() + Suspense を使うため render は await act(async () => render(...)) でラップ
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Suspense } from 'react';
+
+vi.mock('../api/client', () => ({
+  api: {
+    savedViews: {
+      list: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(),
+    },
+  },
+}));
+
+// --- フィクスチャ ---
+const SAVED_VIEW_FIXTURES = [
+  { id: 1, name: '今週のバグ', query: { dateFrom: '2024-01-01', tagIds: [10] }, position: 0 },
+  { id: 2, name: '未読メンション', query: { userId: 5 }, position: 1 },
+  { id: 3, name: '添付あり', query: { hasAttachment: true }, position: 2 },
+];
+
+describe('SavedViewSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('保存ビュー一覧表示', () => {
+    it('保存ビューの名前が一覧に表示される', () => {
+      // TODO
+    });
+
+    it('保存ビューが 0 件のときセクションは空（またはプレースホルダーを表示）', () => {
+      // TODO
+    });
+  });
+
+  describe('保存ビュークリック', () => {
+    it('保存ビューをクリックすると onSelectView コールバックが query を引数として呼ばれる', () => {
+      // TODO
+    });
+  });
+
+  describe('編集ダイアログ', () => {
+    it('編集ボタンをクリックすると編集ダイアログが開く', () => {
+      // TODO
+    });
+
+    it('ダイアログで名前を変更して保存すると api.savedViews.update が呼ばれる', () => {
+      // TODO
+    });
+
+    it('ダイアログをキャンセルすると api.savedViews.update が呼ばれない', () => {
+      // TODO
+    });
+  });
+
+  describe('削除', () => {
+    it('削除ボタンをクリックすると api.savedViews.delete が呼ばれる', () => {
+      // TODO
+    });
+
+    it('削除後に保存ビューが一覧から消える', () => {
+      // TODO
+    });
+  });
+
+  describe('並べ替え（上下ボタン）', () => {
+    it('「上に移動」ボタンをクリックすると api.savedViews.reorder が新順序で呼ばれる', () => {
+      // TODO
+    });
+
+    it('「下に移動」ボタンをクリックすると api.savedViews.reorder が新順序で呼ばれる', () => {
+      // TODO
+    });
+
+    it('先頭の保存ビューの「上に移動」ボタンは無効（disabled）になっている', () => {
+      // TODO
+    });
+
+    it('末尾の保存ビューの「下に移動」ボタンは無効（disabled）になっている', () => {
+      // TODO
+    });
+
+    it('並べ替え後に一覧の表示順が更新される', () => {
+      // TODO
+    });
+  });
+});

--- a/packages/client/src/__tests__/SearchFilterPanel.test.tsx
+++ b/packages/client/src/__tests__/SearchFilterPanel.test.tsx
@@ -371,4 +371,27 @@ describe('SearchFilterPanel', () => {
       expect(within(bugOption as HTMLElement).queryByText(/5\s*件/)).toBeNull();
     });
   });
+
+  // #150 保存ビュー — 「現在の条件を保存」ボタン
+  describe('保存ビューへの保存 (#150)', () => {
+    it('フィルタ条件が 1 つ以上設定されているとき「保存」ボタンが有効になる', () => {
+      // TODO
+    });
+
+    it('フィルタ条件が何も設定されていないとき「保存」ボタンは無効（disabled）', () => {
+      // TODO
+    });
+
+    it('「保存」ボタンをクリックすると名前入力ダイアログが開く', () => {
+      // TODO
+    });
+
+    it('名前を入力して確定すると onSaveView コールバックが { name, filters } で呼ばれる', () => {
+      // TODO
+    });
+
+    it('名前入力ダイアログをキャンセルすると onSaveView は呼ばれない', () => {
+      // TODO
+    });
+  });
 });

--- a/packages/client/src/__tests__/SearchFilterPanel.test.tsx
+++ b/packages/client/src/__tests__/SearchFilterPanel.test.tsx
@@ -54,6 +54,7 @@ type FilterChangeMock = ReturnType<typeof vi.fn> & ((filters: SearchFilters) => 
 async function renderPanel(
   searchResults?: MessageSearchResult[],
   onSaveView?: ReturnType<typeof vi.fn>,
+  initialFilters?: SearchFilters,
 ) {
   const onFilterChange = vi.fn() as FilterChangeMock;
   await act(async () => {
@@ -62,6 +63,7 @@ async function renderPanel(
         <SearchFilterPanel
           onFilterChange={onFilterChange}
           searchResults={searchResults}
+          filters={initialFilters}
           onSaveView={
             onSaveView as ((params: { name: string; filters: SearchFilters }) => void) | undefined
           }
@@ -463,6 +465,60 @@ describe('SearchFilterPanel', () => {
       await userEvent.click(cancelBtn);
 
       expect(onSaveView).not.toHaveBeenCalled();
+    });
+  });
+
+  // #166 保存ビュークリック時の結線 — 外部 filters props が UI に反映される
+  describe('外部 filters props による初期値反映 (#166)', () => {
+    it('dateFrom を含む filters を渡すと開始日入力欄に値が反映される', async () => {
+      await renderPanel(undefined, undefined, { dateFrom: '2024-03-01' });
+      const input = screen.getByLabelText(/開始日/) as HTMLInputElement;
+      expect(input.value).toBe('2024-03-01');
+    });
+
+    it('dateTo を含む filters を渡すと終了日入力欄に値が反映される', async () => {
+      await renderPanel(undefined, undefined, { dateTo: '2024-03-31' });
+      const input = screen.getByLabelText(/終了日/) as HTMLInputElement;
+      expect(input.value).toBe('2024-03-31');
+    });
+
+    it('userId を含む filters を渡すと送信者 Select に値が反映される', async () => {
+      await renderPanel(undefined, undefined, { userId: 2 });
+      const select = screen.getByLabelText(/送信者/) as HTMLSelectElement;
+      expect(select.value).toBe('2');
+    });
+
+    it('hasAttachment=true を含む filters を渡すと添付ファイル Select に値が反映される', async () => {
+      await renderPanel(undefined, undefined, { hasAttachment: true });
+      const select = screen.getByLabelText(/添付ファイル/) as HTMLSelectElement;
+      expect(select.value).toBe('true');
+    });
+
+    it('hasAttachment=false を含む filters を渡すと添付ファイル Select に値が反映される', async () => {
+      await renderPanel(undefined, undefined, { hasAttachment: false });
+      const select = screen.getByLabelText(/添付ファイル/) as HTMLSelectElement;
+      expect(select.value).toBe('false');
+    });
+
+    it('tagIds を含む filters を渡すと対応するタグが選択済み状態で表示される', async () => {
+      await renderPanel(undefined, undefined, { tagIds: [10, 11] });
+      // 選択済みチップとして bug と urgent が表示される
+      await waitFor(() => {
+        expect(screen.getByText('bug')).toBeInTheDocument();
+        expect(screen.getByText('urgent')).toBeInTheDocument();
+      });
+    });
+
+    it('filters を渡さない場合は各入力欄が空の初期状態になる', async () => {
+      await renderPanel();
+      const fromInput = screen.getByLabelText(/開始日/) as HTMLInputElement;
+      const toInput = screen.getByLabelText(/終了日/) as HTMLInputElement;
+      const senderSelect = screen.getByLabelText(/送信者/) as HTMLSelectElement;
+      const attachSelect = screen.getByLabelText(/添付ファイル/) as HTMLSelectElement;
+      expect(fromInput.value).toBe('');
+      expect(toInput.value).toBe('');
+      expect(senderSelect.value).toBe('');
+      expect(attachSelect.value).toBe('');
     });
   });
 });

--- a/packages/client/src/__tests__/SearchFilterPanel.test.tsx
+++ b/packages/client/src/__tests__/SearchFilterPanel.test.tsx
@@ -51,12 +51,21 @@ vi.mock('../hooks/useTagSuggestions', () => ({
 
 type FilterChangeMock = ReturnType<typeof vi.fn> & ((filters: SearchFilters) => void);
 
-async function renderPanel(searchResults?: MessageSearchResult[]) {
+async function renderPanel(
+  searchResults?: MessageSearchResult[],
+  onSaveView?: ReturnType<typeof vi.fn>,
+) {
   const onFilterChange = vi.fn() as FilterChangeMock;
   await act(async () => {
     render(
       <ReactSuspense fallback={<div>loading...</div>}>
-        <SearchFilterPanel onFilterChange={onFilterChange} searchResults={searchResults} />
+        <SearchFilterPanel
+          onFilterChange={onFilterChange}
+          searchResults={searchResults}
+          onSaveView={
+            onSaveView as ((params: { name: string; filters: SearchFilters }) => void) | undefined
+          }
+        />
       </ReactSuspense>,
     );
   });
@@ -374,24 +383,86 @@ describe('SearchFilterPanel', () => {
 
   // #150 保存ビュー — 「現在の条件を保存」ボタン
   describe('保存ビューへの保存 (#150)', () => {
-    it('フィルタ条件が 1 つ以上設定されているとき「保存」ボタンが有効になる', () => {
-      // TODO
+    it('フィルタ条件が 1 つ以上設定されているとき「保存」ボタンが有効になる', async () => {
+      const onSaveView = vi.fn();
+      const { onFilterChange } = await renderPanel(undefined, onSaveView);
+
+      // 開始日を設定するとフィルタ条件が1つ以上になる
+      const dateFromInput = screen.getByLabelText(/開始日/);
+      await userEvent.type(dateFromInput, '2024-01-01');
+      onFilterChange({ dateFrom: '2024-01-01' });
+
+      // 保存ボタンが有効になる（disabled でない）
+      const saveBtn = await screen.findByRole('button', { name: /保存/ });
+      expect(saveBtn).not.toBeDisabled();
     });
 
-    it('フィルタ条件が何も設定されていないとき「保存」ボタンは無効（disabled）', () => {
-      // TODO
+    it('フィルタ条件が何も設定されていないとき「保存」ボタンは無効（disabled）', async () => {
+      const onSaveView = vi.fn();
+      await renderPanel(undefined, onSaveView);
+
+      const saveBtn = await screen.findByRole('button', { name: /保存/ });
+      expect(saveBtn).toBeDisabled();
     });
 
-    it('「保存」ボタンをクリックすると名前入力ダイアログが開く', () => {
-      // TODO
+    it('「保存」ボタンをクリックすると名前入力ダイアログが開く', async () => {
+      const onSaveView = vi.fn();
+      const { onFilterChange } = await renderPanel(undefined, onSaveView);
+
+      // フィルタ条件を設定
+      const select = screen.getByLabelText(/添付ファイル/);
+      await userEvent.selectOptions(select, 'true');
+      onFilterChange({ hasAttachment: true });
+
+      const saveBtn = await screen.findByRole('button', { name: /保存/ });
+      await userEvent.click(saveBtn);
+
+      // ダイアログが開く
+      expect(await screen.findByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', { name: /ビュー名/ })).toBeInTheDocument();
     });
 
-    it('名前を入力して確定すると onSaveView コールバックが { name, filters } で呼ばれる', () => {
-      // TODO
+    it('名前を入力して確定すると onSaveView コールバックが { name, filters } で呼ばれる', async () => {
+      const onSaveView = vi.fn();
+      await renderPanel(undefined, onSaveView);
+
+      // 添付ありフィルタを設定
+      const select = screen.getByLabelText(/添付ファイル/);
+      await userEvent.selectOptions(select, 'true');
+
+      const saveBtn = await screen.findByRole('button', { name: /保存/ });
+      await userEvent.click(saveBtn);
+
+      const nameInput = screen.getByRole('textbox', { name: /ビュー名/ });
+      await userEvent.type(nameInput, '添付あり検索');
+
+      const confirmBtn = screen.getByRole('button', { name: /確定|保存/ });
+      await userEvent.click(confirmBtn);
+
+      await waitFor(() => {
+        expect(onSaveView).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: '添付あり検索',
+            filters: expect.objectContaining({ hasAttachment: true }),
+          }),
+        );
+      });
     });
 
-    it('名前入力ダイアログをキャンセルすると onSaveView は呼ばれない', () => {
-      // TODO
+    it('名前入力ダイアログをキャンセルすると onSaveView は呼ばれない', async () => {
+      const onSaveView = vi.fn();
+      await renderPanel(undefined, onSaveView);
+
+      const select = screen.getByLabelText(/添付ファイル/);
+      await userEvent.selectOptions(select, 'true');
+
+      const saveBtn = await screen.findByRole('button', { name: /保存/ });
+      await userEvent.click(saveBtn);
+
+      const cancelBtn = screen.getByRole('button', { name: /キャンセル/ });
+      await userEvent.click(cancelBtn);
+
+      expect(onSaveView).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -42,6 +42,8 @@ import type {
   ReportMessageInput,
   ReportStatus,
   Draft,
+  SavedView,
+  SavedViewQuery,
 } from '@chat-app/shared';
 import type { AdminUser, AdminChannel, AdminStats, AuditLogListResponse } from '../types/admin';
 
@@ -500,5 +502,25 @@ export const api = {
       request<void>(`/drafts/channels/${channelId}`, { method: 'DELETE' }),
     deleteDm: (conversationId: number) =>
       request<void>(`/drafts/dm/${conversationId}`, { method: 'DELETE' }),
+  },
+  // #150 保存ビュー
+  savedViews: {
+    list: () => request<{ savedViews: SavedView[] }>('/saved-views'),
+    create: (data: { name: string; query: SavedViewQuery }) =>
+      request<{ savedView: SavedView }>('/saved-views', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+    update: (id: number, data: { name?: string; query?: SavedViewQuery }) =>
+      request<{ savedView: SavedView }>(`/saved-views/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(data),
+      }),
+    delete: (id: number) => request<void>(`/saved-views/${id}`, { method: 'DELETE' }),
+    reorder: (ids: number[]) =>
+      request<{ success: boolean }>('/saved-views/order', {
+        method: 'PUT',
+        body: JSON.stringify({ ids }),
+      }),
   },
 };

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -24,7 +24,13 @@ import {
   useDroppable,
 } from '@dnd-kit/core';
 import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
-import type { Channel, Message, ChannelCategory } from '@chat-app/shared';
+import type {
+  Channel,
+  Message,
+  ChannelCategory,
+  SavedView,
+  SavedViewQuery,
+} from '@chat-app/shared';
 import { api } from '../../api/client';
 import { useSocket } from '../../contexts/SocketContext';
 import { useAuth } from '../../contexts/AuthContext';
@@ -35,6 +41,7 @@ import ChannelSearchBox from './ChannelSearchBox';
 import ChannelItem from './ChannelItem';
 import ChannelCategorySection from './ChannelCategorySection';
 import ChannelCategoryDialog from './ChannelCategoryDialog';
+import SavedViewSection from './SavedViewSection';
 import DmNavigationItems from './DmNavigationItems';
 import { useChannelNotifications } from '../../hooks/useChannelNotifications';
 
@@ -47,6 +54,7 @@ const PINS_STORAGE_KEY_PREFIX = 'channel_pins';
  */
 let _channelsPromise: Promise<{ channels: Channel[] }> | null = null;
 let _categoriesPromise: Promise<{ categories: ChannelCategory[] }> | null = null;
+let _savedViewsPromise: Promise<{ savedViews: SavedView[] }> | null = null;
 
 function getOrCreateChannelsPromise(): Promise<{ channels: Channel[] }> {
   if (!_channelsPromise) {
@@ -62,10 +70,18 @@ function getOrCreateCategoriesPromise(): Promise<{ categories: ChannelCategory[]
   return _categoriesPromise;
 }
 
+function getOrCreateSavedViewsPromise(): Promise<{ savedViews: SavedView[] }> {
+  if (!_savedViewsPromise) {
+    _savedViewsPromise = api.savedViews.list();
+  }
+  return _savedViewsPromise;
+}
+
 /** テスト用: モジュールレベルのチャンネルキャッシュをリセットする */
 export function resetChannelsCache(): void {
   _channelsPromise = null;
   _categoriesPromise = null;
+  _savedViewsPromise = null;
 }
 
 /** @deprecated テスト用エイリアス。resetChannelsCache() を使うこと */
@@ -74,6 +90,8 @@ export const _resetChannelsPromiseForTest = resetChannelsCache;
 interface Props {
   activeChannelId: number | null;
   onSelect: (id: number, name: string, channel?: Channel) => void;
+  /** 保存ビューをクリックしたときのコールバック */
+  onSelectSavedView?: (query: SavedViewQuery) => void;
   /** channelId → 下書きコンテンツ のマップ（hasDraft 表示に使用） */
   draftMap?: Map<number, string>;
 }
@@ -195,20 +213,25 @@ function UnassignedSection({
 interface ChannelListContentProps {
   channelsPromise: Promise<{ channels: Channel[] }>;
   categoriesPromise: Promise<{ categories: ChannelCategory[] }>;
+  savedViewsPromise: Promise<{ savedViews: SavedView[] }>;
   activeChannelId: number | null;
   onSelect: (id: number, name: string, channel?: Channel) => void;
+  onSelectSavedView?: (query: SavedViewQuery) => void;
   draftMap?: Map<number, string>;
 }
 
 function ChannelListContent({
   channelsPromise,
   categoriesPromise,
+  savedViewsPromise,
   activeChannelId,
   onSelect,
+  onSelectSavedView,
   draftMap,
 }: ChannelListContentProps) {
   const { channels: initialChannels } = use(channelsPromise);
   const { categories: initialCategories } = use(categoriesPromise);
+  const { savedViews: initialSavedViews } = use(savedViewsPromise);
   const [channels, setChannels] = useState<Channel[]>(initialChannels);
   const [categories, setCategories] = useState<ChannelCategory[]>(initialCategories);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -656,6 +679,17 @@ function ChannelListContent({
           </Box>
         )}
 
+        {/* 保存ビューセクション */}
+        {initialSavedViews.length > 0 && (
+          <>
+            <Divider />
+            <SavedViewSection
+              savedViews={initialSavedViews}
+              onSelectView={onSelectSavedView ?? (() => {})}
+            />
+          </>
+        )}
+
         <DmNavigationItems dmUnreadCount={dmUnreadCount} onDmUnreadCountChange={setDmUnreadCount} />
 
         <CreateChannelDialog
@@ -727,9 +761,15 @@ function ChannelListContent({
   );
 }
 
-export default function ChannelList({ activeChannelId, onSelect, draftMap }: Props) {
+export default function ChannelList({
+  activeChannelId,
+  onSelect,
+  onSelectSavedView,
+  draftMap,
+}: Props) {
   const [channelsPromise] = useState(() => getOrCreateChannelsPromise());
   const [categoriesPromise] = useState(() => getOrCreateCategoriesPromise());
+  const [savedViewsPromise] = useState(() => getOrCreateSavedViewsPromise());
 
   return (
     <Suspense
@@ -742,8 +782,10 @@ export default function ChannelList({ activeChannelId, onSelect, draftMap }: Pro
       <ChannelListContent
         channelsPromise={channelsPromise}
         categoriesPromise={categoriesPromise}
+        savedViewsPromise={savedViewsPromise}
         activeChannelId={activeChannelId}
         onSelect={onSelect}
+        onSelectSavedView={onSelectSavedView}
         draftMap={draftMap}
       />
     </Suspense>

--- a/packages/client/src/components/Channel/SavedViewSection.tsx
+++ b/packages/client/src/components/Channel/SavedViewSection.tsx
@@ -1,0 +1,239 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemText,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import type { SavedView, SavedViewQuery } from '@chat-app/shared';
+import { api } from '../../api/client';
+import { useSnackbar } from '../../contexts/SnackbarContext';
+
+interface SavedViewSectionProps {
+  savedViews: SavedView[];
+  onSelectView: (query: SavedViewQuery) => void;
+}
+
+interface EditDialogProps {
+  open: boolean;
+  view: SavedView | null;
+  onClose: () => void;
+  onSave: (name: string) => Promise<void>;
+}
+
+function SavedViewEditDialog({ open, view, onClose, onSave }: EditDialogProps) {
+  const [name, setName] = useState(view?.name ?? '');
+  const [loading, setLoading] = useState(false);
+
+  // ダイアログが開くたびに名前をリセット
+  const handleOpen = () => {
+    setName(view?.name ?? '');
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setLoading(true);
+    try {
+      await onSave(trimmed);
+      onClose();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      maxWidth="xs"
+      fullWidth
+      TransitionProps={{ onEnter: handleOpen }}
+    >
+      <DialogTitle>保存ビューを編集</DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          label="ビュー名"
+          fullWidth
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') void handleSubmit();
+          }}
+          sx={{ mt: 1 }}
+          inputProps={{ 'aria-label': 'ビュー名' }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} aria-label="キャンセル">
+          キャンセル
+        </Button>
+        <Button
+          onClick={() => void handleSubmit()}
+          variant="contained"
+          disabled={!name.trim() || loading}
+          aria-label="保存"
+        >
+          保存
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default function SavedViewSection({
+  savedViews: initialViews,
+  onSelectView,
+}: SavedViewSectionProps) {
+  const [views, setViews] = useState<SavedView[]>(initialViews);
+  const [editingView, setEditingView] = useState<SavedView | null>(null);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const { showError } = useSnackbar();
+
+  const handleSelect = (view: SavedView) => {
+    onSelectView(view.query);
+  };
+
+  const handleEdit = (view: SavedView) => {
+    setEditingView(view);
+    setEditDialogOpen(true);
+  };
+
+  const handleEditSave = async (name: string) => {
+    if (!editingView) return;
+    const updated = await api.savedViews.update(editingView.id, { name });
+    setViews((prev) => prev.map((v) => (v.id === editingView.id ? updated.savedView : v)));
+  };
+
+  const handleDelete = async (view: SavedView) => {
+    try {
+      await api.savedViews.delete(view.id);
+      setViews((prev) => prev.filter((v) => v.id !== view.id));
+    } catch (err) {
+      showError(err instanceof Error ? err.message : '削除に失敗しました');
+    }
+  };
+
+  const handleMoveUp = async (index: number) => {
+    if (index === 0) return;
+    const newViews = [...views];
+    [newViews[index - 1], newViews[index]] = [newViews[index], newViews[index - 1]];
+    setViews(newViews);
+    try {
+      await api.savedViews.reorder(newViews.map((v) => v.id));
+    } catch (err) {
+      // 失敗時は元に戻す
+      setViews(views);
+      showError(err instanceof Error ? err.message : '並べ替えに失敗しました');
+    }
+  };
+
+  const handleMoveDown = async (index: number) => {
+    if (index === views.length - 1) return;
+    const newViews = [...views];
+    [newViews[index], newViews[index + 1]] = [newViews[index + 1], newViews[index]];
+    setViews(newViews);
+    try {
+      await api.savedViews.reorder(newViews.map((v) => v.id));
+    } catch (err) {
+      setViews(views);
+      showError(err instanceof Error ? err.message : '並べ替えに失敗しました');
+    }
+  };
+
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        sx={{
+          px: 2,
+          pt: 1,
+          pb: 0.5,
+          display: 'block',
+          color: 'text.secondary',
+          fontWeight: 'bold',
+          textTransform: 'uppercase',
+          fontSize: 10,
+        }}
+      >
+        保存ビュー
+      </Typography>
+      <List dense disablePadding>
+        {views.map((view, index) => (
+          <ListItem
+            key={view.id}
+            disablePadding
+            secondaryAction={
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                <Tooltip title="上に移動">
+                  <span>
+                    <IconButton
+                      size="small"
+                      aria-label="上に移動"
+                      onClick={() => void handleMoveUp(index)}
+                      disabled={index === 0}
+                    >
+                      <KeyboardArrowUpIcon fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+                <Tooltip title="下に移動">
+                  <span>
+                    <IconButton
+                      size="small"
+                      aria-label="下に移動"
+                      onClick={() => void handleMoveDown(index)}
+                      disabled={index === views.length - 1}
+                    >
+                      <KeyboardArrowDownIcon fontSize="small" />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+                <Tooltip title="編集">
+                  <IconButton size="small" aria-label="編集" onClick={() => handleEdit(view)}>
+                    <EditIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="削除">
+                  <IconButton
+                    size="small"
+                    aria-label="削除"
+                    onClick={() => void handleDelete(view)}
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+            }
+          >
+            <ListItemButton onClick={() => handleSelect(view)} sx={{ pr: 16 }}>
+              <ListItemText primary={view.name} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+
+      <SavedViewEditDialog
+        open={editDialogOpen}
+        view={editingView}
+        onClose={() => setEditDialogOpen(false)}
+        onSave={handleEditSave}
+      />
+    </Box>
+  );
+}

--- a/packages/client/src/components/Chat/SearchFilterPanel.tsx
+++ b/packages/client/src/components/Chat/SearchFilterPanel.tsx
@@ -20,6 +20,8 @@ import { useTagSuggestions } from '../../hooks/useTagSuggestions';
 
 // モジュールレベルでPromiseを一度だけ生成（Suspenseによるアンマウント時のリセットを防ぐ）
 const usersPromise = api.auth.users();
+// タグ一覧を取得するPromise（filters.tagIds → TagSuggestion[] 変換に使用）
+const allTagsPromise = api.tags.suggestions('');
 
 export interface SearchFilters {
   dateFrom?: string;
@@ -43,6 +45,12 @@ interface Props {
    * 未指定または空配列のときは件数欄に "—" を表示する。
    */
   searchResults?: MessageSearchResult[];
+  /**
+   * 外部から流し込む初期フィルタ値（保存ビュークリック時等）。
+   * この props が変化したとき、コンポーネントを key で再マウントすることで内部 state をリセットする。
+   * タグの復元には allTagsPromise で取得したタグ一覧を使用する。
+   */
+  filters?: SearchFilters;
 }
 
 function UserSelectInner({ value, onChange }: { value: string; onChange: (v: string) => void }) {
@@ -67,16 +75,31 @@ function UserSelectInner({ value, onChange }: { value: string; onChange: (v: str
   );
 }
 
-export default function SearchFilterPanel({ onFilterChange, onSaveView, searchResults }: Props) {
-  const [dateFrom, setDateFrom] = useState('');
-  const [dateTo, setDateTo] = useState('');
-  const [userId, setUserId] = useState('');
-  const [hasAttachment, setHasAttachment] = useState('');
+export default function SearchFilterPanel({
+  onFilterChange,
+  onSaveView,
+  searchResults,
+  filters,
+}: Props) {
+  // タグ一覧を取得して tagIds → TagSuggestion[] の変換に使用する
+  const { suggestions: allTags } = use(allTagsPromise);
+
+  // filters props を初期値として内部 state を初期化する（key 変更で再マウントされるため、
+  // 初回レンダリング時に filters の値が正しく反映される）
+  const [dateFrom, setDateFrom] = useState(filters?.dateFrom ?? '');
+  const [dateTo, setDateTo] = useState(filters?.dateTo ?? '');
+  const [userId, setUserId] = useState(filters?.userId !== undefined ? String(filters.userId) : '');
+  const [hasAttachment, setHasAttachment] = useState(
+    filters?.hasAttachment === true ? 'true' : filters?.hasAttachment === false ? 'false' : '',
+  );
   const [dateError, setDateError] = useState('');
   // Autocomplete の入力値（候補取得 prefix）
   const [tagInput, setTagInput] = useState('');
-  // 選択済みタグ（id 付き）
-  const [filterTags, setFilterTags] = useState<TagSuggestion[]>([]);
+  // 選択済みタグ（id 付き）— filters.tagIds があれば allTags から復元する
+  const [filterTags, setFilterTags] = useState<TagSuggestion[]>(() => {
+    if (!filters?.tagIds || filters.tagIds.length === 0) return [];
+    return allTags.filter((t) => filters.tagIds!.includes(t.id));
+  });
   // 保存ビュー名入力ダイアログ
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [saveViewName, setSaveViewName] = useState('');

--- a/packages/client/src/components/Chat/SearchFilterPanel.tsx
+++ b/packages/client/src/components/Chat/SearchFilterPanel.tsx
@@ -4,6 +4,10 @@ import {
   Box,
   Button,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   FormControl,
   Select,
   TextField,
@@ -27,6 +31,12 @@ export interface SearchFilters {
 
 interface Props {
   onFilterChange: (filters: SearchFilters) => void;
+  /**
+   * 「保存」ボタン押下 → 名前入力ダイアログ → 確定時のコールバック。
+   * { name, filters } の形式で渡す。
+   * 未指定の場合はボタンを表示しない。
+   */
+  onSaveView?: (params: { name: string; filters: SearchFilters }) => void;
   /**
    * 現在の検索結果。Autocomplete のタグ候補表示で「現クエリにヒットするメッセージのうち
    * そのタグが付いている件数」を集計するために使う。
@@ -57,7 +67,7 @@ function UserSelectInner({ value, onChange }: { value: string; onChange: (v: str
   );
 }
 
-export default function SearchFilterPanel({ onFilterChange, searchResults }: Props) {
+export default function SearchFilterPanel({ onFilterChange, onSaveView, searchResults }: Props) {
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
   const [userId, setUserId] = useState('');
@@ -67,6 +77,9 @@ export default function SearchFilterPanel({ onFilterChange, searchResults }: Pro
   const [tagInput, setTagInput] = useState('');
   // 選択済みタグ（id 付き）
   const [filterTags, setFilterTags] = useState<TagSuggestion[]>([]);
+  // 保存ビュー名入力ダイアログ
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveViewName, setSaveViewName] = useState('');
   // 既存タグ候補（前方一致・use_count 降順）
   const tagSuggestions = useTagSuggestions(tagInput);
 
@@ -261,9 +274,74 @@ export default function SearchFilterPanel({ onFilterChange, searchResults }: Pro
         />
       </Box>
 
-      <Button variant="outlined" size="small" onClick={handleReset}>
-        リセット
-      </Button>
+      <Box sx={{ display: 'flex', gap: 1 }}>
+        <Button variant="outlined" size="small" onClick={handleReset} sx={{ flex: 1 }}>
+          リセット
+        </Button>
+        {onSaveView && (
+          <Button
+            variant="outlined"
+            size="small"
+            disabled={!dateFrom && !dateTo && !userId && !hasAttachment && filterTags.length === 0}
+            onClick={() => {
+              setSaveViewName('');
+              setSaveDialogOpen(true);
+            }}
+            sx={{ flex: 1 }}
+          >
+            保存
+          </Button>
+        )}
+      </Box>
+
+      {/* 保存ビュー名入力ダイアログ */}
+      {onSaveView && (
+        <Dialog
+          open={saveDialogOpen}
+          onClose={() => setSaveDialogOpen(false)}
+          maxWidth="xs"
+          fullWidth
+        >
+          <DialogTitle>ビューを保存</DialogTitle>
+          <DialogContent>
+            <TextField
+              autoFocus
+              label="ビュー名"
+              fullWidth
+              value={saveViewName}
+              onChange={(e) => setSaveViewName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && saveViewName.trim()) {
+                  onSaveView({
+                    name: saveViewName.trim(),
+                    filters: buildFilters(dateFrom, dateTo, userId, hasAttachment, filterTags),
+                  });
+                  setSaveDialogOpen(false);
+                }
+              }}
+              sx={{ mt: 1 }}
+              inputProps={{ 'aria-label': 'ビュー名' }}
+            />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setSaveDialogOpen(false)}>キャンセル</Button>
+            <Button
+              variant="contained"
+              disabled={!saveViewName.trim()}
+              onClick={() => {
+                onSaveView({
+                  name: saveViewName.trim(),
+                  filters: buildFilters(dateFrom, dateTo, userId, hasAttachment, filterTags),
+                });
+                setSaveDialogOpen(false);
+              }}
+              aria-label="確定"
+            >
+              確定
+            </Button>
+          </DialogActions>
+        </Dialog>
+      )}
     </Box>
   );
 }

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -400,6 +400,8 @@ export default function ChatPage({ users }: Props) {
                   >
                     <Suspense fallback={null}>
                       <SearchFilterPanel
+                        key={JSON.stringify(searchFilters)}
+                        filters={searchFilters}
                         onFilterChange={setSearchFilters}
                         searchResults={searchResults}
                         onSaveView={async ({ name, filters }) => {

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -17,7 +17,7 @@ import { useMessages } from '../hooks/useMessages';
 import { useScheduledMessages } from '../hooks/useScheduledMessages';
 import { useSocket } from '../contexts/SocketContext';
 import { api } from '../api/client';
-import type { User, Message, MessageSearchResult, Channel } from '@chat-app/shared';
+import type { User, Message, MessageSearchResult, Channel, SavedViewQuery } from '@chat-app/shared';
 import PinnedMessages from '../components/Channel/PinnedMessages';
 import ArchivedBanner from '../components/Channel/ArchivedBanner';
 import { useAuth } from '../contexts/AuthContext';
@@ -177,7 +177,7 @@ export default function ChatPage({ users }: Props) {
   }, [socket, activeChannelId]);
 
   // #117 NG ワード関連: 送信エラー / 警告を Socket 経由で受信
-  const { showError, showInfo } = useSnackbar();
+  const { showError, showInfo, showSuccess } = useSnackbar();
   useEffect(() => {
     if (!socket) return;
     const handleError = (msg: string) => {
@@ -286,6 +286,18 @@ export default function ChatPage({ users }: Props) {
             setSearchQuery('');
             setSearchFilters({});
           }}
+          onSelectSavedView={(query: SavedViewQuery) => {
+            // 保存ビュークリック → 検索モードを開始して条件を復元
+            setSearchActive(true);
+            setSearchQuery(query.keyword ?? '');
+            setSearchFilters({
+              dateFrom: query.dateFrom,
+              dateTo: query.dateTo,
+              userId: query.userId,
+              hasAttachment: query.hasAttachment,
+              tagIds: query.tagIds,
+            });
+          }}
           draftMap={draftMap}
         />
       }
@@ -390,6 +402,26 @@ export default function ChatPage({ users }: Props) {
                       <SearchFilterPanel
                         onFilterChange={setSearchFilters}
                         searchResults={searchResults}
+                        onSaveView={async ({ name, filters }) => {
+                          try {
+                            await api.savedViews.create({
+                              name,
+                              query: {
+                                keyword: searchQuery || undefined,
+                                dateFrom: filters.dateFrom,
+                                dateTo: filters.dateTo,
+                                userId: filters.userId,
+                                hasAttachment: filters.hasAttachment,
+                                tagIds: filters.tagIds,
+                              },
+                            });
+                            showSuccess(`保存ビュー「${name}」を保存しました`);
+                          } catch (err) {
+                            showError(
+                              err instanceof Error ? err.message : '保存ビューの作成に失敗しました',
+                            );
+                          }
+                        }}
                       />
                     </Suspense>
                   </Box>

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -343,6 +343,17 @@ export function createTestDatabase() {
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       UNIQUE (message_id, reporter_id)
     );
+
+    CREATE TABLE IF NOT EXISTS saved_views (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      query JSONB NOT NULL DEFAULT '{}',
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (user_id, name)
+    );
   `);
 
   // pg-mem で作った Pool アダプタ
@@ -418,6 +429,7 @@ export function getSharedTestDatabase(): TestDatabase {
  */
 export async function resetTestData(db: TestDatabase): Promise<void> {
   // 外部キー参照の末端から順に削除する
+  await db.execute('DELETE FROM saved_views', []);
   await db.execute('DELETE FROM message_reports', []);
   await db.execute('DELETE FROM event_rsvps', []);
   await db.execute('DELETE FROM events', []);

--- a/packages/server/src/__tests__/saved-view.test.ts
+++ b/packages/server/src/__tests__/saved-view.test.ts
@@ -25,7 +25,8 @@ jest.mock('../db/database', () => testDb);
 
 import request from 'supertest';
 import { createApp } from '../app';
-import { registerUser, registerAndGetCookie } from './__fixtures__/testHelpers';
+import { registerAndGetCookie } from './__fixtures__/testHelpers';
+import * as savedViewService from '../services/savedViewService';
 
 const app = createApp();
 
@@ -61,88 +62,176 @@ beforeEach(async () => {
 
 describe('savedViewService', () => {
   describe('保存ビュー作成', () => {
-    it('名前と query を指定して保存ビューを作成できる', () => {
-      // TODO
+    it('名前と query を指定して保存ビューを作成できる', async () => {
+      const query = { keyword: 'test', tagIds: [1, 2] };
+      const view = await savedViewService.createSavedView(userId1, '今週のバグ', query);
+
+      expect(view.id).toBeDefined();
+      expect(view.userId).toBe(userId1);
+      expect(view.name).toBe('今週のバグ');
+      expect(view.query).toEqual(query);
     });
 
-    it('作成された保存ビューの position はデフォルト 0 になる', () => {
-      // TODO
+    it('作成された保存ビューの position はデフォルト 0 になる', async () => {
+      const view = await savedViewService.createSavedView(userId1, 'テスト', {});
+      expect(view.position).toBe(0);
     });
 
-    it('同一ユーザーで同じ名前を再度作成すると一意制約エラーになる', () => {
-      // TODO
+    it('同一ユーザーで同じ名前を再度作成すると一意制約エラーになる', async () => {
+      await savedViewService.createSavedView(userId1, '重複テスト', {});
+      await expect(savedViewService.createSavedView(userId1, '重複テスト', {})).rejects.toThrow();
     });
 
-    it('異なるユーザーが同じ名前で作成しても一意制約エラーにならない', () => {
-      // TODO
+    it('異なるユーザーが同じ名前で作成しても一意制約エラーにならない', async () => {
+      await savedViewService.createSavedView(userId1, '同名ビュー', {});
+      const view2 = await savedViewService.createSavedView(userId2, '同名ビュー', {});
+      expect(view2.userId).toBe(userId2);
+      expect(view2.name).toBe('同名ビュー');
     });
 
-    it('query の中身は jsonb としてそのまま保存される（キーワード・期間・userId・tagIds を含む）', () => {
-      // TODO
+    it('query の中身は jsonb としてそのまま保存される（キーワード・期間・userId・tagIds を含む）', async () => {
+      const query = {
+        keyword: 'hello',
+        dateFrom: '2024-01-01',
+        dateTo: '2024-12-31',
+        userId: 42,
+        tagIds: [10, 20],
+        hasAttachment: true,
+      };
+      const view = await savedViewService.createSavedView(userId1, 'フルクエリ', query);
+      expect(view.query).toEqual(query);
     });
   });
 
   describe('保存ビュー取得', () => {
-    it('ユーザーの保存ビュー一覧を position 昇順で取得できる', () => {
-      // TODO
+    it('ユーザーの保存ビュー一覧を position 昇順で取得できる', async () => {
+      await testDb.execute(
+        'INSERT INTO saved_views (user_id, name, query, position) VALUES ($1, $2, $3, $4)',
+        [userId1, 'ビューC', '{}', 2],
+      );
+      await testDb.execute(
+        'INSERT INTO saved_views (user_id, name, query, position) VALUES ($1, $2, $3, $4)',
+        [userId1, 'ビューA', '{}', 0],
+      );
+      await testDb.execute(
+        'INSERT INTO saved_views (user_id, name, query, position) VALUES ($1, $2, $3, $4)',
+        [userId1, 'ビューB', '{}', 1],
+      );
+
+      const views = await savedViewService.getSavedViews(userId1);
+      expect(views).toHaveLength(3);
+      expect(views[0].name).toBe('ビューA');
+      expect(views[1].name).toBe('ビューB');
+      expect(views[2].name).toBe('ビューC');
     });
 
-    it('他ユーザーの保存ビューは取得されない', () => {
-      // TODO
+    it('他ユーザーの保存ビューは取得されない', async () => {
+      await savedViewService.createSavedView(userId1, 'user1のビュー', {});
+      await savedViewService.createSavedView(userId2, 'user2のビュー', {});
+
+      const views1 = await savedViewService.getSavedViews(userId1);
+      expect(views1.every((v) => v.userId === userId1)).toBe(true);
     });
 
-    it('保存ビューが 0 件のとき空配列を返す', () => {
-      // TODO
+    it('保存ビューが 0 件のとき空配列を返す', async () => {
+      const views = await savedViewService.getSavedViews(userId1);
+      expect(views).toEqual([]);
     });
   });
 
   describe('保存ビュー更新', () => {
-    it('名前を変更できる', () => {
-      // TODO
+    it('名前を変更できる', async () => {
+      const created = await savedViewService.createSavedView(userId1, '旧名前', {});
+      const updated = await savedViewService.updateSavedView(userId1, created.id, {
+        name: '新名前',
+      });
+      expect(updated.name).toBe('新名前');
     });
 
-    it('query を変更できる', () => {
-      // TODO
+    it('query を変更できる', async () => {
+      const created = await savedViewService.createSavedView(userId1, 'クエリ更新テスト', {
+        keyword: 'old',
+      });
+      const newQuery = { keyword: 'new', tagIds: [5] };
+      const updated = await savedViewService.updateSavedView(userId1, created.id, {
+        query: newQuery,
+      });
+      expect(updated.query).toEqual(newQuery);
     });
 
-    it('他ユーザーの保存ビューを更新しようとするとエラーになる', () => {
-      // TODO
+    it('他ユーザーの保存ビューを更新しようとするとエラーになる', async () => {
+      const created = await savedViewService.createSavedView(userId1, '他人のビュー', {});
+      await expect(
+        savedViewService.updateSavedView(userId2, created.id, { name: '書き換え' }),
+      ).rejects.toThrow();
     });
 
-    it('存在しない id を更新しようとするとエラーになる', () => {
-      // TODO
+    it('存在しない id を更新しようとするとエラーになる', async () => {
+      await expect(
+        savedViewService.updateSavedView(userId1, 99999, { name: '存在しない' }),
+      ).rejects.toThrow();
     });
 
-    it('変更後の名前が同一ユーザーの既存保存ビュー名と重複する場合はエラーになる', () => {
-      // TODO
+    it('変更後の名前が同一ユーザーの既存保存ビュー名と重複する場合はエラーになる', async () => {
+      await savedViewService.createSavedView(userId1, 'ビュー1', {});
+      const view2 = await savedViewService.createSavedView(userId1, 'ビュー2', {});
+      await expect(
+        savedViewService.updateSavedView(userId1, view2.id, { name: 'ビュー1' }),
+      ).rejects.toThrow();
     });
   });
 
   describe('保存ビュー削除', () => {
-    it('自分の保存ビューを削除できる', () => {
-      // TODO
+    it('自分の保存ビューを削除できる', async () => {
+      const created = await savedViewService.createSavedView(userId1, '削除対象', {});
+      await savedViewService.deleteSavedView(userId1, created.id);
+      const views = await savedViewService.getSavedViews(userId1);
+      expect(views.find((v) => v.id === created.id)).toBeUndefined();
     });
 
-    it('他ユーザーの保存ビューを削除しようとするとエラーになる', () => {
-      // TODO
+    it('他ユーザーの保存ビューを削除しようとするとエラーになる', async () => {
+      const created = await savedViewService.createSavedView(userId1, '他人のビュー', {});
+      await expect(savedViewService.deleteSavedView(userId2, created.id)).rejects.toThrow();
     });
 
-    it('存在しない id を削除しようとするとエラーになる', () => {
-      // TODO
+    it('存在しない id を削除しようとするとエラーになる', async () => {
+      await expect(savedViewService.deleteSavedView(userId1, 99999)).rejects.toThrow();
     });
   });
 
   describe('並べ替え', () => {
-    it('保存ビューの順序を id 配列で指定して並べ替えできる', () => {
-      // TODO
+    it('保存ビューの順序を id 配列で指定して並べ替えできる', async () => {
+      const v1 = await savedViewService.createSavedView(userId1, 'ビュー1', {});
+      const v2 = await savedViewService.createSavedView(userId1, 'ビュー2', {});
+      const v3 = await savedViewService.createSavedView(userId1, 'ビュー3', {});
+
+      await savedViewService.reorderSavedViews(userId1, [v3.id, v2.id, v1.id]);
+
+      const views = await savedViewService.getSavedViews(userId1);
+      expect(views[0].id).toBe(v3.id);
+      expect(views[1].id).toBe(v2.id);
+      expect(views[2].id).toBe(v1.id);
     });
 
-    it('自分の保存ビューのみ並べ替えでき、他ユーザーの id が含まれてもエラーになる', () => {
-      // TODO
+    it('自分の保存ビューのみ並べ替えでき、他ユーザーの id が含まれてもエラーになる', async () => {
+      const v1 = await savedViewService.createSavedView(userId1, 'ビュー1', {});
+      const v2other = await savedViewService.createSavedView(userId2, '他人のビュー', {});
+      await expect(
+        savedViewService.reorderSavedViews(userId1, [v1.id, v2other.id]),
+      ).rejects.toThrow();
     });
 
-    it('並べ替え後に取得すると新しい position 順で返る', () => {
-      // TODO
+    it('並べ替え後に取得すると新しい position 順で返る', async () => {
+      const v1 = await savedViewService.createSavedView(userId1, 'ビュー1', {});
+      const v2 = await savedViewService.createSavedView(userId1, 'ビュー2', {});
+
+      await savedViewService.reorderSavedViews(userId1, [v2.id, v1.id]);
+
+      const views = await savedViewService.getSavedViews(userId1);
+      expect(views[0].name).toBe('ビュー2');
+      expect(views[0].position).toBe(0);
+      expect(views[1].name).toBe('ビュー1');
+      expect(views[1].position).toBe(1);
     });
   });
 });
@@ -153,80 +242,261 @@ describe('savedViewService', () => {
 
 describe('保存ビュー APIエンドポイント', () => {
   describe('GET /saved-views', () => {
-    it('認証済みユーザーが自分の保存ビュー一覧を取得できる (200)', () => {
-      // TODO
+    it('認証済みユーザーが自分の保存ビュー一覧を取得できる (200)', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi1', 'svapi1@t.com', 'password123');
+
+      await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: 'テストビュー', query: { keyword: 'hello' } });
+
+      const res = await request(app).get('/api/saved-views').set('Cookie', cookie);
+
+      expect(res.status).toBe(200);
+      expect(res.body.savedViews).toHaveLength(1);
+      expect(res.body.savedViews[0].name).toBe('テストビュー');
     });
 
-    it('認証なしで 401 を返す', () => {
-      // TODO
+    it('認証なしで 401 を返す', async () => {
+      const res = await request(app).get('/api/saved-views');
+      expect(res.status).toBe(401);
     });
   });
 
   describe('POST /saved-views', () => {
-    it('保存ビューを新規作成すると 201 と作成データが返る', () => {
-      // TODO
+    it('保存ビューを新規作成すると 201 と作成データが返る', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi2', 'svapi2@t.com', 'password123');
+
+      const res = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: '新規ビュー', query: { keyword: 'test' } });
+
+      expect(res.status).toBe(201);
+      expect(res.body.savedView).toBeDefined();
+      expect(res.body.savedView.name).toBe('新規ビュー');
+      expect(res.body.savedView.query).toEqual({ keyword: 'test' });
     });
 
-    it('同名保存ビューを作成すると 409 を返す', () => {
-      // TODO
+    it('同名保存ビューを作成すると 409 を返す', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi3', 'svapi3@t.com', 'password123');
+
+      await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: '重複ビュー', query: {} });
+
+      const res = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: '重複ビュー', query: {} });
+
+      expect(res.status).toBe(409);
     });
 
-    it('name が空文字の場合は 400 を返す', () => {
-      // TODO
+    it('name が空文字の場合は 400 を返す', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi4', 'svapi4@t.com', 'password123');
+
+      const res = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: '', query: {} });
+
+      expect(res.status).toBe(400);
     });
 
-    it('認証なしで 401 を返す', () => {
-      // TODO
+    it('認証なしで 401 を返す', async () => {
+      const res = await request(app).post('/api/saved-views').send({ name: 'ビュー', query: {} });
+      expect(res.status).toBe(401);
     });
   });
 
   describe('PUT /saved-views/:id', () => {
-    it('保存ビューの名前・query を更新すると 200 と更新後データが返る', () => {
-      // TODO
+    it('保存ビューの名前・query を更新すると 200 と更新後データが返る', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi5', 'svapi5@t.com', 'password123');
+
+      const createRes = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: '旧名前', query: {} });
+      const id = createRes.body.savedView.id as number;
+
+      const res = await request(app)
+        .put(`/api/saved-views/${id}`)
+        .set('Cookie', cookie)
+        .send({ name: '新名前', query: { keyword: 'updated' } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.savedView.name).toBe('新名前');
+      expect(res.body.savedView.query).toEqual({ keyword: 'updated' });
     });
 
-    it('他ユーザーの保存ビューを更新しようとすると 403 を返す', () => {
-      // TODO
+    it('他ユーザーの保存ビューを更新しようとすると 403 を返す', async () => {
+      const { cookie: cookie1 } = await registerAndGetCookie(
+        app,
+        'svapi6a',
+        'svapi6a@t.com',
+        'password123',
+      );
+
+      const createRes = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie1)
+        .send({ name: 'user1のビュー', query: {} });
+      const id = createRes.body.savedView.id as number;
+
+      const { cookie: cookie2 } = await registerAndGetCookie(
+        app,
+        'svapi6b',
+        'svapi6b@t.com',
+        'password123',
+      );
+
+      const res = await request(app)
+        .put(`/api/saved-views/${id}`)
+        .set('Cookie', cookie2)
+        .send({ name: '書き換え' });
+
+      expect(res.status).toBe(403);
     });
 
-    it('存在しない id を更新しようとすると 404 を返す', () => {
-      // TODO
+    it('存在しない id を更新しようとすると 404 を返す', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi7', 'svapi7@t.com', 'password123');
+
+      const res = await request(app)
+        .put('/api/saved-views/99999')
+        .set('Cookie', cookie)
+        .send({ name: '存在しない' });
+
+      expect(res.status).toBe(404);
     });
 
-    it('認証なしで 401 を返す', () => {
-      // TODO
+    it('認証なしで 401 を返す', async () => {
+      const res = await request(app).put('/api/saved-views/1').send({ name: 'テスト' });
+      expect(res.status).toBe(401);
     });
   });
 
   describe('DELETE /saved-views/:id', () => {
-    it('保存ビューを削除すると 204 を返す', () => {
-      // TODO
+    it('保存ビューを削除すると 204 を返す', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi8', 'svapi8@t.com', 'password123');
+
+      const createRes = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: '削除対象', query: {} });
+      const id = createRes.body.savedView.id as number;
+
+      const res = await request(app).delete(`/api/saved-views/${id}`).set('Cookie', cookie);
+
+      expect(res.status).toBe(204);
     });
 
-    it('他ユーザーの保存ビューを削除しようとすると 403 を返す', () => {
-      // TODO
+    it('他ユーザーの保存ビューを削除しようとすると 403 を返す', async () => {
+      const { cookie: cookie1 } = await registerAndGetCookie(
+        app,
+        'svapi9a',
+        'svapi9a@t.com',
+        'password123',
+      );
+
+      const createRes = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie1)
+        .send({ name: 'user1のビュー', query: {} });
+      const id = createRes.body.savedView.id as number;
+
+      const { cookie: cookie2 } = await registerAndGetCookie(
+        app,
+        'svapi9b',
+        'svapi9b@t.com',
+        'password123',
+      );
+
+      const res = await request(app).delete(`/api/saved-views/${id}`).set('Cookie', cookie2);
+
+      expect(res.status).toBe(403);
     });
 
-    it('存在しない id を削除しようとすると 404 を返す', () => {
-      // TODO
+    it('存在しない id を削除しようとすると 404 を返す', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi10', 'svapi10@t.com', 'password123');
+
+      const res = await request(app).delete('/api/saved-views/99999').set('Cookie', cookie);
+
+      expect(res.status).toBe(404);
     });
 
-    it('認証なしで 401 を返す', () => {
-      // TODO
+    it('認証なしで 401 を返す', async () => {
+      const res = await request(app).delete('/api/saved-views/1');
+      expect(res.status).toBe(401);
     });
   });
 
   describe('PUT /saved-views/order', () => {
-    it('id 配列の順序で保存ビューを並べ替えると 200 を返す', () => {
-      // TODO
+    it('id 配列の順序で保存ビューを並べ替えると 200 を返す', async () => {
+      const { cookie } = await registerAndGetCookie(app, 'svapi11', 'svapi11@t.com', 'password123');
+
+      const r1 = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: 'ビュー1', query: {} });
+      const r2 = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie)
+        .send({ name: 'ビュー2', query: {} });
+
+      const id1 = r1.body.savedView.id as number;
+      const id2 = r2.body.savedView.id as number;
+
+      const res = await request(app)
+        .put('/api/saved-views/order')
+        .set('Cookie', cookie)
+        .send({ ids: [id2, id1] });
+
+      expect(res.status).toBe(200);
     });
 
-    it('他ユーザーの id が含まれていると 403 を返す', () => {
-      // TODO
+    it('他ユーザーの id が含まれていると 403 を返す', async () => {
+      const { cookie: cookie1 } = await registerAndGetCookie(
+        app,
+        'svapi12a',
+        'svapi12a@t.com',
+        'password123',
+      );
+
+      const r1 = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie1)
+        .send({ name: 'user1のビュー', query: {} });
+
+      const { cookie: cookie2 } = await registerAndGetCookie(
+        app,
+        'svapi12b',
+        'svapi12b@t.com',
+        'password123',
+      );
+
+      const r2 = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', cookie2)
+        .send({ name: 'user2のビュー', query: {} });
+
+      const id1 = r1.body.savedView.id as number;
+      const id2 = r2.body.savedView.id as number;
+
+      const res = await request(app)
+        .put('/api/saved-views/order')
+        .set('Cookie', cookie1)
+        .send({ ids: [id1, id2] });
+
+      expect(res.status).toBe(403);
     });
 
-    it('認証なしで 401 を返す', () => {
-      // TODO
+    it('認証なしで 401 を返す', async () => {
+      const res = await request(app)
+        .put('/api/saved-views/order')
+        .send({ ids: [1, 2] });
+      expect(res.status).toBe(401);
     });
   });
 });

--- a/packages/server/src/__tests__/saved-view.test.ts
+++ b/packages/server/src/__tests__/saved-view.test.ts
@@ -1,0 +1,232 @@
+/**
+ * テスト対象: 保存ビュー機能 - サーバーサイド
+ *
+ * 【仕様概要】
+ * ユーザーが検索条件（キーワード・期間・投稿者・チャンネル・タグ）に名前を付けて保存できる機能。
+ * 保存ビューは個人専用（user_id で隔離）、件数上限なし。
+ * 並べ替えは position フィールドで管理し、上下ボタンで操作する。
+ *
+ * 【テーブル: saved_views】
+ *   id serial pk, user_id fk users, name text, query jsonb, position integer,
+ *   created_at, updated_at
+ *   一意制約: (user_id, name)
+ *
+ * 戦略:
+ *   - getSharedTestDatabase() + resetTestData() でインメモリDB共有
+ *   - savedViewService 関数を直接呼び出すユニットテスト
+ *   - HTTP エンドポイントを supertest で検証する統合テスト
+ */
+
+import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+
+jest.mock('../db/database', () => testDb);
+
+import request from 'supertest';
+import { createApp } from '../app';
+import { registerUser, registerAndGetCookie } from './__fixtures__/testHelpers';
+
+const app = createApp();
+
+// ────────────────────────────────────────────────────────────────────────────
+// フィクスチャセットアップ
+// ────────────────────────────────────────────────────────────────────────────
+
+let userId1: number;
+let userId2: number;
+
+async function setupFixtures() {
+  const r1 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['svuser1', 'sv1@t.com', 'h'],
+  );
+  userId1 = r1.rows[0].id as number;
+
+  const r2 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['svuser2', 'sv2@t.com', 'h'],
+  );
+  userId2 = r2.rows[0].id as number;
+}
+
+beforeEach(async () => {
+  await resetTestData(testDb);
+  await setupFixtures();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// サービス層ユニットテスト
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('savedViewService', () => {
+  describe('保存ビュー作成', () => {
+    it('名前と query を指定して保存ビューを作成できる', () => {
+      // TODO
+    });
+
+    it('作成された保存ビューの position はデフォルト 0 になる', () => {
+      // TODO
+    });
+
+    it('同一ユーザーで同じ名前を再度作成すると一意制約エラーになる', () => {
+      // TODO
+    });
+
+    it('異なるユーザーが同じ名前で作成しても一意制約エラーにならない', () => {
+      // TODO
+    });
+
+    it('query の中身は jsonb としてそのまま保存される（キーワード・期間・userId・tagIds を含む）', () => {
+      // TODO
+    });
+  });
+
+  describe('保存ビュー取得', () => {
+    it('ユーザーの保存ビュー一覧を position 昇順で取得できる', () => {
+      // TODO
+    });
+
+    it('他ユーザーの保存ビューは取得されない', () => {
+      // TODO
+    });
+
+    it('保存ビューが 0 件のとき空配列を返す', () => {
+      // TODO
+    });
+  });
+
+  describe('保存ビュー更新', () => {
+    it('名前を変更できる', () => {
+      // TODO
+    });
+
+    it('query を変更できる', () => {
+      // TODO
+    });
+
+    it('他ユーザーの保存ビューを更新しようとするとエラーになる', () => {
+      // TODO
+    });
+
+    it('存在しない id を更新しようとするとエラーになる', () => {
+      // TODO
+    });
+
+    it('変更後の名前が同一ユーザーの既存保存ビュー名と重複する場合はエラーになる', () => {
+      // TODO
+    });
+  });
+
+  describe('保存ビュー削除', () => {
+    it('自分の保存ビューを削除できる', () => {
+      // TODO
+    });
+
+    it('他ユーザーの保存ビューを削除しようとするとエラーになる', () => {
+      // TODO
+    });
+
+    it('存在しない id を削除しようとするとエラーになる', () => {
+      // TODO
+    });
+  });
+
+  describe('並べ替え', () => {
+    it('保存ビューの順序を id 配列で指定して並べ替えできる', () => {
+      // TODO
+    });
+
+    it('自分の保存ビューのみ並べ替えでき、他ユーザーの id が含まれてもエラーになる', () => {
+      // TODO
+    });
+
+    it('並べ替え後に取得すると新しい position 順で返る', () => {
+      // TODO
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// HTTP 統合テスト
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('保存ビュー APIエンドポイント', () => {
+  describe('GET /saved-views', () => {
+    it('認証済みユーザーが自分の保存ビュー一覧を取得できる (200)', () => {
+      // TODO
+    });
+
+    it('認証なしで 401 を返す', () => {
+      // TODO
+    });
+  });
+
+  describe('POST /saved-views', () => {
+    it('保存ビューを新規作成すると 201 と作成データが返る', () => {
+      // TODO
+    });
+
+    it('同名保存ビューを作成すると 409 を返す', () => {
+      // TODO
+    });
+
+    it('name が空文字の場合は 400 を返す', () => {
+      // TODO
+    });
+
+    it('認証なしで 401 を返す', () => {
+      // TODO
+    });
+  });
+
+  describe('PUT /saved-views/:id', () => {
+    it('保存ビューの名前・query を更新すると 200 と更新後データが返る', () => {
+      // TODO
+    });
+
+    it('他ユーザーの保存ビューを更新しようとすると 403 を返す', () => {
+      // TODO
+    });
+
+    it('存在しない id を更新しようとすると 404 を返す', () => {
+      // TODO
+    });
+
+    it('認証なしで 401 を返す', () => {
+      // TODO
+    });
+  });
+
+  describe('DELETE /saved-views/:id', () => {
+    it('保存ビューを削除すると 204 を返す', () => {
+      // TODO
+    });
+
+    it('他ユーザーの保存ビューを削除しようとすると 403 を返す', () => {
+      // TODO
+    });
+
+    it('存在しない id を削除しようとすると 404 を返す', () => {
+      // TODO
+    });
+
+    it('認証なしで 401 を返す', () => {
+      // TODO
+    });
+  });
+
+  describe('PUT /saved-views/order', () => {
+    it('id 配列の順序で保存ビューを並べ替えると 200 を返す', () => {
+      // TODO
+    });
+
+    it('他ユーザーの id が含まれていると 403 を返す', () => {
+      // TODO
+    });
+
+    it('認証なしで 401 を返す', () => {
+      // TODO
+    });
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -19,6 +19,7 @@ import inviteRoutes from './routes/invites';
 import scheduledMessageRoutes from './routes/scheduledMessages';
 import eventRoutes from './routes/events';
 import draftRoutes from './routes/drafts';
+import savedViewRoutes from './routes/savedViews';
 import { errorHandler } from './middleware/errorHandler';
 import { setupSwagger } from './swagger/setup';
 
@@ -57,6 +58,7 @@ export function createApp() {
   app.use('/api/scheduled-messages', scheduledMessageRoutes);
   app.use('/api/events', eventRoutes);
   app.use('/api/drafts', draftRoutes);
+  app.use('/api/saved-views', savedViewRoutes);
 
   app.use(errorHandler);
 

--- a/packages/server/src/routes/savedViews.ts
+++ b/packages/server/src/routes/savedViews.ts
@@ -1,0 +1,137 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
+import * as savedViewService from '../services/savedViewService';
+
+const router = Router();
+
+/** query フィールドの最低限バリデーション */
+const savedViewQuerySchema = z
+  .object({
+    keyword: z.string().optional(),
+    dateFrom: z.string().optional(),
+    dateTo: z.string().optional(),
+    userId: z.number().int().positive().optional(),
+    channelId: z.number().int().positive().optional(),
+    hasAttachment: z.boolean().optional(),
+    tagIds: z.array(z.number().int().positive()).optional(),
+  })
+  .strict();
+
+const createBodySchema = z.object({
+  name: z.string().min(1),
+  query: savedViewQuerySchema,
+});
+
+const updateBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  query: savedViewQuerySchema.optional(),
+});
+
+const reorderBodySchema = z.object({
+  ids: z.array(z.number().int().positive()).min(1),
+});
+
+// GET /saved-views
+router.get('/', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  const savedViews = await savedViewService.getSavedViews(userId);
+  return res.json({ savedViews });
+});
+
+// PUT /saved-views/order — 並べ替え（:id より前に定義して優先させる）
+router.put('/order', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  const parsed = reorderBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: '無効なリクエストです', details: parsed.error.issues });
+  }
+
+  try {
+    await savedViewService.reorderSavedViews(userId, parsed.data.ids);
+    return res.json({ success: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '並べ替えに失敗しました';
+    if (msg.includes('他ユーザー')) return res.status(403).json({ error: msg });
+    return res.status(400).json({ error: msg });
+  }
+});
+
+// POST /saved-views
+router.post('/', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  const parsed = createBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: '無効なリクエストです', details: parsed.error.issues });
+  }
+
+  try {
+    const savedView = await savedViewService.createSavedView(
+      userId,
+      parsed.data.name,
+      parsed.data.query,
+    );
+    return res.status(201).json({ savedView });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '保存ビューの作成に失敗しました';
+    // unique constraint violation
+    if (
+      msg.includes('unique') ||
+      msg.includes('duplicate') ||
+      msg.includes('一意制約') ||
+      msg.toLowerCase().includes('already exists')
+    ) {
+      return res.status(409).json({ error: '同じ名前の保存ビューが既に存在します' });
+    }
+    return res.status(500).json({ error: msg });
+  }
+});
+
+// PUT /saved-views/:id
+router.put('/:id', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  const viewId = parseInt(req.params.id, 10);
+  if (isNaN(viewId)) return res.status(400).json({ error: '無効な id です' });
+
+  const parsed = updateBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ error: '無効なリクエストです', details: parsed.error.issues });
+  }
+
+  try {
+    const savedView = await savedViewService.updateSavedView(userId, viewId, parsed.data);
+    return res.json({ savedView });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '更新に失敗しました';
+    if (msg.includes('見つかりません')) return res.status(404).json({ error: msg });
+    if (msg.includes('他ユーザー')) return res.status(403).json({ error: msg });
+    if (
+      msg.includes('unique') ||
+      msg.includes('duplicate') ||
+      msg.includes('一意制約') ||
+      msg.toLowerCase().includes('already exists')
+    ) {
+      return res.status(409).json({ error: '同じ名前の保存ビューが既に存在します' });
+    }
+    return res.status(500).json({ error: msg });
+  }
+});
+
+// DELETE /saved-views/:id
+router.delete('/:id', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  const viewId = parseInt(req.params.id, 10);
+  if (isNaN(viewId)) return res.status(400).json({ error: '無効な id です' });
+
+  try {
+    await savedViewService.deleteSavedView(userId, viewId);
+    return res.status(204).send();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '削除に失敗しました';
+    if (msg.includes('見つかりません')) return res.status(404).json({ error: msg });
+    if (msg.includes('他ユーザー')) return res.status(403).json({ error: msg });
+    return res.status(500).json({ error: msg });
+  }
+});
+
+export default router;

--- a/packages/server/src/services/savedViewService.ts
+++ b/packages/server/src/services/savedViewService.ts
@@ -1,0 +1,136 @@
+import { query, queryOne, execute } from '../db/database';
+import type { SavedView, SavedViewQuery } from '@chat-app/shared';
+
+interface SavedViewRow {
+  id: number;
+  user_id: number;
+  name: string;
+  query: SavedViewQuery;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function toSavedView(row: SavedViewRow): SavedView {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    name: row.name,
+    query: row.query,
+    position: row.position,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * 指定ユーザーの保存ビュー一覧を position 昇順で取得する
+ */
+export async function getSavedViews(userId: number): Promise<SavedView[]> {
+  const rows = await query<SavedViewRow>(
+    'SELECT id, user_id, name, query, position, created_at, updated_at FROM saved_views WHERE user_id = $1 ORDER BY position ASC, id ASC',
+    [userId],
+  );
+  return rows.map(toSavedView);
+}
+
+/**
+ * 保存ビューを作成する
+ */
+export async function createSavedView(
+  userId: number,
+  name: string,
+  savedQuery: SavedViewQuery,
+): Promise<SavedView> {
+  const row = await queryOne<SavedViewRow>(
+    `INSERT INTO saved_views (user_id, name, query, position)
+     VALUES ($1, $2, $3, 0)
+     RETURNING id, user_id, name, query, position, created_at, updated_at`,
+    [userId, name, JSON.stringify(savedQuery)],
+  );
+  if (!row) throw new Error('保存ビューの作成に失敗しました');
+  return toSavedView(row);
+}
+
+/**
+ * 保存ビューを更新する
+ * 自分以外の保存ビューを更新しようとするとエラーになる
+ * 存在しない id はエラーになる
+ */
+export async function updateSavedView(
+  userId: number,
+  viewId: number,
+  updates: { name?: string; query?: SavedViewQuery },
+): Promise<SavedView> {
+  // 存在確認と所有者確認
+  const existing = await queryOne<SavedViewRow>(
+    'SELECT id, user_id, name, query, position, created_at, updated_at FROM saved_views WHERE id = $1',
+    [viewId],
+  );
+  if (!existing) throw new Error('保存ビューが見つかりません');
+  if (existing.user_id !== userId) throw new Error('他ユーザーの保存ビューは更新できません');
+
+  const newName = updates.name !== undefined ? updates.name : existing.name;
+  const newQuery = updates.query !== undefined ? updates.query : existing.query;
+
+  const row = await queryOne<SavedViewRow>(
+    `UPDATE saved_views
+     SET name = $1, query = $2, updated_at = NOW()
+     WHERE id = $3 AND user_id = $4
+     RETURNING id, user_id, name, query, position, created_at, updated_at`,
+    [newName, JSON.stringify(newQuery), viewId, userId],
+  );
+  if (!row) throw new Error('保存ビューの更新に失敗しました');
+  return toSavedView(row);
+}
+
+/**
+ * 保存ビューを削除する
+ * 自分以外の保存ビューを削除しようとするとエラーになる
+ * 存在しない id はエラーになる
+ */
+export async function deleteSavedView(userId: number, viewId: number): Promise<void> {
+  const existing = await queryOne<{ id: number; user_id: number }>(
+    'SELECT id, user_id FROM saved_views WHERE id = $1',
+    [viewId],
+  );
+  if (!existing) throw new Error('保存ビューが見つかりません');
+  if (existing.user_id !== userId) throw new Error('他ユーザーの保存ビューは削除できません');
+
+  await execute('DELETE FROM saved_views WHERE id = $1 AND user_id = $2', [viewId, userId]);
+}
+
+/**
+ * 保存ビューの順序を id 配列で指定して並べ替える
+ * 自分の保存ビューのみ並べ替えでき、他ユーザーの id が含まれるとエラー
+ */
+export async function reorderSavedViews(userId: number, orderedIds: number[]): Promise<void> {
+  if (orderedIds.length === 0) return;
+
+  // 全 id が自分のものかチェック
+  // pg-mem との互換性のため ANY($1::int[]) ではなく IN (…) で動的プレースホルダーを生成
+  const placeholders = orderedIds.map((_, i) => `$${i + 1}`).join(', ');
+  const rows = await query<{ id: number; user_id: number }>(
+    `SELECT id, user_id FROM saved_views WHERE id IN (${placeholders})`,
+    orderedIds,
+  );
+
+  for (const row of rows) {
+    if (row.user_id !== userId) {
+      throw new Error('他ユーザーの保存ビューは並べ替えできません');
+    }
+  }
+
+  // 見つかった数が指定 id 数と一致しない（存在しない id が含まれる）場合もエラー
+  if (rows.length !== orderedIds.length) {
+    throw new Error('指定された保存ビューが見つかりません');
+  }
+
+  // position を更新
+  for (let i = 0; i < orderedIds.length; i++) {
+    await execute('UPDATE saved_views SET position = $1, updated_at = NOW() WHERE id = $2', [
+      i,
+      orderedIds[i],
+    ]);
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,3 +16,4 @@ export * from './types/moderation';
 export * from './types/event';
 export * from './types/draft';
 export * from './types/presence';
+export * from './types/savedView';

--- a/packages/shared/src/types/savedView.ts
+++ b/packages/shared/src/types/savedView.ts
@@ -1,0 +1,35 @@
+// 保存ビュー型定義 (#150)
+
+/** 保存ビューのクエリ条件 */
+export interface SavedViewQuery {
+  keyword?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  userId?: number;
+  channelId?: number;
+  hasAttachment?: boolean;
+  tagIds?: number[];
+}
+
+/** 保存ビュー */
+export interface SavedView {
+  id: number;
+  userId: number;
+  name: string;
+  query: SavedViewQuery;
+  position: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** 保存ビュー作成リクエスト */
+export interface CreateSavedViewInput {
+  name: string;
+  query: SavedViewQuery;
+}
+
+/** 保存ビュー更新リクエスト */
+export interface UpdateSavedViewInput {
+  name?: string;
+  query?: SavedViewQuery;
+}


### PR DESCRIPTION
## 概要

検索条件（キーワード・期間・投稿者・添付・タグ）に名前を付けて保存し、サイドバーからワンクリックで再表示できる「保存ビュー」機能を追加する。Issue #150 の MVP 実装。

- 個人専用（`user_id` 単位で隔離）／件数上限なし
- 並べ替えは上下ボタン（DnD は導入しない）
- 編集ダイアログから名称変更可能

## 変更内容

### DB

- `db/schema.hcl` に `saved_views` テーブル追加
  - `id` / `user_id` (FK users CASCADE) / `name` / `query jsonb` / `position` / `created_at` / `updated_at`
  - 一意制約: `(user_id, name)` ／ index: `(user_id, position)`
- `packages/server/src/__tests__/__fixtures__/pgTestHelper.ts` のスキーマ＆ `resetTestData` に `saved_views` を追加

### 共有型

- `packages/shared/src/types/savedView.ts` 新規（`SavedView`/`SavedViewQuery`/`CreateSavedViewInput`/`UpdateSavedViewInput`）
- `packages/shared/src/index.ts` に export 追加

### サーバ

- `packages/server/src/services/savedViewService.ts` 新規（CRUD ＋ reorder）
- `packages/server/src/routes/savedViews.ts` 新規
  - `GET /api/saved-views` / `POST /api/saved-views`
  - `PUT /api/saved-views/:id` / `DELETE /api/saved-views/:id`
  - `PUT /api/saved-views/order`（並べ替え）
  - `query` フィールドの zod バリデーション（不明キーは `.strict()` で拒否）
- `packages/server/src/app.ts` にルーター登録

### クライアント

- `packages/client/src/api/client.ts` に `api.savedViews.*` を追加
- `packages/client/src/components/Chat/SearchFilterPanel.tsx`
  - 「現在の条件を保存」ボタン＋名前入力ダイアログを追加（フィルタ条件が 1 つ以上のときのみ有効）
  - `onSaveView({ name, filters })` コールバックを props に追加
- `packages/client/src/components/Channel/SavedViewSection.tsx` 新規
  - 一覧表示／クリックで `onSelectView(query)`／編集ダイアログ／削除／上下並べ替え
- `packages/client/src/components/Channel/ChannelList.tsx`
  - `getOrCreateSavedViewsPromise` で `use()` パターンの安定化（カテゴリ・チャンネルと同じ方式）
  - 「お気に入り」「カテゴリ」と並ぶ位置に `SavedViewSection` を差し込み
  - `onSelectSavedView?: (query) => void` props 追加
- `packages/client/src/pages/ChatPage.tsx`
  - `ChannelList.onSelectSavedView` → 検索モード起動＋ `SearchFilters` 復元
  - `SearchFilterPanel.onSaveView` → `api.savedViews.create` ＋ Snackbar 通知

## 影響範囲

- 既存ファイル（変更）
  - `db/schema.hcl` ／ `packages/shared/src/index.ts` ／ `packages/server/src/app.ts`
  - `packages/server/src/__tests__/__fixtures__/pgTestHelper.ts`
  - `packages/client/src/api/client.ts` ／ `packages/client/src/components/Channel/ChannelList.tsx`
  - `packages/client/src/components/Chat/SearchFilterPanel.tsx` ／ `packages/client/src/pages/ChatPage.tsx`
- 既存テスト（修正）
  - `packages/client/src/__tests__/ChannelList.test.tsx`
    Phase 1 で先行追加されていた「`useNavigate` で `/search` 遷移」前提のテストを、実装方針（親コンポーネント側で `SearchFilters` を復元する設計）に合わせて `onSelectSavedView` コールバック検証に書き換え
  - `packages/client/src/__tests__/PinChannel.test.tsx`
    `api.savedViews` 未モックで `ChannelList` 描画時に落ちていたため、空配列を返すモックを追加
  - `packages/client/src/__tests__/SearchFilterPanel.test.tsx`
    「保存ボタン無効状態」テストで `onSaveView` 未指定だとボタン自体が描画されない仕様のため、モック関数を渡す形に修正

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（vitest 1040 件 / 72 ファイル）
- [x] バックエンドユニットテストがすべてパスする（jest 1065 件 / 52 ファイル、うち saved-view 36 件）
- [x] ビルドが正常に完了すること（`npm run build` で shared/server/client すべて成功）

### 追加された保存ビュー関連テスト

- server: `saved-view.test.ts` 36 件（service ユニット 19 + HTTP 統合 17）
- client: `SavedViewSection.test.tsx` 13 件（一覧／クリック／編集／削除／並べ替え）
- client: `SearchFilterPanel.test.tsx` の保存ビュー関連 5 件（保存ボタン enable/disable・ダイアログ・確定・キャンセル）
- client: `ChannelList.test.tsx` の保存ビュー関連 2 件（描画・`onSelectSavedView` 呼び出し）

## 関連Issue

Fixes #150

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（今回は不要）