### PR TITLE
test: タグ機能の TODO テスト 73 件を実装 + useTagSuggestions リファクタ

### DIFF
--- a/packages/client/src/components/Chat/TagInput.tsx
+++ b/packages/client/src/components/Chat/TagInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, KeyboardEvent } from 'react';
+import { useState, useRef, useEffect, KeyboardEvent, Suspense } from 'react';
 import { Box, Chip, TextField, Paper, List, ListItemButton, ListItemText } from '@mui/material';
 import { useTagSuggestions } from '../../hooks/useTagSuggestions';
 import { normalizeTagName } from './tagUtils';
@@ -14,12 +14,22 @@ interface Props {
  * - Enter / カンマで確定
  * - 入力欄が空の状態で Backspace を押すと最後尾のタグを削除
  * - 候補リストから選択でも確定
+ * - 候補取得は use() + Suspense（CLAUDE.md ルール準拠）
  */
+const SUGGESTION_DEBOUNCE_MS = 200;
+
 export default function TagInput({ value, onChange, placeholder = 'タグを追加...' }: Props) {
   const [input, setInput] = useState('');
+  // 候補取得用のデバウンスされた入力値。Suspense 境界内では useState 初期値が
+  // suspend → remount で再評価されるため、debounce は境界の外側（ここ）で行う。
+  const [debouncedInput, setDebouncedInput] = useState('');
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const suggestions = useTagSuggestions(input);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedInput(input), SUGGESTION_DEBOUNCE_MS);
+    return () => clearTimeout(t);
+  }, [input]);
 
   function confirm(raw: string) {
     const name = normalizeTagName(raw);
@@ -43,13 +53,12 @@ export default function TagInput({ value, onChange, placeholder = 'タグを追�
   }
 
   function handleInputChange(v: string) {
-    // カンマ入力は即確定
     if (v.endsWith(',')) {
       confirm(v.slice(0, -1));
       return;
     }
     setInput(v);
-    setOpen(v.length > 0 && suggestions.length > 0);
+    setOpen(v.length > 0);
   }
 
   return (
@@ -82,7 +91,7 @@ export default function TagInput({ value, onChange, placeholder = 'タグを追�
           value={input}
           onChange={(e) => handleInputChange(e.target.value)}
           onKeyDown={handleKeyDown}
-          onFocus={() => setOpen(input.length > 0 && suggestions.length > 0)}
+          onFocus={() => setOpen(input.length > 0)}
           onBlur={() => setTimeout(() => setOpen(false), 150)}
           placeholder={value.length === 0 ? placeholder : ''}
           variant="standard"
@@ -92,34 +101,48 @@ export default function TagInput({ value, onChange, placeholder = 'タグを追�
         />
       </Box>
 
-      {open && suggestions.length > 0 && (
-        <Paper
-          elevation={3}
-          sx={{
-            position: 'absolute',
-            top: '100%',
-            left: 0,
-            right: 0,
-            zIndex: 10,
-            maxHeight: 200,
-            overflow: 'auto',
-          }}
-        >
-          <List dense disablePadding>
-            {suggestions.map((s) => (
-              <ListItemButton
-                key={s.name}
-                onMouseDown={(e) => {
-                  e.preventDefault(); // blur を防ぐ
-                  confirm(s.name);
-                }}
-              >
-                <ListItemText primary={`#${s.name}`} secondary={`${s.useCount} 件`} />
-              </ListItemButton>
-            ))}
-          </List>
-        </Paper>
+      {open && (
+        <Suspense fallback={null}>
+          <SuggestionPanel input={debouncedInput} onSelect={confirm} />
+        </Suspense>
       )}
     </Box>
+  );
+}
+
+/**
+ * 候補リスト本体（Suspense 境界の内側）。
+ * 候補が空のときは何も描画しない。
+ */
+function SuggestionPanel({ input, onSelect }: { input: string; onSelect: (name: string) => void }) {
+  const suggestions = useTagSuggestions(input);
+  if (suggestions.length === 0) return null;
+  return (
+    <Paper
+      elevation={3}
+      sx={{
+        position: 'absolute',
+        top: '100%',
+        left: 0,
+        right: 0,
+        zIndex: 10,
+        maxHeight: 200,
+        overflow: 'auto',
+      }}
+    >
+      <List dense disablePadding>
+        {suggestions.map((s) => (
+          <ListItemButton
+            key={s.name}
+            onMouseDown={(e) => {
+              e.preventDefault(); // blur を防ぐ
+              onSelect(s.name);
+            }}
+          >
+            <ListItemText primary={`#${s.name}`} secondary={`${s.useCount} 件`} />
+          </ListItemButton>
+        ))}
+      </List>
+    </Paper>
   );
 }

--- a/packages/client/src/components/Chat/__tests__/TagChip.test.tsx
+++ b/packages/client/src/components/Chat/__tests__/TagChip.test.tsx
@@ -5,28 +5,54 @@
  *   - スタイリングや細かい aria 属性は対象外（画面で確認可能な範囲）。
  */
 
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { Tag } from '@chat-app/shared';
+import TagChip from '../TagChip';
+
+const sample: Tag = {
+  id: 1,
+  name: 'bug',
+  useCount: 3,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
 describe('TagChip', () => {
   describe('表示', () => {
     it('渡された tag.name が "#" プレフィックス付きで表示される', () => {
-      // TODO
+      render(<TagChip tag={sample} />);
+      expect(screen.getByText('#bug')).toBeInTheDocument();
     });
 
     it('readOnly=true のとき削除ボタン (×) が表示されない', () => {
-      // TODO
+      const onDelete = vi.fn();
+      render(<TagChip tag={sample} readOnly onDelete={onDelete} />);
+      // MUI Chip の削除アイコンは onDelete が渡らないと描画されない
+      expect(screen.queryByTestId('CancelIcon')).toBeNull();
     });
 
     it('readOnly=false のとき削除ボタン (×) が表示される', () => {
-      // TODO
+      const onDelete = vi.fn();
+      render(<TagChip tag={sample} readOnly={false} onDelete={onDelete} />);
+      expect(screen.getByTestId('CancelIcon')).toBeInTheDocument();
     });
   });
 
   describe('クリック動作', () => {
     it('チップ本体をクリックすると onClick が tag.name を引数に呼ばれる', () => {
-      // TODO
+      const onClick = vi.fn();
+      render(<TagChip tag={sample} onClick={onClick} />);
+      fireEvent.click(screen.getByText('#bug'));
+      expect(onClick).toHaveBeenCalledWith('bug');
     });
 
     it('削除ボタンをクリックすると onDelete が tag.id を引数に呼ばれ、onClick は呼ばれない (stopPropagation)', () => {
-      // TODO
+      const onClick = vi.fn();
+      const onDelete = vi.fn();
+      render(<TagChip tag={sample} onClick={onClick} readOnly={false} onDelete={onDelete} />);
+      fireEvent.click(screen.getByTestId('CancelIcon'));
+      expect(onDelete).toHaveBeenCalledWith(1);
+      expect(onClick).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/client/src/components/Chat/__tests__/TagInput.test.tsx
+++ b/packages/client/src/components/Chat/__tests__/TagInput.test.tsx
@@ -6,64 +6,169 @@
  *     キーボードからしか確認できないインタラクションをカバーする。
  */
 
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { TagSuggestion } from '@chat-app/shared';
+import TagInput from '../TagInput';
+
+let mockSuggestions: TagSuggestion[] = [];
+vi.mock('../../../hooks/useTagSuggestions', () => ({
+  useTagSuggestions: () => mockSuggestions,
+}));
+
+beforeEach(() => {
+  mockSuggestions = [];
+});
+
 describe('TagInput', () => {
-  describe('候補表示 (Autocomplete)', () => {
+  describe('候補表示', () => {
     it('入力中の文字列を prefix として候補リストに表示する', () => {
-      // TODO
+      mockSuggestions = [
+        { id: 1, name: 'apple', useCount: 5 },
+        { id: 2, name: 'apricot', useCount: 3 },
+      ];
+      render(<TagInput value={[]} onChange={vi.fn()} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'ap' } });
+      expect(screen.getByText('#apple')).toBeInTheDocument();
+      expect(screen.getByText('#apricot')).toBeInTheDocument();
     });
 
     it('useTagSuggestions が返す候補は use_count 順に並んでいる前提で、その順番のまま表示される', () => {
-      // TODO
+      mockSuggestions = [
+        { id: 1, name: 'high', useCount: 10 },
+        { id: 2, name: 'mid', useCount: 5 },
+        { id: 3, name: 'low', useCount: 1 },
+      ];
+      render(<TagInput value={[]} onChange={vi.fn()} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'x' } });
+      const items = screen.getAllByRole('button').map((el) => el.textContent ?? '');
+      // ListItemButton は role=button。先頭は #high, 次が #mid, 最後が #low
+      const labels = items.filter((t) => t.startsWith('#'));
+      expect(labels.findIndex((l) => l.includes('high'))).toBeLessThan(
+        labels.findIndex((l) => l.includes('mid')),
+      );
+      expect(labels.findIndex((l) => l.includes('mid'))).toBeLessThan(
+        labels.findIndex((l) => l.includes('low')),
+      );
     });
 
-    it('入力が空のときも use_count 上位の候補を表示する', () => {
-      // TODO
+    // 仕様の精緻化（#177）：
+    // 旧テスト名「入力が空のときも use_count 上位の候補を表示する」は実装と乖離しており、
+    // TagInput は入力文字数 > 0 のときのみ候補リストを開く実装になっているため、
+    // 「入力が空のときは候補リストが表示されない」に更新する。
+    it('入力が空のときは候補リストが表示されない', () => {
+      mockSuggestions = [{ id: 1, name: 'apple', useCount: 5 }];
+      render(<TagInput value={[]} onChange={vi.fn()} />);
+      // 何も入力していない状態では候補は描画されない
+      expect(screen.queryByText('#apple')).toBeNull();
     });
   });
 
   describe('タグ確定操作', () => {
     it('Enter キーで現在の入力値を新規タグとして確定し onChange に追加後の配列が渡る', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={[]} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'newtag' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(['newtag']);
     });
 
-    it('候補を矢印キーで選択し Enter を押すと候補のタグ名で確定される', () => {
-      // TODO
+    // 仕様の精緻化（#177）：
+    // 旧テスト名「候補を矢印キーで選択し Enter を押すと候補のタグ名で確定される」は
+    // 実装に矢印キー選択が無いため、現実装のマウス操作に合わせて
+    // 「候補をクリックすると候補のタグ名で確定される」に更新する。
+    it('候補をクリックすると候補のタグ名で確定される', () => {
+      const onChange = vi.fn();
+      mockSuggestions = [{ id: 1, name: 'apple', useCount: 5 }];
+      render(<TagInput value={[]} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'ap' } });
+      // 候補は onMouseDown で確定する実装
+      fireEvent.mouseDown(screen.getByText('#apple'));
+      expect(onChange).toHaveBeenCalledWith(['apple']);
     });
 
     it('カンマ "," 入力でも確定される', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={[]} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      // 末尾にカンマを含む入力で即確定
+      fireEvent.change(input, { target: { value: 'newtag,' } });
+      expect(onChange).toHaveBeenCalledWith(['newtag']);
     });
 
     it('既に追加済みのタグ名を再入力しても重複追加されない', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={['apple']} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'apple' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('空文字または空白のみの入力では確定されない', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={[]} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      // 空文字
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).not.toHaveBeenCalled();
+      // 空白のみ
+      fireEvent.change(input, { target: { value: '   ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).not.toHaveBeenCalled();
     });
   });
 
   describe('タグ削除操作', () => {
     it('入力欄が空の状態で Backspace を押すと最後尾のタグが削除される', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={['a', 'b', 'c']} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.keyDown(input, { key: 'Backspace' });
+      expect(onChange).toHaveBeenCalledWith(['a', 'b']);
     });
 
     it('入力欄に文字がある状態で Backspace を押してもタグは削除されない (通常の文字削除)', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={['a', 'b']} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'x' } });
+      onChange.mockClear();
+      fireEvent.keyDown(input, { key: 'Backspace' });
+      expect(onChange).not.toHaveBeenCalled();
     });
 
     it('チップの × ボタン経由でも削除できる', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={['apple', 'banana']} onChange={onChange} />);
+      // 'apple' チップの削除アイコンをクリック
+      const cancelIcons = screen.getAllByTestId('CancelIcon');
+      fireEvent.click(cancelIcons[0]);
+      expect(onChange).toHaveBeenCalledWith(['banana']);
     });
   });
 
   describe('正規化との整合', () => {
     it('"Bug" を入力して確定すると、表示上は小文字 "bug" として正規化される', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={[]} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: 'Bug' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(['bug']);
     });
 
     it('前後空白付きで入力しても trim されてから追加される', () => {
-      // TODO
+      const onChange = vi.fn();
+      render(<TagInput value={[]} onChange={onChange} />);
+      const input = screen.getByTestId('tag-input');
+      fireEvent.change(input, { target: { value: '  bug  ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onChange).toHaveBeenCalledWith(['bug']);
     });
   });
 });

--- a/packages/client/src/hooks/__tests__/useTagSuggestions.test.ts
+++ b/packages/client/src/hooks/__tests__/useTagSuggestions.test.ts
@@ -1,38 +1,105 @@
 /**
  * テスト対象: hooks/useTagSuggestions.ts (タグ候補取得フック)
  * 戦略:
- *   - api.tags.suggestions をモックし、prefix 変更時の再フェッチ・デバウンス・キャッシュ挙動を検証する。
- *   - React 19 の use() + Suspense 構成を想定するため、render は Suspense でラップする。
+ *   - api.tags.suggestions をモックし、prefix 変更時の再フェッチ・キャッシュ・
+ *     エラーフォールバック挙動を検証する。
+ *   - React 19 の use() + Suspense 構成のため、Probe を <Suspense> でラップする。
+ *   - Suspense サスペンド解消は waitFor では不十分（react19-troubleshooting 参照）。
+ *     render 自体を act(async) でラップしてサスペンド解消まで進める。
+ *
+ * NOTE: 入力デバウンスは TagInput 側の責務（Suspense 境界の外側）に分離した
+ *       ため、本フックではテスト対象外（#177）。
  */
+
+import React, { Suspense } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import type { TagSuggestion } from '@chat-app/shared';
+import { useTagSuggestions, _resetSuggestionsCacheForTest } from '../useTagSuggestions';
+
+const suggestionsMock = vi.fn();
+vi.mock('../../api/client', () => ({
+  api: {
+    tags: {
+      suggestions: (prefix: string, limit: number) => suggestionsMock(prefix, limit),
+    },
+  },
+}));
+
+function Probe({ prefix, limit }: { prefix: string; limit?: number }) {
+  const data = useTagSuggestions(prefix, limit);
+  return React.createElement('div', { 'data-testid': 'probe' }, JSON.stringify(data));
+}
+
+function Wrap({ prefix, limit }: { prefix: string; limit?: number }) {
+  return React.createElement(
+    Suspense,
+    { fallback: React.createElement('div', { 'data-testid': 'loading' }, 'loading') },
+    React.createElement(Probe, { prefix, limit }),
+  );
+}
+
+async function renderWithSuspense(ui: React.ReactElement) {
+  let result!: ReturnType<typeof render>;
+  await act(async () => {
+    result = render(ui);
+  });
+  return result;
+}
+
+beforeEach(() => {
+  suggestionsMock.mockReset();
+  _resetSuggestionsCacheForTest();
+});
 
 describe('useTagSuggestions', () => {
   describe('初期取得', () => {
-    it('マウント時に prefix なしで api.tags.suggestions が呼ばれる', () => {
-      // TODO
+    it('マウント時に prefix なしで api.tags.suggestions が呼ばれる', async () => {
+      suggestionsMock.mockResolvedValue({ suggestions: [] });
+      await renderWithSuspense(React.createElement(Wrap, { prefix: '' }));
+      expect(suggestionsMock).toHaveBeenCalledWith('', 10);
     });
 
-    it('取得した候補配列が data として返る', () => {
-      // TODO
+    it('取得した候補配列が data として返る', async () => {
+      const data: TagSuggestion[] = [{ id: 1, name: 'apple', useCount: 1 }];
+      suggestionsMock.mockResolvedValue({ suggestions: data });
+      await renderWithSuspense(React.createElement(Wrap, { prefix: 'data-key' }));
+      expect(screen.getByTestId('probe').textContent).toBe(JSON.stringify(data));
     });
   });
 
   describe('prefix の変更', () => {
-    it('prefix を変更すると新しい prefix で再フェッチされる', () => {
-      // TODO
+    it('prefix を変更すると新しい prefix で再フェッチされる', async () => {
+      suggestionsMock.mockResolvedValue({ suggestions: [] });
+      const { rerender } = await renderWithSuspense(React.createElement(Wrap, { prefix: '' }));
+      expect(suggestionsMock).toHaveBeenCalledWith('', 10);
+
+      await act(async () => {
+        rerender(React.createElement(Wrap, { prefix: 'ap' }));
+      });
+      expect(suggestionsMock).toHaveBeenCalledWith('ap', 10);
     });
 
-    it('短時間に連続で prefix が変わってもデバウンスにより最後の値だけリクエストされる', () => {
-      // TODO
-    });
+    it('同じ prefix への再要求はキャッシュから返り API は呼ばれない', async () => {
+      const data: TagSuggestion[] = [{ id: 1, name: 'cached', useCount: 7 }];
+      suggestionsMock.mockResolvedValue({ suggestions: data });
+      const { unmount } = await renderWithSuspense(React.createElement(Wrap, { prefix: 'k' }));
+      expect(screen.getByTestId('probe').textContent).toBe(JSON.stringify(data));
+      const callsBefore = suggestionsMock.mock.calls.length;
+      unmount();
 
-    it('同じ prefix への再要求はキャッシュから返り API は呼ばれない', () => {
-      // TODO
+      // 同じ prefix で再マウント → 内部 promiseCache からヒット
+      await renderWithSuspense(React.createElement(Wrap, { prefix: 'k' }));
+      expect(screen.getByTestId('probe').textContent).toBe(JSON.stringify(data));
+      expect(suggestionsMock.mock.calls.length).toBe(callsBefore);
     });
   });
 
   describe('エラー処理', () => {
-    it('API がエラーを投げた場合、空配列にフォールバックして UI を壊さない', () => {
-      // TODO
+    it('API がエラーを投げた場合、空配列にフォールバックして UI を壊さない', async () => {
+      suggestionsMock.mockRejectedValue(new Error('network error'));
+      await renderWithSuspense(React.createElement(Wrap, { prefix: 'errkey' }));
+      expect(screen.getByTestId('probe').textContent).toBe('[]');
     });
   });
 });

--- a/packages/client/src/hooks/useTagSuggestions.ts
+++ b/packages/client/src/hooks/useTagSuggestions.ts
@@ -1,41 +1,42 @@
-import { useState, useEffect, useRef } from 'react';
+import { use, useMemo } from 'react';
 import type { TagSuggestion } from '@chat-app/shared';
 import { api } from '../api/client';
 
-const DEBOUNCE_MS = 200;
+// prefix:limit → Promise のキャッシュ。
+// 同一キーは同じ Promise を返し、レンダリングごとに Promise を再生成しない
+// （CLAUDE.md「Promise は useState または useMemo で安定化」準拠）。
+const promiseCache = new Map<string, Promise<TagSuggestion[]>>();
+
+function getSuggestionsPromise(prefix: string, limit: number): Promise<TagSuggestion[]> {
+  const key = `${prefix}:${limit}`;
+  let p = promiseCache.get(key);
+  if (!p) {
+    p = api.tags
+      .suggestions(prefix, limit)
+      .then((r) => r.suggestions)
+      .catch(() => [] as TagSuggestion[]);
+    promiseCache.set(key, p);
+  }
+  return p;
+}
 
 /**
- * タグ候補を取得するフック。
- * - prefix の変更をデバウンスして API を呼び出す
- * - 同一 prefix は内部キャッシュから返す（API 二重呼び出しを防ぐ）
+ * タグ候補を取得するフック（React 19 use() + Suspense）。
+ * 呼び出し側コンポーネントは <Suspense> でラップする必要がある。
+ *
+ * - 同一 prefix:limit は内部 promiseCache から返す（API 二重呼び出しを防ぐ）
  * - API エラー時は空配列にフォールバック
+ *
+ * NOTE: 入力デバウンスは呼び出し側で行う。Suspense 内で useState を持つと
+ * suspend → unmount → remount で初期値が再評価されるため、フック内での
+ * 自前デバウンスは機能しない（#177）。
  */
 export function useTagSuggestions(prefix: string, limit = 10): TagSuggestion[] {
-  const [suggestions, setSuggestions] = useState<TagSuggestion[]>([]);
-  // prefix → 結果のシンプルなキャッシュ
-  const cache = useRef<Map<string, TagSuggestion[]>>(new Map());
+  const promise = useMemo(() => getSuggestionsPromise(prefix, limit), [prefix, limit]);
+  return use(promise);
+}
 
-  useEffect(() => {
-    const key = `${prefix}:${limit}`;
-    if (cache.current.has(key)) {
-      setSuggestions(cache.current.get(key)!);
-      return;
-    }
-
-    const timer = setTimeout(() => {
-      api.tags
-        .suggestions(prefix, limit)
-        .then(({ suggestions: s }) => {
-          cache.current.set(key, s);
-          setSuggestions(s);
-        })
-        .catch(() => {
-          setSuggestions([]);
-        });
-    }, DEBOUNCE_MS);
-
-    return () => clearTimeout(timer);
-  }, [prefix, limit]);
-
-  return suggestions;
+/** テスト用: 内部 promise キャッシュを初期化する */
+export function _resetSuggestionsCacheForTest(): void {
+  promiseCache.clear();
 }

--- a/packages/server/src/__tests__/tag.test.ts
+++ b/packages/server/src/__tests__/tag.test.ts
@@ -4,172 +4,442 @@
  *   - pg-mem のインメモリ PostgreSQL 互換 DB を使いサービス層を直接テストする。
  *   - tags / message_tags / channel_tags の整合性とユースケース全体を検証する。
  *   - HTTP レイヤーは別途 routes 経由のテストを設けず、サービス層で十分カバーできるよう設計する。
- *   - 外部キー制約を満たすため beforeAll でユーザー・チャンネル・メッセージを挿入する。
+ *   - 外部キー制約を満たすため beforeEach でユーザー・チャンネル・メッセージを挿入する。
+ *   - getForMessages の N+1 検証のため、testDb.query を spy 化してサービスから観測する。
  */
+
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
+
+const baseDb = createTestDatabase();
+const querySpy = jest.fn(baseDb.query);
+const testDb = {
+  ...baseDb,
+  query: ((text: string, params?: unknown[]) => querySpy(text, params)) as typeof baseDb.query,
+};
+
+jest.mock('../db/database', () => testDb);
+
+import {
+  findOrCreate,
+  attachToMessage,
+  detachFromMessage,
+  attachToChannel,
+  detachFromChannel,
+  listSuggestions,
+  getForMessages,
+} from '../services/tagService';
+
+let userMember: number;
+let userOther: number;
+let publicChannelId: number;
+let privateChannelId: number;
+let publicMessageId: number;
+let privateMessageId: number;
+
+async function resetDb() {
+  await testDb.execute('DELETE FROM message_tags', []);
+  await testDb.execute('DELETE FROM channel_tags', []);
+  await testDb.execute('DELETE FROM tags', []);
+  await testDb.execute('DELETE FROM messages', []);
+  await testDb.execute('DELETE FROM channel_members', []);
+  await testDb.execute('DELETE FROM channels', []);
+  await testDb.execute('DELETE FROM users', []);
+}
+
+async function setupBaseData() {
+  const u1 = await testDb.queryOne<{ id: number }>(
+    "INSERT INTO users (username, email, password_hash) VALUES ('member', 'm@x.com', 'hash') RETURNING id",
+    [],
+  );
+  const u2 = await testDb.queryOne<{ id: number }>(
+    "INSERT INTO users (username, email, password_hash) VALUES ('other', 'o@x.com', 'hash') RETURNING id",
+    [],
+  );
+  userMember = u1!.id;
+  userOther = u2!.id;
+
+  const cPub = await testDb.queryOne<{ id: number }>(
+    "INSERT INTO channels (name, created_by, is_private) VALUES ('public', $1, false) RETURNING id",
+    [userMember],
+  );
+  const cPriv = await testDb.queryOne<{ id: number }>(
+    "INSERT INTO channels (name, created_by, is_private) VALUES ('private', $1, true) RETURNING id",
+    [userMember],
+  );
+  publicChannelId = cPub!.id;
+  privateChannelId = cPriv!.id;
+
+  // private のメンバーは userMember のみ
+  await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+    privateChannelId,
+    userMember,
+  ]);
+
+  const m1 = await testDb.queryOne<{ id: number }>(
+    "INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, 'pub') RETURNING id",
+    [publicChannelId, userMember],
+  );
+  const m2 = await testDb.queryOne<{ id: number }>(
+    "INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, 'priv') RETURNING id",
+    [privateChannelId, userMember],
+  );
+  publicMessageId = m1!.id;
+  privateMessageId = m2!.id;
+}
+
+beforeEach(async () => {
+  await resetDb();
+  await setupBaseData();
+  querySpy.mockClear();
+});
 
 describe('タグ機能', () => {
   describe('タグの作成・取得 (findOrCreate)', () => {
-    it('新規タグ名を渡すと新しいタグレコードが INSERT され ID が返る', () => {
-      // TODO
+    it('新規タグ名を渡すと新しいタグレコードが INSERT され ID が返る', async () => {
+      const tag = await findOrCreate('newtag', userMember);
+      expect(tag.id).toBeGreaterThan(0);
+      expect(tag.name).toBe('newtag');
+      const rows = await testDb.query("SELECT id FROM tags WHERE name = 'newtag'", []);
+      expect(rows.length).toBe(1);
     });
 
-    it('既存タグと同じ名前を渡すと新規 INSERT されず既存 ID が返る', () => {
-      // TODO
+    it('既存タグと同じ名前を渡すと新規 INSERT されず既存 ID が返る', async () => {
+      const a = await findOrCreate('foo', userMember);
+      const b = await findOrCreate('foo', userMember);
+      expect(b.id).toBe(a.id);
+      const rows = await testDb.query("SELECT id FROM tags WHERE name = 'foo'", []);
+      expect(rows.length).toBe(1);
     });
 
-    it('タグ名の前後空白は除去されて保存される', () => {
-      // TODO
+    it('タグ名は小文字に正規化されて保存される (例: "Bug" → "bug")', async () => {
+      const t = await findOrCreate('Bug', userMember);
+      expect(t.name).toBe('bug');
     });
 
-    it('タグ名は小文字に正規化されて保存される (例: "Bug" → "bug")', () => {
-      // TODO
+    it('大文字小文字違いの同名タグは同一タグとして扱われる ("BUG" と "bug" は同じ ID)', async () => {
+      const a = await findOrCreate('BUG', userMember);
+      const b = await findOrCreate('bug', userMember);
+      expect(b.id).toBe(a.id);
     });
 
-    it('大文字小文字違いの同名タグは同一タグとして扱われる ("BUG" と "bug" は同じ ID)', () => {
-      // TODO
+    it('空文字または空白のみの名前を渡すとエラーになる', async () => {
+      await expect(findOrCreate('', userMember)).rejects.toThrow();
+      await expect(findOrCreate('   ', userMember)).rejects.toThrow();
     });
 
-    it('空文字または空白のみの名前を渡すとエラーになる', () => {
-      // TODO
+    it('50 文字を超える名前を渡すとエラーになる', async () => {
+      await expect(findOrCreate('a'.repeat(51), userMember)).rejects.toThrow();
     });
 
-    it('50 文字を超える名前を渡すとエラーになる', () => {
-      // TODO
-    });
-
-    it('名前に空白文字や "#" を含む場合はエラーになる', () => {
-      // TODO
+    it('名前に空白文字や "#" を含む場合はエラーになる', async () => {
+      await expect(findOrCreate('bu g', userMember)).rejects.toThrow();
+      await expect(findOrCreate('#bug', userMember)).rejects.toThrow();
     });
   });
 
   describe('メッセージへのタグ付与 (attachToMessage)', () => {
-    it('単一タグを付与すると message_tags に行が追加される', () => {
-      // TODO
+    it('単一タグを付与すると message_tags に行が追加される', async () => {
+      const tag = await findOrCreate('a', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      const rows = await testDb.query(
+        'SELECT * FROM message_tags WHERE message_id = $1 AND tag_id = $2',
+        [publicMessageId, tag.id],
+      );
+      expect(rows.length).toBe(1);
     });
 
-    it('複数タグを一括付与すると message_tags に複数行が追加される', () => {
-      // TODO
+    it('複数タグを一括付与すると message_tags に複数行が追加される', async () => {
+      const t1 = await findOrCreate('t1', userMember);
+      const t2 = await findOrCreate('t2', userMember);
+      await attachToMessage(publicMessageId, [t1.id, t2.id], userMember);
+      const rows = await testDb.query('SELECT * FROM message_tags WHERE message_id = $1', [
+        publicMessageId,
+      ]);
+      expect(rows.length).toBe(2);
     });
 
-    it('付与時に対象タグの use_count が +1 される', () => {
-      // TODO
+    it('付与時に対象タグの use_count が +1 される', async () => {
+      const tag = await findOrCreate('cnt', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(1);
     });
 
-    it('既に付与済みのタグを再付与しても重複行は作られず use_count も増えない', () => {
-      // TODO
+    it('既に付与済みのタグを再付与しても重複行は作られず use_count も増えない', async () => {
+      const tag = await findOrCreate('dup', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      const rows = await testDb.query(
+        'SELECT * FROM message_tags WHERE message_id = $1 AND tag_id = $2',
+        [publicMessageId, tag.id],
+      );
+      expect(rows.length).toBe(1);
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(1);
     });
 
-    it('チャンネルメンバーであれば自分以外のメッセージにもタグを付与できる', () => {
-      // TODO
+    it('チャンネルメンバーであれば自分以外のメッセージにもタグを付与できる', async () => {
+      // userOther を private channel メンバーに追加 → 別ユーザーが userMember 投稿の
+      // メッセージにタグ付け
+      await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+        privateChannelId,
+        userOther,
+      ]);
+      const tag = await findOrCreate('peer', userOther);
+      await expect(attachToMessage(privateMessageId, [tag.id], userOther)).resolves.not.toThrow();
     });
 
-    /**
-     * 仕様の精緻化：パブリックチャンネルは全認証ユーザー許可
-     * プライベートチャンネル (is_private=true) でメンバー外→403 を検証する。
-     * 旧テスト名「チャンネル非メンバーのユーザーが付与しようとするとエラーになる」は
-     * パブリック/プライベート区別なしの実装に依存した仕様不正確なテストだったため、
-     * 「プライベートチャンネルでメンバー外→403」に更新する。
-     */
-    it('プライベートチャンネルでチャンネル非メンバーのユーザーが付与しようとすると 403 エラーになる', () => {
-      // TODO
+    it('プライベートチャンネルでチャンネル非メンバーのユーザーが付与しようとすると 403 エラーになる', async () => {
+      const tag = await findOrCreate('p', userMember);
+      await expect(attachToMessage(privateMessageId, [tag.id], userOther)).rejects.toThrow();
     });
 
-    it('パブリックチャンネル (is_private=false) では非メンバーでもタグを付与できる', () => {
-      // TODO
+    it('パブリックチャンネル (is_private=false) では非メンバーでもタグを付与できる', async () => {
+      const tag = await findOrCreate('publ', userMember);
+      await expect(attachToMessage(publicMessageId, [tag.id], userOther)).resolves.not.toThrow();
     });
 
-    it('存在しないメッセージ ID への付与はエラーになる', () => {
-      // TODO
+    it('存在しないメッセージ ID への付与はエラーになる', async () => {
+      const tag = await findOrCreate('q', userMember);
+      await expect(attachToMessage(999999, [tag.id], userMember)).rejects.toThrow();
     });
   });
 
   describe('メッセージからのタグ解除 (detachFromMessage)', () => {
-    it('指定したタグの message_tags 行が削除される', () => {
-      // TODO
+    it('指定したタグの message_tags 行が削除される', async () => {
+      const tag = await findOrCreate('det', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      await detachFromMessage(publicMessageId, [tag.id]);
+      const rows = await testDb.query(
+        'SELECT * FROM message_tags WHERE message_id = $1 AND tag_id = $2',
+        [publicMessageId, tag.id],
+      );
+      expect(rows.length).toBe(0);
     });
 
-    it('解除時に対象タグの use_count が -1 される', () => {
-      // TODO
+    it('解除時に対象タグの use_count が -1 される', async () => {
+      const tag = await findOrCreate('dec', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      await detachFromMessage(publicMessageId, [tag.id]);
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(0);
     });
 
-    it('use_count は 0 未満にならない (下限ガード)', () => {
-      // TODO
+    it('use_count は 0 未満にならない (下限ガード)', async () => {
+      // タグだけ作成して付与せず、use_count=0 の状態で detach しても 0 のままを期待
+      const tag = await findOrCreate('zero', userMember);
+      // 直接 use_count を負に下げないことを確認するため SQL で 1 行作って試す
+      await testDb.execute(
+        'INSERT INTO message_tags (message_id, tag_id, created_by) VALUES ($1, $2, $3)',
+        [publicMessageId, tag.id, userMember],
+      );
+      // この時点で行は存在するが tags.use_count は 0 のまま（attach 経由でない）
+      await detachFromMessage(publicMessageId, [tag.id]);
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(0);
     });
 
-    it('付与されていないタグの解除を要求しても例外を投げず、use_count も変動しない', () => {
-      // TODO
+    it('付与されていないタグの解除を要求しても例外を投げず、use_count も変動しない', async () => {
+      const tag = await findOrCreate('nope', userMember);
+      await expect(detachFromMessage(publicMessageId, [tag.id])).resolves.not.toThrow();
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(0);
     });
   });
 
   describe('チャンネルへのタグ付与・解除', () => {
-    it('attachToChannel で channel_tags に行が追加され use_count が +1 される', () => {
-      // TODO
+    it('attachToChannel で channel_tags に行が追加され use_count が +1 される', async () => {
+      const tag = await findOrCreate('ct1', userMember);
+      await attachToChannel(publicChannelId, [tag.id]);
+      const rows = await testDb.query(
+        'SELECT * FROM channel_tags WHERE channel_id = $1 AND tag_id = $2',
+        [publicChannelId, tag.id],
+      );
+      expect(rows.length).toBe(1);
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(1);
     });
 
-    it('detachFromChannel で channel_tags から削除され use_count が -1 される', () => {
-      // TODO
+    it('detachFromChannel で channel_tags から削除され use_count が -1 される', async () => {
+      const tag = await findOrCreate('ct2', userMember);
+      await attachToChannel(publicChannelId, [tag.id]);
+      await detachFromChannel(publicChannelId, [tag.id]);
+      const rows = await testDb.query(
+        'SELECT * FROM channel_tags WHERE channel_id = $1 AND tag_id = $2',
+        [publicChannelId, tag.id],
+      );
+      expect(rows.length).toBe(0);
+      const row = await testDb.queryOne<{ use_count: number }>(
+        'SELECT use_count FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row!.use_count).toBe(0);
     });
 
-    it('既に付与済みのタグをチャンネルに再付与しても重複行は作られない', () => {
-      // TODO
+    it('既に付与済みのタグをチャンネルに再付与しても重複行は作られない', async () => {
+      const tag = await findOrCreate('ctd', userMember);
+      await attachToChannel(publicChannelId, [tag.id]);
+      await attachToChannel(publicChannelId, [tag.id]);
+      const rows = await testDb.query(
+        'SELECT * FROM channel_tags WHERE channel_id = $1 AND tag_id = $2',
+        [publicChannelId, tag.id],
+      );
+      expect(rows.length).toBe(1);
     });
   });
 
   describe('タグ候補取得 (listSuggestions)', () => {
-    it('use_count 降順で候補が返る', () => {
-      // TODO
+    it('use_count 降順で候補が返る', async () => {
+      const tA = await findOrCreate('alpha', userMember);
+      const tB = await findOrCreate('beta', userMember);
+      // alpha に2回、beta に1回
+      await attachToMessage(publicMessageId, [tA.id], userMember);
+      await attachToChannel(publicChannelId, [tA.id]);
+      await attachToMessage(publicMessageId, [tB.id], userMember);
+      const list = await listSuggestions();
+      const names = list.map((s) => s.name);
+      expect(names.indexOf('alpha')).toBeLessThan(names.indexOf('beta'));
     });
 
-    it('use_count が同値のときは name 昇順で返る', () => {
-      // TODO
+    it('use_count が同値のときは name 昇順で返る', async () => {
+      await findOrCreate('zoo', userMember);
+      await findOrCreate('apple', userMember);
+      await findOrCreate('mango', userMember);
+      const list = await listSuggestions();
+      const names = list.map((s) => s.name);
+      expect(names).toEqual(['apple', 'mango', 'zoo']);
     });
 
-    it('prefix を指定するとその文字列で前方一致する候補のみ返る', () => {
-      // TODO
+    it('prefix を指定するとその文字列で前方一致する候補のみ返る', async () => {
+      await findOrCreate('apple', userMember);
+      await findOrCreate('apricot', userMember);
+      await findOrCreate('banana', userMember);
+      const list = await listSuggestions('ap');
+      const names = list.map((s) => s.name);
+      expect(names).toContain('apple');
+      expect(names).toContain('apricot');
+      expect(names).not.toContain('banana');
     });
 
-    it('prefix のマッチングは大文字小文字を無視する (prefix="BU" でも "bug" がヒットする)', () => {
-      // TODO
+    it('prefix のマッチングは大文字小文字を無視する (prefix="BU" でも "bug" がヒットする)', async () => {
+      await findOrCreate('bug', userMember);
+      const list = await listSuggestions('BU');
+      const names = list.map((s) => s.name);
+      expect(names).toContain('bug');
     });
 
-    it('limit を指定すると最大件数を超えない', () => {
-      // TODO
+    it('limit を指定すると最大件数を超えない', async () => {
+      for (let i = 0; i < 5; i++) {
+        await findOrCreate(`tag${i}`, userMember);
+      }
+      const list = await listSuggestions('', 3);
+      expect(list.length).toBe(3);
     });
 
-    it('use_count が 0 のタグも候補に含まれる', () => {
-      // TODO
+    it('use_count が 0 のタグも候補に含まれる', async () => {
+      await findOrCreate('zerocnt', userMember);
+      const list = await listSuggestions();
+      const names = list.map((s) => s.name);
+      expect(names).toContain('zerocnt');
     });
   });
 
   describe('メッセージ単位のタグ取得 (getForMessages)', () => {
-    it('複数メッセージ ID を渡すと messageId ごとに Tag[] のマップが返る', () => {
-      // TODO
+    it('複数メッセージ ID を渡すと messageId ごとに Tag[] のマップが返る', async () => {
+      const t1 = await findOrCreate('m1', userMember);
+      const t2 = await findOrCreate('m2', userMember);
+      const m2 = await testDb.queryOne<{ id: number }>(
+        "INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, 'm2') RETURNING id",
+        [publicChannelId, userMember],
+      );
+      await attachToMessage(publicMessageId, [t1.id, t2.id], userMember);
+      await attachToMessage(m2!.id, [t1.id], userMember);
+      const map = await getForMessages([publicMessageId, m2!.id]);
+      expect(map.get(publicMessageId)!.length).toBe(2);
+      expect(map.get(m2!.id)!.length).toBe(1);
     });
 
-    it('タグが付与されていないメッセージ ID には空配列が返る', () => {
-      // TODO
+    it('タグが付与されていないメッセージ ID には空配列が返る', async () => {
+      const map = await getForMessages([publicMessageId]);
+      expect(map.get(publicMessageId)).toEqual([]);
     });
 
-    it('1 回のクエリで bulk fetch される (N+1 にならない)', () => {
-      // TODO
+    it('1 回のクエリで bulk fetch される (N+1 にならない)', async () => {
+      const t = await findOrCreate('bulk', userMember);
+      const ids: number[] = [publicMessageId];
+      for (let i = 0; i < 2; i++) {
+        const m = await testDb.queryOne<{ id: number }>(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [publicChannelId, userMember, `m-${i}`],
+        );
+        ids.push(m!.id);
+      }
+      await attachToMessage(publicMessageId, [t.id], userMember);
+      querySpy.mockClear();
+      await getForMessages(ids);
+      expect(querySpy).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('CASCADE 削除', () => {
-    it('メッセージを削除すると message_tags の関連行も削除される', () => {
-      // TODO
+    it('メッセージを削除すると message_tags の関連行も削除される', async () => {
+      const tag = await findOrCreate('cascade1', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      await testDb.execute('DELETE FROM messages WHERE id = $1', [publicMessageId]);
+      const rows = await testDb.query('SELECT * FROM message_tags WHERE message_id = $1', [
+        publicMessageId,
+      ]);
+      expect(rows.length).toBe(0);
     });
 
-    it('チャンネルを削除すると channel_tags の関連行も削除される', () => {
-      // TODO
+    it('チャンネルを削除すると channel_tags の関連行も削除される', async () => {
+      const tag = await findOrCreate('cascade2', userMember);
+      await attachToChannel(publicChannelId, [tag.id]);
+      await testDb.execute('DELETE FROM channels WHERE id = $1', [publicChannelId]);
+      const rows = await testDb.query('SELECT * FROM channel_tags WHERE channel_id = $1', [
+        publicChannelId,
+      ]);
+      expect(rows.length).toBe(0);
     });
 
-    it('タグ自体を削除すると message_tags / channel_tags の関連行も削除される', () => {
-      // TODO
+    it('タグ自体を削除すると message_tags / channel_tags の関連行も削除される', async () => {
+      const tag = await findOrCreate('cascade3', userMember);
+      await attachToMessage(publicMessageId, [tag.id], userMember);
+      await attachToChannel(publicChannelId, [tag.id]);
+      await testDb.execute('DELETE FROM tags WHERE id = $1', [tag.id]);
+      const m = await testDb.query('SELECT * FROM message_tags WHERE tag_id = $1', [tag.id]);
+      const c = await testDb.query('SELECT * FROM channel_tags WHERE tag_id = $1', [tag.id]);
+      expect(m.length).toBe(0);
+      expect(c.length).toBe(0);
     });
 
-    it('タグ作成者ユーザーが削除されても tags 行は残り created_by が NULL になる', () => {
-      // TODO
+    it('タグ作成者ユーザーが削除されても tags 行は残り created_by が NULL になる', async () => {
+      const tag = await findOrCreate('cascade4', userMember);
+      await testDb.execute('DELETE FROM users WHERE id = $1', [userMember]);
+      const row = await testDb.queryOne<{ id: number; created_by: number | null }>(
+        'SELECT id, created_by FROM tags WHERE id = $1',
+        [tag.id],
+      );
+      expect(row).not.toBeNull();
+      expect(row!.created_by).toBeNull();
     });
   });
 });

--- a/packages/server/src/__tests__/unit/tagService.test.ts
+++ b/packages/server/src/__tests__/unit/tagService.test.ts
@@ -6,70 +6,101 @@
  *   - findOrCreate のロジック（同名重複排除）も pg-mem を使って単独で確認する。
  */
 
+import { createTestDatabase } from '../__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+
+jest.mock('../../db/database', () => testDb);
+
+import { normalizeTagName, validateTagName, findOrCreate } from '../../services/tagService';
+
 describe('tagService - 純粋ロジック', () => {
   describe('normalizeTagName (タグ名正規化)', () => {
     it('前後の空白を除去する', () => {
-      // TODO
+      expect(normalizeTagName('  bug  ')).toBe('bug');
     });
 
     it('英大文字を小文字に変換する', () => {
-      // TODO
+      expect(normalizeTagName('Bug')).toBe('bug');
+      expect(normalizeTagName('BUG')).toBe('bug');
     });
 
     it('全角空白も前後から除去する', () => {
-      // TODO
+      expect(normalizeTagName('　bug　')).toBe('bug');
     });
 
     it('内部の空白はそのまま残る (中間空白は normalize しない / バリデーションで弾く)', () => {
-      // TODO
+      expect(normalizeTagName(' bu g ')).toBe('bu g');
     });
 
     it('日本語タグはそのまま小文字化されない (大文字小文字概念のない文字は変化しない)', () => {
-      // TODO
+      expect(normalizeTagName('バグ')).toBe('バグ');
     });
 
     it('絵文字を含むタグもそのまま保持される', () => {
-      // TODO
+      expect(normalizeTagName('🐛bug')).toBe('🐛bug');
     });
   });
 
   describe('validateTagName (タグ名バリデーション)', () => {
     it('空文字は不正として例外を投げる', () => {
-      // TODO
+      expect(() => validateTagName('')).toThrow();
     });
 
     it('空白のみの文字列は不正として例外を投げる', () => {
-      // TODO
+      expect(() => validateTagName('   ')).toThrow();
     });
 
     it('1 文字のタグ名は許可される', () => {
-      // TODO
+      expect(() => validateTagName('a')).not.toThrow();
     });
 
     it('50 文字ちょうどのタグ名は許可される (境界値)', () => {
-      // TODO
+      expect(() => validateTagName('a'.repeat(50))).not.toThrow();
     });
 
     it('51 文字以上のタグ名は不正として例外を投げる', () => {
-      // TODO
+      expect(() => validateTagName('a'.repeat(51))).toThrow();
     });
 
     it('"#" を含むタグ名は不正として例外を投げる (UI 側で # を切り落とす想定)', () => {
-      // TODO
+      expect(() => validateTagName('#bug')).toThrow();
     });
 
     it('内部に空白を含むタグ名は不正として例外を投げる', () => {
-      // TODO
+      expect(() => validateTagName('bu g')).toThrow();
     });
   });
 
   describe('findOrCreate - 一意性保証', () => {
-    it('同じ正規化結果になる入力 ("Bug" / " bug " / "BUG") はすべて同じ ID を返す', () => {
-      // TODO
+    beforeEach(async () => {
+      await testDb.execute('DELETE FROM tags', []);
     });
 
-    it('並行に同名タグの findOrCreate が走っても unique 制約により最終的に 1 行に収束する', () => {
-      // TODO
+    it('同じ正規化結果になる入力 ("Bug" / "BUG" / "bug") はすべて同じ ID を返す', async () => {
+      // findOrCreate は raw 入力に空白文字を許さない仕様（validateTagName で弾く）。
+      // よって正規化結果が一致する大文字小文字違いのみでテストする。
+      const a = await findOrCreate('Bug');
+      const b = await findOrCreate('BUG');
+      const c = await findOrCreate('bug');
+      expect(b.id).toBe(a.id);
+      expect(c.id).toBe(a.id);
+      expect(a.name).toBe('bug');
+    });
+
+    it('並行に同名タグの findOrCreate が走っても unique 制約により最終的に 1 行に収束する', async () => {
+      const results = await Promise.all([
+        findOrCreate('parallel'),
+        findOrCreate('parallel'),
+        findOrCreate('parallel'),
+      ]);
+      const ids = new Set(results.map((r) => r.id));
+      expect(ids.size).toBe(1);
+      const rows = await testDb.query<{ count: string }>(
+        "SELECT COUNT(*)::text AS count FROM tags WHERE name = 'parallel'",
+        [],
+      );
+      expect(parseInt(rows[0].count, 10)).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## 概要
タグ機能関連の `// TODO` 状態のテストを実装。あわせて、CLAUDE.md ルールに違反していた `useTagSuggestions` を `use()` + Suspense 構成にリファクタリング。

## 変更内容
**コミット単位で分割** — レビューしやすいよう、機能群ごとにコミットを分けています。

| # | コミット | 内容 | 件数 |
|---|---|---|---|
| 1 | `tagService.test.ts` | 純粋ロジック (normalize/validate/findOrCreate) | 15 |
| 2 | `tag.test.ts` | サービス層全体 (attach/detach/listSuggestions/CASCADE) | 35 |
| 3 | `TagChip.test.tsx` | 表示 + クリック動作 | 5 |
| 4 | `TagInput.test.tsx` | 候補表示・確定・削除・正規化 | 13 |
| 5 | `useTagSuggestions` リファクタ + テスト | use() + Suspense 移行 + 5 件 | 5 |
| **計** | | | **73** |

### useTagSuggestions リファクタ詳細
- `useEffect` + `useState` での古典的フェッチ → `use(promise)` + `useMemo` に変更
- `TagInput.tsx` を Suspense 境界対応（候補リストを `SuggestionPanel` 子コンポーネントに分離）
- 入力デバウンス（200ms）は Suspense 境界の外側（親 `TagInput` 内）に移動
  - 理由: Suspense 内の `useState` は suspend → unmount → remount で初期値が再評価され、フック内デバウンスが成立しないため
- 既存呼び出し元の API は変えず、デグレを避けた

### テスト項目の修正（#177 で承認済み）
TDD ステップ1 の項目と現実装が乖離していた箇所を以下に揃えました。

| ファイル | 元の項目 | 修正 | 理由 |
|---|---|---|---|
| `tagService.test.ts` | 同じ正規化結果になる入力 (`"Bug"` / `" bug "` / `"BUG"`) | 前後空白付きを削除し `"Bug"` / `"BUG"` / `"bug"` のみに | `findOrCreate` は raw 入力に空白文字を許さない仕様 |
| `tag.test.ts` | タグ名の前後空白は除去されて保存される | 削除 | 同上 |
| `TagInput.test.tsx` | 入力が空のときも use_count 上位の候補を表示する | 「入力が空のときは候補リストが表示されない」に変更 | 実装は `v.length > 0` のときのみ open |
| `TagInput.test.tsx` | 候補を矢印キーで選択し Enter を押すと確定される | 「候補をクリックすると確定される」に変更 | 矢印キー選択は未実装、`onMouseDown` のみ |
| `useTagSuggestions.test.ts` | 短時間に連続で prefix が変わってもデバウンスにより最後の値だけリクエストされる | 削除（5 件に） | デバウンスは TagInput 側の責務に分離 |

UX 改善（空入力時の人気候補表示・矢印キー選択）は別 issue で取り扱う想定。

## 影響範囲
- 新規テスト: 73 件追加
- 実装変更:
  - `packages/client/src/hooks/useTagSuggestions.ts` (use() + Suspense 化)
  - `packages/client/src/components/Chat/TagInput.tsx` (Suspense 境界 + debounce 移動)
- 呼び出し元（`MessageInput` 等）への影響なし — TagInput のインターフェースは変更していない

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1286 tests）
- [x] バックエンドユニットテストがすべてパスする（1360 tests）
- [x] ビルドが正常に完了すること
- [ ] **(手動確認のお願い)** タグ入力 UI（メッセージ作成時のタグ追加）で以下を確認してください:
  1. タグ入力欄に文字を入力 → 200ms 後に候補が表示される
  2. 候補をクリックするとタグが追加される
  3. Enter キーで新規タグが追加される
  4. × ボタンでタグを削除できる
  5. 既存タグの再入力で重複しないこと

## 関連Issue
Fixes #177

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）