### PR TITLE
test: 招待リンクの TODO テスト 25 件を実装

### DIFF
--- a/packages/client/src/__tests__/InviteLinkDialog.test.tsx
+++ b/packages/client/src/__tests__/InviteLinkDialog.test.tsx
@@ -5,82 +5,228 @@
  *       管理者／作成者のみ「無効化」ボタンが表示されることを確認する。
  */
 
-import { describe, it, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { InviteLink } from '@chat-app/shared';
+import InviteLinkDialog from '../components/Channel/InviteLinkDialog';
 
+const createMock = vi.fn();
+const listMock = vi.fn();
+const revokeMock = vi.fn();
 vi.mock('../api/client', () => ({
   api: {
     invites: {
-      create: vi.fn(),
-      list: vi.fn(),
-      revoke: vi.fn(),
+      create: (...args: unknown[]) => createMock(...args),
+      list: (...args: unknown[]) => listMock(...args),
+      revoke: (...args: unknown[]) => revokeMock(...args),
     },
   },
 }));
 
+type MockUser = { id: number; username: string; role: string };
+let mockUserOverride: MockUser | null = { id: 1, username: 'me', role: 'user' };
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUserOverride }),
+}));
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  createMock.mockReset();
+  listMock.mockReset().mockResolvedValue({ invites: [] });
+  revokeMock.mockReset();
+  mockUserOverride = { id: 1, username: 'me', role: 'user' };
+  writeTextMock.mockClear();
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeTextMock },
+    configurable: true,
+  });
+});
+
+function makeInvite(overrides: Partial<InviteLink> = {}): InviteLink {
+  return {
+    id: 1,
+    token: 'tok',
+    channelId: 5,
+    createdBy: 1,
+    maxUses: null,
+    usedCount: 0,
+    expiresAt: null,
+    isRevoked: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+async function renderDialog() {
+  const onClose = vi.fn();
+  render(<InviteLinkDialog open={true} channelId={5} onClose={onClose} />);
+  // MUI Dialog の onEntered で list が呼ばれるまで待つ
+  await waitFor(() => expect(listMock).toHaveBeenCalled());
+  return { onClose };
+}
+
 describe('InviteLinkDialog', () => {
   describe('リンク生成', () => {
     it('「リンクを生成」ボタンをクリックすると api.invites.create が呼ばれる', async () => {
-      // TODO
+      createMock.mockResolvedValue({ invite: makeInvite() });
+      await renderDialog();
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'リンクを生成' }));
+      });
+      expect(createMock).toHaveBeenCalled();
     });
 
     it('生成されたリンクが URL 形式でダイアログ内に表示される', async () => {
-      // TODO
+      createMock.mockResolvedValue({ invite: makeInvite({ id: 99, token: 'newtok' }) });
+      await renderDialog();
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'リンクを生成' }));
+      });
+      // ${origin}/invite/newtok を表示
+      expect(screen.getByText(/\/invite\/newtok/)).toBeInTheDocument();
     });
 
     it('有効期限（expiresInHours）を選択して生成できる', async () => {
-      // TODO
+      const user = userEvent.setup();
+      createMock.mockResolvedValue({ invite: makeInvite() });
+      await renderDialog();
+      // MUI Select の trigger を combobox role で取得（このダイアログ内で1つだけ）
+      await user.click(screen.getAllByRole('combobox')[0]);
+      await user.click(await screen.findByRole('option', { name: '24時間' }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'リンクを生成' }));
+      });
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ expiresInHours: 24 }));
     });
 
     it('最大使用回数（maxUses）を入力して生成できる', async () => {
-      // TODO
+      createMock.mockResolvedValue({ invite: makeInvite() });
+      await renderDialog();
+      fireEvent.change(screen.getByLabelText('最大使用回数'), { target: { value: '5' } });
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'リンクを生成' }));
+      });
+      expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ maxUses: 5 }));
     });
   });
 
   describe('クリップボードコピー', () => {
     it('「コピー」ボタンをクリックするとリンクがクリップボードに書き込まれる', async () => {
-      // TODO
+      listMock.mockResolvedValue({ invites: [makeInvite({ token: 'copytok' })] });
+      await renderDialog();
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('URLをコピー'));
+      });
+      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining('/invite/copytok'));
     });
   });
 
   describe('一覧表示', () => {
     it('既存の招待リンク一覧が表示される', async () => {
-      // TODO
+      listMock.mockResolvedValue({
+        invites: [makeInvite({ id: 1, token: 't1' }), makeInvite({ id: 2, token: 't2' })],
+      });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByText(/\/invite\/t1/)).toBeInTheDocument();
+        expect(screen.getByText(/\/invite\/t2/)).toBeInTheDocument();
+      });
     });
 
     it('有効期限付きリンクに期限が表示される', async () => {
-      // TODO
+      listMock.mockResolvedValue({
+        invites: [makeInvite({ expiresAt: '2030-12-31T23:59:00Z' })],
+      });
+      await renderDialog();
+      await waitFor(() => {
+        // 期限: の表示が secondary に出る
+        expect(screen.getByText(/期限:/)).toBeInTheDocument();
+      });
     });
 
     it('期限切れリンクに「期限切れ」が表示される', async () => {
-      // TODO
+      listMock.mockResolvedValue({
+        invites: [makeInvite({ expiresAt: '2000-01-01T00:00:00Z' })],
+      });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByText(/期限切れ/)).toBeInTheDocument();
+      });
     });
 
     it('revoke 済みリンクに「無効」が表示される', async () => {
-      // TODO
+      listMock.mockResolvedValue({
+        invites: [makeInvite({ isRevoked: true })],
+      });
+      await renderDialog();
+      await waitFor(() => {
+        // statusLabel が「無効」を返す
+        expect(screen.getByText(/状態: 無効/)).toBeInTheDocument();
+      });
     });
   });
 
   describe('無効化ボタンの表示制御', () => {
     it('作成者には「無効化」ボタンが表示される', async () => {
-      // TODO
+      mockUserOverride = { id: 1, username: 'me', role: 'user' };
+      listMock.mockResolvedValue({ invites: [makeInvite({ createdBy: 1 })] });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByLabelText('無効化')).toBeInTheDocument();
+      });
     });
 
     it('admin ロールのユーザーには他ユーザーのリンクにも「無効化」ボタンが表示される', async () => {
-      // TODO
+      mockUserOverride = { id: 99, username: 'admin', role: 'admin' };
+      listMock.mockResolvedValue({ invites: [makeInvite({ createdBy: 1 })] });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByLabelText('無効化')).toBeInTheDocument();
+      });
     });
 
     it('作成者でも admin でもないユーザーには「無効化」ボタンが表示されない', async () => {
-      // TODO
+      mockUserOverride = { id: 99, username: 'other', role: 'user' };
+      listMock.mockResolvedValue({ invites: [makeInvite({ createdBy: 1 })] });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByText(/\/invite\//)).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText('無効化')).toBeNull();
     });
   });
 
   describe('無効化操作', () => {
     it('「無効化」ボタンをクリックすると api.invites.revoke が呼ばれる', async () => {
-      // TODO
+      const invite = makeInvite({ id: 7, createdBy: 1 });
+      listMock.mockResolvedValue({ invites: [invite] });
+      revokeMock.mockResolvedValue({ invite: { ...invite, isRevoked: true } });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByLabelText('無効化')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('無効化'));
+      });
+      expect(revokeMock).toHaveBeenCalledWith(7);
     });
 
     it('revoke 後にリンクの状態が「無効」に更新される', async () => {
-      // TODO
+      const invite = makeInvite({ id: 7, createdBy: 1 });
+      listMock.mockResolvedValue({ invites: [invite] });
+      revokeMock.mockResolvedValue({ invite: { ...invite, isRevoked: true } });
+      await renderDialog();
+      await waitFor(() => {
+        expect(screen.getByLabelText('無効化')).toBeInTheDocument();
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('無効化'));
+      });
+      await waitFor(() => {
+        expect(screen.getByText(/状態: 無効/)).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/client/src/__tests__/InviteRedeemPage.test.tsx
+++ b/packages/client/src/__tests__/InviteRedeemPage.test.tsx
@@ -1,79 +1,200 @@
 /**
  * テスト対象: pages/InviteRedeemPage.tsx（/invite/:token ルート）
  * 戦略: AuthContext と api.invites を vi.mock で差し替え、
- *       未ログイン時のリダイレクト・ログイン済み時の自動 redeem・
- *       ログイン後のトークン保持フローを検証する。
+ *       未ログイン時のリダイレクト・ログイン済み時の lookup と参加フロー・
+ *       エラーハンドリングを検証する。
+ *
+ * NOTE: 「ログイン済みで自動 redeem」「sessionStorage redirect_after_login の
+ *       LoginPage 側挙動」は実装と齟齬があったため #182 で項目修正済み。
+ *       redirect_after_login の消費は LoginPage の責務（LoginPage.test.tsx でカバー）。
  */
 
-import { describe, it, vi } from 'vitest';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import InviteRedeemPage from '../pages/InviteRedeemPage';
 
-vi.mock('../contexts/AuthContext', () => ({
-  useAuth: vi.fn(),
-}));
-
+const lookupMock = vi.fn();
+const redeemMock = vi.fn();
 vi.mock('../api/client', () => ({
   api: {
     invites: {
-      lookup: vi.fn(),
-      redeem: vi.fn(),
+      lookup: (...args: unknown[]) => lookupMock(...args),
+      redeem: (...args: unknown[]) => redeemMock(...args),
     },
   },
 }));
 
+let mockUser: { id: number; username: string } | null = null;
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+let mockToken: string | undefined = 'tok';
+const navigateFn = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ token: mockToken }),
+  useNavigate: () => navigateFn,
+  Navigate: ({ to }: { to: string }) =>
+    React.createElement('div', { 'data-testid': 'navigate' }, to),
+}));
+
+beforeEach(() => {
+  lookupMock.mockReset();
+  redeemMock.mockReset();
+  mockUser = null;
+  mockToken = 'tok';
+  navigateFn.mockClear();
+  sessionStorage.clear();
+});
+
+function validInvite(channelId: number | null = 5, channelName: string | null = 'general') {
+  return {
+    invite: {
+      token: 'tok',
+      channelId,
+      channelName,
+      expiresAt: null,
+      isExpired: false,
+      isRevoked: false,
+      isExhausted: false,
+    },
+  };
+}
+
 describe('InviteRedeemPage', () => {
   describe('未ログイン状態でのアクセス', () => {
-    it('/invite/:token に未ログインでアクセスすると /login へリダイレクトされる', async () => {
-      // TODO
+    it('/invite/:token に未ログインでアクセスすると /login へリダイレクトされる', () => {
+      mockUser = null;
+      render(<InviteRedeemPage />);
+      expect(screen.getByTestId('navigate').textContent).toBe('/login');
     });
 
-    it('リダイレクト前に sessionStorage に redirect_after_login が保存される', async () => {
-      // TODO
+    it('リダイレクト前に sessionStorage に redirect_after_login が保存される', () => {
+      mockUser = null;
+      mockToken = 'mytok';
+      render(<InviteRedeemPage />);
+      expect(sessionStorage.getItem('redirect_after_login')).toBe('/invite/mytok');
     });
 
-    it('token の情報（チャンネル名）が表示されてからリダイレクトされる', async () => {
-      // TODO
+    // 仕様の精緻化（#182）:
+    // 旧テスト「token の情報（チャンネル名）が表示されてからリダイレクトされる」は
+    // 実装と乖離していたため「未ログイン時は lookup を呼ばずに即リダイレクトされる」に変更。
+    it('未ログイン時は lookup を呼ばずに即リダイレクトされる', () => {
+      mockUser = null;
+      render(<InviteRedeemPage />);
+      expect(lookupMock).not.toHaveBeenCalled();
+      expect(screen.getByTestId('navigate').textContent).toBe('/login');
     });
   });
 
-  describe('ログイン済み状態での自動 redeem', () => {
-    it('ログイン済みで有効なトークンにアクセスすると自動で redeem が呼ばれる', async () => {
-      // TODO
+  describe('ログイン済み状態での lookup と参加確認カード', () => {
+    // 仕様の精緻化（#182）:
+    // 旧テスト「自動で redeem が呼ばれる」は実装と乖離（実装は手動「参加する」ボタン）。
+    it('ログイン済みで有効なトークンにアクセスすると lookup が呼ばれて参加確認カード（参加するボタン）が表示される', async () => {
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(validInvite());
+      render(<InviteRedeemPage />);
+      await waitFor(() => {
+        expect(lookupMock).toHaveBeenCalledWith('tok');
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '参加する' })).toBeInTheDocument();
+      });
+    });
+
+    // 新規追加（#182）: 旧 #4 の自動 redeem 部分を手動操作として独立項目化。
+    it('参加するボタンをクリックすると redeem が呼ばれる', async () => {
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(validInvite());
+      redeemMock.mockResolvedValue({ success: true, channelId: 5 });
+      render(<InviteRedeemPage />);
+      await waitFor(() => screen.getByRole('button', { name: '参加する' }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '参加する' }));
+      });
+      expect(redeemMock).toHaveBeenCalledWith('tok');
     });
 
     it('redeem 成功後に対象チャンネルへ遷移する', async () => {
-      // TODO
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(validInvite(5));
+      redeemMock.mockResolvedValue({ success: true, channelId: 5 });
+      render(<InviteRedeemPage />);
+      await waitFor(() => screen.getByRole('button', { name: '参加する' }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '参加する' }));
+      });
+      expect(navigateFn).toHaveBeenCalledWith('/?channel=5', { replace: true });
     });
 
     it('ワークスペース招待（channelId = null）の redeem 成功後はホームへ遷移する', async () => {
-      // TODO
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(validInvite(null, null));
+      redeemMock.mockResolvedValue({ success: true, channelId: null });
+      render(<InviteRedeemPage />);
+      await waitFor(() => screen.getByRole('button', { name: '参加する' }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: '参加する' }));
+      });
+      expect(navigateFn).toHaveBeenCalledWith('/', { replace: true });
     });
   });
 
   describe('トークンのエラーハンドリング', () => {
+    function invalidInvite(flags: {
+      isExpired?: boolean;
+      isRevoked?: boolean;
+      isExhausted?: boolean;
+    }) {
+      return {
+        invite: {
+          token: 'tok',
+          channelId: 5,
+          channelName: 'general',
+          expiresAt: null,
+          isExpired: false,
+          isRevoked: false,
+          isExhausted: false,
+          ...flags,
+        },
+      };
+    }
+
     it('期限切れトークンにアクセスするとエラーメッセージが表示される', async () => {
-      // TODO
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(invalidInvite({ isExpired: true }));
+      render(<InviteRedeemPage />);
+      await waitFor(() => {
+        expect(screen.getByText(/有効期限切れ/)).toBeInTheDocument();
+      });
     });
 
     it('revoke 済みトークンにアクセスするとエラーメッセージが表示される', async () => {
-      // TODO
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(invalidInvite({ isRevoked: true }));
+      render(<InviteRedeemPage />);
+      await waitFor(() => {
+        expect(screen.getByText(/無効化されています/)).toBeInTheDocument();
+      });
     });
 
     it('使用上限到達トークンにアクセスするとエラーメッセージが表示される', async () => {
-      // TODO
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockResolvedValue(invalidInvite({ isExhausted: true }));
+      render(<InviteRedeemPage />);
+      await waitFor(() => {
+        expect(screen.getByText(/使用上限/)).toBeInTheDocument();
+      });
     });
 
     it('存在しないトークンにアクセスすると 404 エラーメッセージが表示される', async () => {
-      // TODO
-    });
-  });
-
-  describe('ログイン後の自動参加フロー', () => {
-    it('sessionStorage に redirect_after_login がある状態でログインすると自動で redeem が走る', async () => {
-      // TODO
-    });
-
-    it('redeem 完了後に sessionStorage の redirect_after_login が削除される', async () => {
-      // TODO
+      mockUser = { id: 1, username: 'me' };
+      lookupMock.mockRejectedValue(new Error('Not found'));
+      render(<InviteRedeemPage />);
+      await waitFor(() => {
+        expect(screen.getByText(/招待リンクが見つかりません/)).toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要
招待リンク機能のテスト TODO を実装。実装と齟齬があった InviteRedeemPage の項目を #182 で承認のうえ修正・削除した。

## 変更内容

| # | コミット | 内容 | pass |
|---|---|---|---|
| 1 | \`InviteLinkDialog.test.tsx\` | リンク生成・コピー・一覧表示・無効化ボタン制御・無効化操作 | 14 |
| 2 | \`InviteRedeemPage.test.tsx\` | 未ログインリダイレクト・lookup・redeem・エラー4種 | 11 |
| **計** | | | **25** |

## テスト項目の修正（#182 で承認済み）

| ファイル | 元の項目 | 修正後 | 理由 |
|---|---|---|---|
| \`InviteRedeemPage.test.tsx\` | token の情報（チャンネル名）が表示されてからリダイレクトされる | **未ログイン時は lookup を呼ばずに即リダイレクトされる** | 実装は未ログイン時 lookup を呼ばず即遷移する仕様 |
| \`InviteRedeemPage.test.tsx\` | ログイン済みで有効なトークンにアクセスすると自動で redeem が呼ばれる | **lookup が呼ばれて参加確認カードが表示される** + 新規「参加するボタンをクリックすると redeem が呼ばれる」 | 自動 redeem ではなく手動操作。1 項目を 2 項目に分割 |
| \`InviteRedeemPage.test.tsx\` | sessionStorage に redirect_after_login がある状態でログインすると自動で redeem が走る | **削除** | LoginPage の責務（\`LoginPage.test.tsx:60-89\` でカバー済み） |
| \`InviteRedeemPage.test.tsx\` | redeem 完了後に sessionStorage の redirect_after_login が削除される | **削除** | 同上 |

結果: 12 件 → 11 件（1 件削減・1 件分割）

## 影響範囲
- 新規テスト: 25 件追加
- 実装変更: なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1281 pass / 4 skip）
- [x] バックエンドユニットテストがすべてパスする（1360 tests）
- [x] ビルドが正常に完了すること
- [x] (手動確認の場合) 確認した手順やスクリーンショット → 該当なし（テスト追加のみ・実装変更なし）

## 関連Issue
Fixes #182

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない（\`it.skip\` も無し）