### PR TITLE
feat: CreateChannelDialog と ChannelTopicBar に TagInput / TagChip を統合 (#187)

### DIFF
--- a/packages/client/src/__tests__/ChannelTopic.test.tsx
+++ b/packages/client/src/__tests__/ChannelTopic.test.tsx
@@ -217,11 +217,65 @@ describe('トピック編集ダイアログ', () => {
   });
 
   // #115 タグ機能 — ChannelTopicBar でのチャンネルタグ表示
-  // ChannelTopicBar にタグ表示が未統合のため #187 で機能追加されるまで保留
   describe('チャンネルタグ表示 (#115)', () => {
-    it.skip('channel.tags が存在するとき TopicBar にタグチップが並んで表示される', () => {});
-    it.skip('channel.tags が空配列のときタグ表示エリアは描画されない', () => {});
-    it.skip('タグチップをクリックすると onTagClick が tag.name を引数に呼ばれる', () => {});
+    it('channel.tags が存在するとき TopicBar にタグチップが並んで表示される', () => {
+      const channel = {
+        ...baseChannel,
+        tags: [
+          { id: 1, name: 'frontend', useCount: 3, createdAt: '2024-01-01T00:00:00Z' },
+          { id: 2, name: 'react', useCount: 1, createdAt: '2024-01-01T00:00:00Z' },
+        ],
+      };
+      render(
+        <ChannelTopicBar
+          channel={channel}
+          currentUserId={2}
+          userRole="user"
+          onTopicUpdated={vi.fn()}
+          onTagClick={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText('#frontend')).toBeInTheDocument();
+      expect(screen.getByText('#react')).toBeInTheDocument();
+    });
+
+    it('channel.tags が空配列のときタグ表示エリアは描画されない', () => {
+      const channel = { ...baseChannel, tags: [] };
+      render(
+        <ChannelTopicBar
+          channel={channel}
+          currentUserId={2}
+          userRole="user"
+          onTopicUpdated={vi.fn()}
+          onTagClick={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('channel-tags')).not.toBeInTheDocument();
+    });
+
+    it('タグチップをクリックすると onTagClick が tag.name を引数に呼ばれる', async () => {
+      const user = userEvent.setup();
+      const onTagClick = vi.fn();
+      const channel = {
+        ...baseChannel,
+        tags: [{ id: 1, name: 'frontend', useCount: 3, createdAt: '2024-01-01T00:00:00Z' }],
+      };
+      render(
+        <ChannelTopicBar
+          channel={channel}
+          currentUserId={2}
+          userRole="user"
+          onTopicUpdated={vi.fn()}
+          onTagClick={onTagClick}
+        />,
+      );
+
+      await user.click(screen.getByText('#frontend'));
+
+      expect(onTagClick).toHaveBeenCalledWith('frontend');
+    });
   });
 });
 

--- a/packages/client/src/__tests__/CreateChannelDialog.test.tsx
+++ b/packages/client/src/__tests__/CreateChannelDialog.test.tsx
@@ -27,10 +27,14 @@ vi.mock('../api/client', () => ({
     auth: {
       users: vi.fn(),
     },
+    tags: {
+      suggestions: vi.fn().mockResolvedValue({ suggestions: [] }),
+    },
   },
 }));
 
 import { api } from '../api/client';
+import { _resetSuggestionsCacheForTest } from '../hooks/useTagSuggestions';
 const mockCreate = api.channels.create as ReturnType<typeof vi.fn>;
 const mockUsers = api.auth.users as ReturnType<typeof vi.fn>;
 
@@ -58,6 +62,10 @@ const defaultProps = {
 
 beforeEach(() => {
   vi.resetAllMocks();
+  _resetSuggestionsCacheForTest();
+  // TagInput 内部の useTagSuggestions が api.tags.suggestions を呼ぶため、
+  // resetAllMocks 後に毎回デフォルト値を設定する
+  (api.tags.suggestions as ReturnType<typeof vi.fn>).mockResolvedValue({ suggestions: [] });
   user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
 });
 
@@ -270,10 +278,36 @@ describe('CreateChannelDialog', () => {
   });
 
   // #115 タグ機能 — チャンネル作成時のタグ付与
-  // CreateChannelDialog に TagInput が未統合のため #187 で機能追加されるまで保留
   describe('タグ付与 (#115)', () => {
-    it.skip('TagInput に入力したタグ名が submit 時に create API の tagNames に渡される', () => {});
-    it.skip('タグを指定しない場合は tagNames が空配列または未指定で API が呼ばれる', () => {});
+    it('TagInput に入力したタグ名が submit 時に create API の tagNames に渡される', async () => {
+      mockCreate.mockResolvedValue({ channel: makeChannel(1, 'tagged') });
+
+      render(<CreateChannelDialog {...defaultProps} />);
+      await user.type(screen.getByLabelText(/channel name/i), 'tagged');
+      // TagInput の入力欄にタグ名を入力して Enter で確定
+      await user.type(screen.getByLabelText(/タグ入力/i), 'frontend{Enter}');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() =>
+        expect(mockCreate).toHaveBeenCalledWith(
+          expect.objectContaining({ tagNames: ['frontend'] }),
+        ),
+      );
+    });
+
+    it('タグを指定しない場合は tagNames が空配列または未指定で API が呼ばれる', async () => {
+      mockCreate.mockResolvedValue({ channel: makeChannel(1, 'no-tags') });
+
+      render(<CreateChannelDialog {...defaultProps} />);
+      await user.type(screen.getByLabelText(/channel name/i), 'no-tags');
+      await user.click(screen.getByRole('button', { name: /^create$/i }));
+
+      await waitFor(() => {
+        const call = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+        const tagNames = call.tagNames;
+        expect(!tagNames || (Array.isArray(tagNames) && tagNames.length === 0)).toBe(true);
+      });
+    });
   });
 
   // #113 投稿権限制御チャンネル — 作成時の権限選択

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -137,6 +137,7 @@ export const api = {
       isPrivate?: boolean;
       memberIds?: number[];
       postingPermission?: ChannelPostingPermission;
+      tagNames?: string[];
     }) =>
       request<{ channel: Channel }>('/channels', {
         method: 'POST',
@@ -146,6 +147,7 @@ export const api = {
           is_private: data.isPrivate,
           memberIds: data.memberIds,
           postingPermission: data.postingPermission,
+          tagNames: data.tagNames,
         }),
       }),
     delete: (id: number) => request<void>(`/channels/${id}`, { method: 'DELETE' }),

