### PR TITLE
feat: ScheduledMessagesDialog に ErrorBoundary を追加してエラーハンドリングを実装

### DIFF
--- a/packages/client/src/__tests__/ScheduledMessagesDialog.test.tsx
+++ b/packages/client/src/__tests__/ScheduledMessagesDialog.test.tsx
@@ -218,8 +218,18 @@ describe('ScheduledMessagesDialog', () => {
   });
 
   describe('エラーハンドリング', () => {
-    // #184 で機能追加されるまで保留
-    it.skip('一覧取得に失敗したときはエラーメッセージとリトライボタンが表示される', () => {});
+    it('一覧取得に失敗したときはエラーメッセージとリトライボタンが表示される', async () => {
+      const onRefresh = vi.fn();
+      const rejectedPromise = Promise.reject(new Error('fetch error'));
+      // unhandled rejection を抑制
+      rejectedPromise.catch(() => {});
+      await renderDialog({ promise: rejectedPromise, onRefresh });
+      expect(screen.getByText('読み込みに失敗しました')).toBeInTheDocument();
+      const retryBtn = screen.getByRole('button', { name: '再試行' });
+      expect(retryBtn).toBeInTheDocument();
+      fireEvent.click(retryBtn);
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
 
     it('キャンセル API がエラーを返したらスナックバーでエラー通知される', async () => {
       const onCancel = vi.fn().mockRejectedValue(new Error('サーバーエラー'));

--- a/packages/client/src/components/Chat/ScheduledMessagesDialog.tsx
+++ b/packages/client/src/components/Chat/ScheduledMessagesDialog.tsx
@@ -1,4 +1,5 @@
-import { use, useState, Suspense } from 'react';
+import { use, useState, Suspense, Component } from 'react';
+import type { ReactNode } from 'react';
 import {
   Box,
   Button,
@@ -45,6 +46,42 @@ const STATUS_COLORS: Record<string, 'default' | 'primary' | 'success' | 'error' 
   failed: 'error',
   canceled: 'default',
 };
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  onRefresh: () => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ScheduledMessagesErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Box sx={{ textAlign: 'center', py: 2 }}>
+          <Typography variant="body2" color="error" sx={{ mb: 1 }}>
+            読み込みに失敗しました
+          </Typography>
+          <Button size="small" onClick={this.props.onRefresh}>
+            再試行
+          </Button>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 function ScheduledMessageList({
   promise,
@@ -201,11 +238,17 @@ export default function ScheduledMessagesDialog({
     <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
       <DialogTitle>予約送信一覧</DialogTitle>
       <DialogContent>
-        <Suspense
-          fallback={<CircularProgress size={24} sx={{ display: 'block', mx: 'auto', my: 2 }} />}
-        >
-          <ScheduledMessageList promise={promise} onCancel={handleCancel} onUpdate={handleUpdate} />
-        </Suspense>
+        <ScheduledMessagesErrorBoundary onRefresh={onRefresh}>
+          <Suspense
+            fallback={<CircularProgress size={24} sx={{ display: 'block', mx: 'auto', my: 2 }} />}
+          >
+            <ScheduledMessageList
+              promise={promise}
+              onCancel={handleCancel}
+              onUpdate={handleUpdate}
+            />
+          </Suspense>
+        </ScheduledMessagesErrorBoundary>
       </DialogContent>
       <DialogActions>
         <Button onClick={onRefresh} size="small">


### PR DESCRIPTION
## 概要

`ScheduledMessagesDialog` は `<Suspense>` で予約一覧を読み込んでいたが、Promise が reject されたときの ErrorBoundary が存在せず、失敗時は永続的にローディング表示のままになっていた。本 PR で ErrorBoundary を追加し、エラー時に「読み込みに失敗しました」メッセージと「再試行」ボタンを表示するよう修正する。

## 変更内容

- `ScheduledMessagesDialog.tsx` に `ScheduledMessagesErrorBoundary` クラスコンポーネントを追加
  - Promise reject 時に「読み込みに失敗しました」テキストと「再試行」ボタンを表示
  - 再試行ボタン押下で `onRefresh` を呼び出す
  - `<Suspense>` を ErrorBoundary でラップして適用
- `ScheduledMessagesDialog.test.tsx` の `it.skip` テスト（#184 保留分）を `it` に変更し、アサーションを実装

## 影響範囲

- `packages/client/src/components/Chat/ScheduledMessagesDialog.tsx`
- `packages/client/src/__tests__/ScheduledMessagesDialog.test.tsx`

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（1271 件、うち ScheduledMessagesDialog 13 件）
- [x] バックエンドユニットテストがすべてパスする（変更なし）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #184

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）