### PR TITLE
fix: サーバーテストの並列実行 flaky を解消（共有DB→ファイル独立DB）

### DIFF
--- a/packages/server/src/__tests__/advanced-search.test.ts
+++ b/packages/server/src/__tests__/advanced-search.test.ts
@@ -8,9 +8,9 @@
  *   - DB は pg-mem のインメモリ DB を使用（jest.mock('../db/database')）
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 import { searchMessages } from '../services/messageService';

--- a/packages/server/src/__tests__/bookmark.test.ts
+++ b/packages/server/src/__tests__/bookmark.test.ts
@@ -5,9 +5,9 @@
  * ブックマークはユーザーごとに個別管理されることを重点的に検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/calendar-route.test.ts
+++ b/packages/server/src/__tests__/calendar-route.test.ts
@@ -8,14 +8,14 @@
  * 戦略:
  *  - supertest + createApp() で実エンドポイントを叩く
  *  - 認証は authenticateToken を通すためテスト用 JWT を発行して Cookie に付与（既存 events-route.test.ts の流儀踏襲）
- *  - DB は pg-mem を共有（getSharedTestDatabase）
+ *  - DB は pg-mem を共有（createTestDatabase）
  *
  * 関連 Issue: #152
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 import request from 'supertest';

--- a/packages/server/src/__tests__/calendar.test.ts
+++ b/packages/server/src/__tests__/calendar.test.ts
@@ -12,9 +12,9 @@
  * 関連 Issue: #152
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/channel-archive.test.ts
+++ b/packages/server/src/__tests__/channel-archive.test.ts
@@ -12,9 +12,9 @@
  *       channels テーブルに is_archived カラムが追加されることを前提とする。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/channel-category.test.ts
+++ b/packages/server/src/__tests__/channel-category.test.ts
@@ -20,9 +20,9 @@
  *   - サービス層を直接テスト（unit系）と supertest で HTTP層をテスト（integration系）
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/channel-posting-permission.test.ts
+++ b/packages/server/src/__tests__/channel-posting-permission.test.ts
@@ -12,9 +12,9 @@
  * 戦略: pg-mem のインメモリ PostgreSQL 互換 DB を使用。supertest で HTTP 経由でも検証する。
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 import request from 'supertest';

--- a/packages/server/src/__tests__/channel-topic.test.ts
+++ b/packages/server/src/__tests__/channel-topic.test.ts
@@ -10,9 +10,9 @@
  * システムメッセージ送信を重点的にテストする。
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 import request from 'supertest';

--- a/packages/server/src/__tests__/channelNotification.test.ts
+++ b/packages/server/src/__tests__/channelNotification.test.ts
@@ -4,9 +4,9 @@
  *       UPSERT の冪等性・デフォルト挙動・バリデーションを検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/custom-status.test.ts
+++ b/packages/server/src/__tests__/custom-status.test.ts
@@ -8,9 +8,9 @@
  *   - 絵文字のみ・テキストのみ・両方空でのクリアの各ケースを網羅する
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/direct-message.test.ts
+++ b/packages/server/src/__tests__/direct-message.test.ts
@@ -6,9 +6,9 @@
  *   - 正常系・境界条件・エラーケースを網羅する
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/draft.test.ts
+++ b/packages/server/src/__tests__/draft.test.ts
@@ -7,9 +7,9 @@
  *   - 下書き削除時に紐付く一時添付（draft_id）も削除されることを検証する
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/event.test.ts
+++ b/packages/server/src/__tests__/event.test.ts
@@ -6,9 +6,9 @@
  *   - イベント作成 / RSVP（参加・不参加・未定）/ 集計 / 権限 / 境界値を網羅する
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/events-route.test.ts
+++ b/packages/server/src/__tests__/events-route.test.ts
@@ -6,9 +6,9 @@
  *   - supertest で HTTP リクエストを発行し、201 レスポンスと Socket emit を確認する
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 // Socket.IO サーバーモック

--- a/packages/server/src/__tests__/invite.test.ts
+++ b/packages/server/src/__tests__/invite.test.ts
@@ -5,9 +5,9 @@
  *       ワークスペース招待、監査ログ記録を重点的に検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/mention-badge.test.ts