--- a/packages/client/src/components/Channel/ChannelTopicBar.tsx
+++ b/packages/client/src/components/Channel/ChannelTopicBar.tsx
@@ -25,12 +25,14 @@ import { api } from '../../api/client';
 import { useSnackbar } from '../../contexts/SnackbarContext';
 import InviteLinkDialog from './InviteLinkDialog';
 import GuestLinkDialog from './GuestLinkDialog';
+import TagChip from '../Chat/TagChip';
 
 interface Props {
   channel: Channel;
   currentUserId: number;
   userRole: string;
   onTopicUpdated: (channel: Channel) => void;
+  onTagClick?: (tagName: string) => void;
 }
 
 export default function ChannelTopicBar({
@@ -38,6 +40,7 @@ export default function ChannelTopicBar({
   currentUserId,
   userRole,
   onTopicUpdated,
+  onTagClick,
 }: Props) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
@@ -104,6 +107,16 @@ export default function ChannelTopicBar({
           </Typography>
         )}
         {!channel.topic && <Box sx={{ flexGrow: 1 }} />}
+        {channel.tags && channel.tags.length > 0 && (
+          <Box
+            data-testid="channel-tags"
+            sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center', mr: 0.5 }}
+          >
+            {channel.tags.map((tag) => (
+              <TagChip key={tag.id} tag={tag} onClick={onTagClick} />
+            ))}
+          </Box>
+        )}
         {canEdit && (
           <>
             <Tooltip title="招待リンクを作成">

--- a/packages/client/src/components/Channel/CreateChannelDialog.tsx
+++ b/packages/client/src/components/Channel/CreateChannelDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@mui/material';
 import { api } from '../../api/client';
 import type { Channel, ChannelPostingPermission, User } from '@chat-app/shared';
+import TagInput from '../Chat/TagInput';
 
 interface Props {
   open: boolean;
@@ -68,6 +69,7 @@ export default function CreateChannelDialog({ open, onClose, onCreate }: Props) 
   const [isPrivate, setIsPrivate] = useState(false);
   const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [postingPermission, setPostingPermission] = useState<ChannelPostingPermission>('everyone');
+  const [tagNames, setTagNames] = useState<string[]>([]);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -94,6 +96,7 @@ export default function CreateChannelDialog({ open, onClose, onCreate }: Props) 
         isPrivate,
         memberIds: isPrivate ? selectedIds : [],
         postingPermission,
+        tagNames,
       });
       onCreate(channel);
       setName('');
@@ -101,6 +104,7 @@ export default function CreateChannelDialog({ open, onClose, onCreate }: Props) 
       setIsPrivate(false);
       setSelectedIds([]);
       setPostingPermission('everyone');
+      setTagNames([]);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create channel');
@@ -130,6 +134,11 @@ export default function CreateChannelDialog({ open, onClose, onCreate }: Props) 
             fullWidth
             multiline
             rows={2}
+          />
+          <TagInput
+            value={tagNames}
+            onChange={setTagNames}
+            placeholder="タグを追加（例: frontend）"
           />
           <FormControlLabel
             control={


### PR DESCRIPTION
## 概要

Issue #187 対応。チャンネル作成ダイアログとチャンネルヘッダーバーに既存のタグ UI コンポーネントを統合する。

## 変更内容

- `CreateChannelDialog.tsx` に既存の `TagInput` を組み込み、確定したタグ名を `tagNames` として `api.channels.create` に渡すよう実装
- `ChannelTopicBar.tsx` に `channel.tags` が存在するとき `TagChip` を並べて表示し、`onTagClick` コールバック経由でタグ名を通知する実装を追加
- `api/client.ts` の `channels.create` 型定義に `tagNames?: string[]` を追加
- `CreateChannelDialog.test.tsx` の `it.skip` 2件を `it` に有効化してテストロジックを実装
- `ChannelTopic.test.tsx` の `it.skip` 3件を `it` に有効化してテストロジックを実装
- `CreateChannelDialog.test.tsx` のモックに `api.tags.suggestions` を追加（`TagInput` 内部の `useTagSuggestions` が要求するため）

## 影響範囲

- `packages/client/src/components/Channel/CreateChannelDialog.tsx`
- `packages/client/src/components/Channel/ChannelTopicBar.tsx`
- `packages/client/src/api/client.ts`
- `packages/client/src/__tests__/CreateChannelDialog.test.tsx`
- `packages/client/src/__tests__/ChannelTopic.test.tsx`

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（1276 passed / 9 skipped）
- [x] バックエンドユニットテストがすべてパスする（変更なし）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #187

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した