### PR TITLE
fix: 誤って main に流入した node_modules symlink を削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/node_modules/
+**/node_modules
 dist/
 *.tsbuildinfo
 *.db

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/shoma/Code/claude-code-test/node_modules

--- a/packages/client/node_modules
+++ b/packages/client/node_modules
@@ -1,1 +1,0 @@
-/Users/shoma/Code/claude-code-test/packages/client/node_modules


### PR DESCRIPTION
## 概要

PR #171 (#149 ゲスト閲覧リンク) のマージで、worker のセットアップ用 symlink が誤って main に流入していた問題を修正。

## 変更内容

- ルート直下の `node_modules` symlink を削除（`git rm`）
- `packages/client/node_modules` symlink を削除
- `.gitignore` の `**/node_modules/` を `**/node_modules` に変更
  - 末尾スラッシュ付きはディレクトリのみマッチするため、symlink ファイルが追跡対象になっていた
  - 末尾スラッシュを外すことでディレクトリ・symlink の両方を ignore できる

## 影響範囲

- マージ前の main は `node_modules` が自己参照 symlink になっており、本来の node_modules ディレクトリが上書きされていた
- マージ後、各開発環境で `npm install` を再実行して node_modules を再構築する必要がある
- worker（worktree）側のセットアップで使う symlink は引き続き作成可能だが、`.gitignore` で除外されるため commit には乗らない

## 動作確認・テスト結果
- [x] `git status` でクリーン
- [x] symlink 削除済み（`git ls-files | grep node_modules` で何も出ないこと）
- [x] `.gitignore` 更新済み
- [ ] マージ後、ローカルで `npm install` → ビルド・テスト確認

## 関連Issue
Fixes -

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント更新は不要（小規模な hotfix）

## 補足: 再発防止

`parallel-feature-dev` スキルで worker に渡しているセットアップ手順:

```sh
[ ! -e node_modules ] && ln -s /Users/shoma/Code/claude-code-test/node_modules ./node_modules
[ ! -e packages/client/node_modules ] && ln -s /Users/shoma/Code/claude-code-test/packages/client/node_modules ./packages/client/node_modules
```

worktree でこの symlink が作成されると `**/node_modules/`（末尾スラッシュ付き）では除外されないため git に追跡されてしまう。本 PR で `.gitignore` を修正することで再発を防ぐ。