+++ b/packages/server/src/__tests__/mention-badge.test.ts
@@ -5,9 +5,9 @@
  * 戦略: pg-mem のインメモリ PostgreSQL 互換 DB を使いサービス層を直接テストする。
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/messageForward.test.ts
+++ b/packages/server/src/__tests__/messageForward.test.ts
@@ -5,9 +5,9 @@
  *       元メッセージ削除後は forwardedFromMessage が null になることを検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/messageTemplate.test.ts
+++ b/packages/server/src/__tests__/messageTemplate.test.ts
@@ -6,9 +6,9 @@
  *   - REST API テストでは supertest を使い HTTP 契約のみを確認する
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/middleware/guestAuth.test.ts
+++ b/packages/server/src/__tests__/middleware/guestAuth.test.ts
@@ -6,9 +6,9 @@
  *   - middleware/auth.ts には触らない方針（#153 とのコンフリクト回避）。本ミドルウェアは独立して動作することを境界として確認する
  */
 
-import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/moderation.test.ts
+++ b/packages/server/src/__tests__/moderation.test.ts
@@ -18,9 +18,9 @@
  *   - Socket テストは registerMessageHandlers をモックソケットで直接呼ぶ
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 import request from 'supertest';

--- a/packages/server/src/__tests__/moderationReport.test.ts
+++ b/packages/server/src/__tests__/moderationReport.test.ts
@@ -8,9 +8,9 @@
  *   - pg-mem のインメモリ PostgreSQL 互換 DB を使用
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 import request from 'supertest';

--- a/packages/server/src/__tests__/onboarding.test.ts
+++ b/packages/server/src/__tests__/onboarding.test.ts
@@ -8,9 +8,9 @@
  *     integration/adminController.test.ts で追加する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/pin-channel.test.ts
+++ b/packages/server/src/__tests__/pin-channel.test.ts
@@ -4,9 +4,9 @@
  *       pinned_channels テーブルへの CRUD 操作と、ユーザーごとの永続化を検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/pin-message.test.ts
+++ b/packages/server/src/__tests__/pin-message.test.ts
@@ -4,9 +4,9 @@
  * 外部キー制約を満たすため beforeAll でユーザー・チャンネル・メッセージを挿入する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/quote-reply.test.ts
+++ b/packages/server/src/__tests__/quote-reply.test.ts
@@ -4,9 +4,9 @@
  * 外部キー制約を満たすため beforeAll でユーザー・チャンネルを挿入する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/rateLimit.test.ts
+++ b/packages/server/src/__tests__/rateLimit.test.ts
@@ -14,9 +14,9 @@
  *   - Socket イベントハンドラは rateLimitService をモックして検証
  */
 
-import { getSharedTestDatabase } from './__fixtures__/pgTestHelper';
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/reminder.test.ts
+++ b/packages/server/src/__tests__/reminder.test.ts
@@ -1,9 +1,9 @@
 // テスト対象: リマインダー機能 (POST /api/reminders, GET /api/reminders, DELETE /api/reminders/:id, 通知処理)
 // 戦略: Express ルートハンドラを supertest で結合テスト。DB は pg-mem のインメモリ、Socket.IO はモックで差し替える
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/routes/guestLinks.test.ts
+++ b/packages/server/src/__tests__/routes/guestLinks.test.ts
@@ -7,9 +7,9 @@
  *   - 既存 routes/messages.ts や middleware/auth.ts への副作用がないことを境界として確認する
  */
 
-import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/saved-view.test.ts
+++ b/packages/server/src/__tests__/saved-view.test.ts
@@ -12,14 +12,14 @@
  *   一意制約: (user_id, name)
  *
  * 戦略:
- *   - getSharedTestDatabase() + resetTestData() でインメモリDB共有
+ *   - createTestDatabase() + resetTestData() でインメモリDB共有
  *   - savedViewService 関数を直接呼び出すユニットテスト
  *   - HTTP エンドポイントを supertest で検証する統合テスト
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/scheduledMessage.test.ts
+++ b/packages/server/src/__tests__/scheduledMessage.test.ts
@@ -6,9 +6,9 @@
 //     サービス層を直接呼んで検証する（setInterval はテスト中起動しない）
 //   - タイムゾーンは UTC 保存 / 入力は ISO 文字列で受け取る前提を検証する
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../db/database', () => testDb);
 
 // Socket.IO サーバーモック

