### PR TITLE
feat: ChannelList の isArchived フィルタ + Socket リアルタイム反映 (#188)

### DIFF
--- a/packages/client/src/__tests__/ChannelList.test.tsx
+++ b/packages/client/src/__tests__/ChannelList.test.tsx
@@ -424,12 +424,72 @@ describe('ChannelList', () => {
       expect(screen.getByText('# active2')).toBeInTheDocument();
     });
 
-    // 以下 5 件は #188（クライアント側 isArchived フィルタ + Socket ハンドラ）で機能追加されるまで保留
-    it.skip('isArchived=true のチャンネルはサイドバー一覧に表示されない', () => {});
-    it.skip('アーカイブ済みチャンネルとそうでないチャンネルが混在する場合、アーカイブ済みのみ非表示になる', () => {});
-    it.skip('ピン留め済みかつアーカイブ済みのチャンネルはピン留めセクションにも表示されない', () => {});
-    it.skip('アーカイブ済みチャンネルは検索結果にも表示されない', () => {});
-    it.skip('Socket経由でチャンネルがアーカイブされた場合、リアルタイムでサイドバーから消える', () => {});
+    it('isArchived=true のチャンネルはサイドバー一覧に表示されない', async () => {
+      mockList.mockResolvedValue({
+        channels: [makeChannel(1, 'archived-ch', false, 0, true)],
+      });
+      await renderChannelList({ activeChannelId: null, onSelect: vi.fn() });
+      expect(screen.queryByText('# archived-ch')).not.toBeInTheDocument();
+    });
+
+    it('アーカイブ済みチャンネルとそうでないチャンネルが混在する場合、アーカイブ済みのみ非表示になる', async () => {
+      mockList.mockResolvedValue({
+        channels: [
+          makeChannel(1, 'active-ch', false, 0, false),
+          makeChannel(2, 'archived-ch', false, 0, true),
+        ],
+      });
+      await renderChannelList({ activeChannelId: null, onSelect: vi.fn() });
+      expect(screen.getByText('# active-ch')).toBeInTheDocument();
+      expect(screen.queryByText('# archived-ch')).not.toBeInTheDocument();
+    });
+
+    it('ピン留め済みかつアーカイブ済みのチャンネルはピン留めセクションにも表示されない', async () => {
+      // ピン留めIDを localStorage に事前登録する（userId=1 のキー）
+      localStorage.setItem('channel_pins_1', JSON.stringify([2]));
+      mockList.mockResolvedValue({
+        channels: [
+          makeChannel(1, 'active-ch', false, 0, false),
+          makeChannel(2, 'archived-pinned', false, 0, true),
+        ],
+      });
+      await renderChannelList({ activeChannelId: null, onSelect: vi.fn() });
+      expect(screen.queryByTestId('pinned-channels')).not.toBeInTheDocument();
+      expect(screen.queryByText('# archived-pinned')).not.toBeInTheDocument();
+    });
+
+    it('アーカイブ済みチャンネルは検索結果にも表示されない', async () => {
+      mockList.mockResolvedValue({
+        channels: [
+          makeChannel(1, 'active-search', false, 0, false),
+          makeChannel(2, 'archived-search', false, 0, true),
+        ],
+      });
+      await renderChannelList({ activeChannelId: null, onSelect: vi.fn() });
+
+      await userEvent.type(screen.getByPlaceholderText(/search/i), 'search');
+
+      expect(screen.getByText('# active-search')).toBeInTheDocument();
+      expect(screen.queryByText('# archived-search')).not.toBeInTheDocument();
+    });
+
+    it('Socket経由でチャンネルがアーカイブされた場合、リアルタイムでサイドバーから消える', async () => {
+      mockList.mockResolvedValue({
+        channels: [makeChannel(1, 'general'), makeChannel(2, 'to-archive')],
+      });
+      await renderChannelList({ activeChannelId: null, onSelect: vi.fn() });
+
+      expect(screen.getByText('# to-archive')).toBeInTheDocument();
+
+      act(() => {
+        capturedHandlers['channel:archived']?.({ channelId: 2 });
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByText('# to-archive')).not.toBeInTheDocument();
+      });
+      expect(screen.getByText('# general')).toBeInTheDocument();
+    });
   });
 
   describe('ドラッグ&ドロップによるカテゴリ間移動', () => {

--- a/packages/client/src/__tests__/__fixtures__/channels.ts
+++ b/packages/client/src/__tests__/__fixtures__/channels.ts
@@ -3,7 +3,13 @@ import type { Channel, Message } from '@chat-app/shared';
 /**
  * テスト共通フィクスチャ: Channel / Message ファクトリ（ChannelList テスト用）
  */
-export function makeChannel(id: number, name: string, isPrivate = false, unreadCount = 0): Channel {
+export function makeChannel(
+  id: number,
+  name: string,
+  isPrivate = false,
+  unreadCount = 0,
+  isArchived = false,
+): Channel {
   return {
     id,
     name,
@@ -14,6 +20,7 @@ export function makeChannel(id: number, name: string, isPrivate = false, unreadC
     isPrivate,
     postingPermission: 'everyone',
     unreadCount,
+    isArchived,
   };
 }
 

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -301,6 +301,20 @@ function ChannelListContent({
     };
   }, [socket]);
 
+  // channel:archived を受信してリアルタイムでサイドバーから除去（#188）
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleChannelArchived = (data: { channelId: number }) => {
+      setChannels((prev) => prev.filter((ch) => ch.id !== data.channelId));
+    };
+
+    socket.on('channel:archived', handleChannelArchived);
+    return () => {
+      socket.off('channel:archived', handleChannelArchived);
+    };
+  }, [socket]);
+
   const handleSelect = (channelId: number) => {
     // 即時リセット（API レスポンス待ちなし）
     setChannels((prev) =>
@@ -478,9 +492,12 @@ function ChannelListContent({
     }
   };
 
+  // isArchived=true のチャンネルはサイドバーに表示しない（#188）
+  const activeChannels = channels.filter((ch) => !ch.isArchived);
+
   const filteredChannels = searchQuery
-    ? channels.filter((ch) => ch.name.toLowerCase().includes(searchQuery.toLowerCase()))
-    : channels;
+    ? activeChannels.filter((ch) => ch.name.toLowerCase().includes(searchQuery.toLowerCase()))
+    : activeChannels;
 
   const pinnedChannels = filteredChannels.filter((ch) => pinnedIds.includes(ch.id));
   const unpinnedChannels = filteredChannels.filter((ch) => !pinnedIds.includes(ch.id));

--- a/packages/server/src/controllers/channelController.ts
+++ b/packages/server/src/controllers/channelController.ts
@@ -4,6 +4,7 @@ import * as auditLogService from '../services/auditLogService';
 import { AuthenticatedRequest } from '../middleware/auth';
 import { queryOne } from '../db/database';
 import type { ChannelPostingPermission } from '@chat-app/shared';
+import { getSocketServer } from '../socket';
 
 export async function getChannels(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
@@ -203,6 +204,9 @@ export async function archiveChannel(
       targetType: 'channel',
       targetId: channelId,
     });
+    // 全接続クライアントにアーカイブをリアルタイム通知
+    const io = getSocketServer();
+    io?.emit('channel:archived', { channelId });
     res.json({ channel });
   } catch (err) {
     next(err);

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -56,6 +56,8 @@ export interface ServerToClientEvents {
   // #146 プレゼンス（オンライン/オフラインステータス）
   'presence:bulk': (data: PresenceBulk) => void;
   'presence:state': (data: PresenceUpdate) => void;
+  // #188 チャンネルアーカイブのリアルタイム反映
+  'channel:archived': (data: { channelId: number }) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
## 概要

サイドバーのチャンネル一覧でアーカイブ済みチャンネルが表示されてしまう問題を修正。クライアント側フィルタとSocket経由のリアルタイム除去を実装する。

## 変更内容

- `packages/shared/src/types/socket.ts`: `ServerToClientEvents` に `channel:archived` イベントを追加
- `packages/server/src/controllers/channelController.ts`: `archiveChannel` 処理後に `io.emit('channel:archived', { channelId })` を送信
- `packages/client/src/components/Channel/ChannelList.tsx`:
  - `filteredChannels` の前段に `isArchived=true` を除外する `activeChannels` フィルタを追加（ピン留め・検索・カテゴリセクション全てに適用）
  - `channel:archived` Socket イベントを購読して `setChannels(prev => prev.filter(...))` でリアルタイム除去するハンドラを追加
- `packages/client/src/__tests__/__fixtures__/channels.ts`: `makeChannel` に `isArchived` 第5引数を追加
- `packages/client/src/__tests__/ChannelList.test.tsx`: 5件の `it.skip` を有効化・実装

## 影響範囲

- `ChannelList.tsx`: サイドバーのチャンネル表示ロジック（ピン留め・検索・カテゴリ分類全てに影響）
- `ArchivedChannelsDialog`: 変更なし（アーカイブ済みチャンネル一覧は別 API / 別コンポーネントで表示）
- `channelController.ts`: archiveChannel のみ変更、他のアクションに影響なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1285件: 1281 passed, 4 skipped）
- [x] バックエンドユニットテストがすべてパスする（1360件: 1360 passed）
- [x] ビルドが正常に完了すること

## 関連Issue
Fixes #188

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）