### PR TITLE
test: レート制限 (rateLimitService) の TODO テスト 11 件を実装

### DIFF
--- a/packages/server/src/__tests__/unit/rateLimitService.test.ts
+++ b/packages/server/src/__tests__/unit/rateLimitService.test.ts
@@ -7,58 +7,120 @@
  *   - 時刻制御は jest.useFakeTimers() で行う
  */
 
+import { rateLimitService, getRateLimitConfig } from '../../services/rateLimitService';
+
 describe('RateLimitService', () => {
+  beforeEach(() => {
+    rateLimitService.reset();
+    // テスト時は RATE_LIMIT_* 環境変数が未設定のため、設定値は 10 件 / 10 秒
+    jest.useFakeTimers({ now: new Date('2026-01-01T00:00:00Z').getTime() });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   describe('check / increment', () => {
     it('ウィンドウ内の件数が上限以下のときは許可される', () => {
-      // TODO
+      for (let i = 0; i < 9; i++) {
+        expect(rateLimitService.check(1, 'message').allowed).toBe(true);
+      }
     });
 
     it('ウィンドウ内の件数が上限ちょうどのときは拒否される', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        expect(rateLimitService.check(1, 'message').allowed).toBe(true);
+      }
+      expect(rateLimitService.check(1, 'message').allowed).toBe(false);
     });
 
     it('上限超過後に retryAfterSec が正の整数で返される', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      const r = rateLimitService.check(1, 'message');
+      expect(r.allowed).toBe(false);
+      if (!r.allowed) {
+        expect(Number.isInteger(r.retryAfterSec)).toBe(true);
+        expect(r.retryAfterSec).toBeGreaterThan(0);
+      }
     });
   });
 
   describe('sliding window の挙動', () => {
     it('ウィンドウ開始より前のタイムスタンプはカウントから除外される', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      // ウィンドウ秒（10 秒）を超えて経過 → 過去のタイムスタンプは除外される
+      jest.advanceTimersByTime(11_000);
+      expect(rateLimitService.check(1, 'message').allowed).toBe(true);
     });
 
     it('ウィンドウ境界ちょうどのタイムスタンプは除外される（境界値）', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      expect(rateLimitService.check(1, 'message').allowed).toBe(false);
+      // ちょうど windowMs（10000ms）経過 → 実装は now - ts < windowMs のため等値は除外
+      jest.advanceTimersByTime(10_000);
+      expect(rateLimitService.check(1, 'message').allowed).toBe(true);
     });
 
     it('時間が経過してウィンドウが抜けたカウントはリセットされ再び送信できる', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      expect(rateLimitService.check(1, 'message').allowed).toBe(false);
+      jest.advanceTimersByTime(11_000);
+      for (let i = 0; i < 10; i++) {
+        expect(rateLimitService.check(1, 'message').allowed).toBe(true);
+      }
     });
   });
 
   describe('ユーザー独立性', () => {
     it('別ユーザーは独立してカウントされる（ユーザーAが上限に達してもユーザーBは送信できる）', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      expect(rateLimitService.check(1, 'message').allowed).toBe(false);
+      expect(rateLimitService.check(2, 'message').allowed).toBe(true);
     });
 
     it('同一ユーザーでもアクション種別（message / dm）が異なれば独立してカウントされる', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      expect(rateLimitService.check(1, 'message').allowed).toBe(false);
+      expect(rateLimitService.check(1, 'dm').allowed).toBe(true);
     });
   });
 
   describe('環境変数による設定', () => {
     it('RATE_LIMIT_MESSAGES_PER_WINDOW が未設定のときデフォルト値 10 が使われる', () => {
-      // TODO
+      expect(process.env.RATE_LIMIT_MESSAGES_PER_WINDOW).toBeUndefined();
+      const cfg = getRateLimitConfig();
+      expect(cfg.messagesPerWindow).toBe(10);
+      expect(cfg.limit).toBe(10);
     });
 
     it('RATE_LIMIT_WINDOW_SECONDS が未設定のときデフォルト値 10 が使われる', () => {
-      // TODO
+      expect(process.env.RATE_LIMIT_WINDOW_SECONDS).toBeUndefined();
+      const cfg = getRateLimitConfig();
+      expect(cfg.windowSeconds).toBe(10);
+      expect(cfg.windowSec).toBe(10);
     });
   });
 
   describe('reset', () => {
     it('reset を呼ぶとユーザーのカウントが初期化される', () => {
-      // TODO
+      for (let i = 0; i < 10; i++) {
+        rateLimitService.check(1, 'message');
+      }
+      expect(rateLimitService.check(1, 'message').allowed).toBe(false);
+      rateLimitService.reset();
+      expect(rateLimitService.check(1, 'message').allowed).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## 概要
`#153` でマージされたレート制限機能（`packages/server/src/services/rateLimitService.ts`）に対し、TDD ステップ1（テスト項目作成）で止まっていた `// TODO` 状態のテスト 11 件を実装した。

## 変更内容
`packages/server/src/__tests__/unit/rateLimitService.test.ts` の TODO 11 件を実装。
- check / increment（3件）: 上限以下で許可・上限ちょうどで拒否・retryAfterSec が正の整数
- sliding window の挙動（3件）: ウィンドウ外除外・境界値（`now - ts === windowMs` は除外）・ウィンドウ抜け後の再送信
- ユーザー独立性（2件）: 別ユーザー間・同一ユーザーの異 action 間の独立性
- 環境変数による設定（2件）: `RATE_LIMIT_*` 未設定時のデフォルト値 10
- reset（1件）: カウント初期化

時刻制御は `jest.useFakeTimers({ now: ... })` + `jest.advanceTimersByTime()` を使用し、DB 不使用の純粋なインメモリロジックとして検証。

## 影響範囲
- `packages/server/src/__tests__/unit/rateLimitService.test.ts`（テストファイルのみ）
- 既存実装・他テストへの影響なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1287 tests）
- [x] バックエンドユニットテストがすべてパスする（1361 tests）
- [x] ビルドが正常に完了すること
- [x] (手動確認の場合) 確認した手順やスクリーンショット → 該当なし（テスト追加のみ）

## 関連Issue
Fixes #175

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）