--- a/packages/server/src/__tests__/services/guestLinkService.test.ts
+++ b/packages/server/src/__tests__/services/guestLinkService.test.ts
@@ -7,9 +7,9 @@
  *   - 公開メッセージ取得が読み取り専用（DM・スレッド・リアクションを含まない）であることを検証する
  */
 
-import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/task.test.ts
+++ b/packages/server/src/__tests__/task.test.ts
@@ -5,9 +5,9 @@
  * タスク作成・更新・削除・フィルタ・並べ替えのビジネスロジックを検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/threadReply.test.ts
+++ b/packages/server/src/__tests__/threadReply.test.ts
@@ -4,9 +4,9 @@
  * 外部キー制約を満たすため beforeAll でユーザー・チャンネルを挿入する。
  */
 
-import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/unit/auth.test.ts
+++ b/packages/server/src/__tests__/unit/auth.test.ts
@@ -11,9 +11,9 @@
  * 本番 DB に影響を与えずに各テストを独立して実行できるようにしている。
  */
 
-import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../../db/database', () => testDb);
 

--- a/packages/server/src/__tests__/unit/calendarReminderWorker.test.ts
+++ b/packages/server/src/__tests__/unit/calendarReminderWorker.test.ts
@@ -5,7 +5,7 @@
  *  - jobs/calendarReminderWorker.ts の pickDueReminders / runOnce / ライフサイクル
  *
  * 戦略:
- *  - pg-mem インメモリ DB を共有（getSharedTestDatabase）
+ *  - pg-mem インメモリ DB を共有（createTestDatabase）
  *  - 時刻は runOnce(now) / pickDueReminders(now) に Date を渡して制御
  *  - messageService.createMessage は jest.mock してメッセージ投稿の引数と回数を検証
  *  - 既存 unit/scheduledMessageWorker.test.ts のパターンを踏襲
@@ -13,9 +13,9 @@
  * 関連 Issue: #152
  */
 
-import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 jest.mock('../../db/database', () => testDb);
 
 const mockCreateMessage = jest.fn();

--- a/packages/server/src/__tests__/unit/inviteService.test.ts
+++ b/packages/server/src/__tests__/unit/inviteService.test.ts
@@ -5,9 +5,9 @@
  *       redeem のトランザクション整合性（行ロック・条件付き UPDATE）を重点検証する。
  */
 
-import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
 
-const testDb = getSharedTestDatabase();
+const testDb = createTestDatabase();
 
 jest.mock('../../db/database', () => testDb);
 


### PR DESCRIPTION
## 概要
\`npm test\` の並列実行（\`jest --maxWorkers=50%\`）で発生していた flaky 失敗を解消。

## 原因
36 テストファイルが \`getSharedTestDatabase()\`（worker 内シングルトン）を使い、worker 内の複数テストファイル間で同じ pg-mem DB を共有していた。並列ビルドの高負荷時に以下が発生:
- supertest のレスポンスが timing で 5xx になる
- 前テストファイルの async 後始末が次ファイルに漏れる

その結果、本来 pass するはずのテストが flaky で落ちる事象が発生していた。

### 観測されていた flaky 失敗例
- \`POST /api/events — Socket.IO 配信 / バリデーションエラー（400）時は new_message が emit されない\`
- \`監査ログ / 通報作成時に "report.create" が記録される\`
- \`POST /api/invites/:token/redeem / maxUses が 1 のとき 1 度だけ redeem できる\`

いずれも単独実行では pass、再実行で消える典型的な flaky。

## 変更内容
36 テストファイルで \`getSharedTestDatabase()\` を \`createTestDatabase()\` に sed 置換。各ファイルが独立した pg-mem DB を持つようになり、worker 競合が原理的に発生しない。

\`resetTestData()\` の利用は従来どおり（ファイル内のテスト間データ分離のため）。

## 影響範囲
- 36 ファイル（テストのみ）
- 実装変更なし
- pgTestHelper.ts の \`getSharedTestDatabase\` エクスポート自体は残置（破壊的変更を避ける）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1270 pass / 15 skip）
- [x] バックエンドユニットテストがすべてパスする（1360 tests）— **3 回連続実行で全件 pass を確認**
- [x] ビルドが正常に完了すること
- [x] (手動確認の場合) 確認した手順やスクリーンショット → サーバーテスト 3 連続実行: 17.5s / 12.0s / 12.5s（flaky なし）

## 関連Issue
Fixes #193

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない