### PR TITLE
feat(layout): AppLayout 3 列グリッド化 + Rail 新設 (Step 2a)

### DIFF
--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -1,21 +1,20 @@
 /**
  * components/Layout/AppLayout.tsx のユニットテスト
  *
- * テスト対象: アプリ共通レイアウト（ヘッダー表示名）
+ * テスト対象: アプリ共通レイアウト（ヘッダー表示名 / Rail 統合 / 3 列グリッド）
  * 戦略:
- *   - AuthContext をモックして現在のユーザー情報を注入する
- *   - usePushNotifications をモックして通知機能を無効化する
- *   - useNavigate をモックしてルーティングを差し替える
+ *   - AuthContext / ThemeContext / SocketContext / usePushNotifications をモックする
+ *   - react-router-dom は実体を使い MemoryRouter でラップする（NavLink を使う Rail のため）
  */
 
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import AppLayout from '../components/Layout/AppLayout';
 
 vi.mock('../contexts/AuthContext', () => ({
-  useAuth: () => ({ user: mockUser, logout: vi.fn() }),
+  useAuth: () => ({ user: mockUser, logout: vi.fn(), updateUser: vi.fn() }),
 }));
 
 vi.mock('../contexts/ThemeContext', () => ({
@@ -33,10 +32,6 @@ vi.mock('../hooks/usePushNotifications', () => ({
   }),
 }));
 
-vi.mock('react-router-dom', () => ({
-  useNavigate: () => vi.fn(),
-}));
-
 vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => null,
 }));
@@ -46,6 +41,7 @@ const mockUser = {
   username: 'alice',
   email: 'alice@example.com',
   displayName: null as string | null,
+  role: 'user' as 'user' | 'admin',
   location: null,
   avatarUrl: null,
   createdAt: '2024-01-01T00:00:00Z',
@@ -53,13 +49,14 @@ const mockUser = {
 
 beforeEach(() => {
   mockUser.displayName = null;
+  mockUser.role = 'user';
 });
 
-function renderLayout(sidebarContent?: React.ReactNode) {
+function renderLayout(sidebarContent?: React.ReactNode, mainContent?: React.ReactNode) {
   return render(
-    <AppLayout sidebar={sidebarContent ?? <div />}>
-      <div />
-    </AppLayout>,
+    <MemoryRouter>
+      <AppLayout sidebar={sidebarContent ?? <div />}>{mainContent ?? <div />}</AppLayout>
+    </MemoryRouter>,
   );
 }
 
@@ -78,38 +75,32 @@ describe('AppLayout', () => {
   });
 
   // ----------------------------------------------------------------
-  // タスクボードナビゲーション #151
+  // Step 2a: 3 列グリッド + Rail 統合
+  // 既存の「タスクボードナビゲーション」「チャットナビゲーション」テストは
+  // Rail.test.tsx に移管したため削除。AppLayout 側では「Rail が表示される」
+  // 「3 列グリッド構造である」のみ確認する。
   // ----------------------------------------------------------------
-  describe('タスクボードナビゲーション', () => {
-    it('サイドバーに「タスクボード」へのナビリンクが表示される', () => {
+  describe('Rail との統合', () => {
+    it('Rail コンポーネントの代表的なナビ（ホーム）が AppLayout 内に表示される', () => {
       renderLayout();
-      expect(screen.getByRole('button', { name: 'タスクボード' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'ホーム' })).toBeInTheDocument();
     });
 
-    it('タスクボードリンクをクリックすると /tasks へ遷移する', async () => {
+    it('AppLayout のレイアウト要素が grid 表示で 3 列構造になっている', () => {
       renderLayout();
-      // navigate は vi.mock('react-router-dom') で vi.fn() に差し替え済み
-      // ボタンをクリックしてもエラーにならないことを確認
-      const btn = screen.getByRole('button', { name: 'タスクボード' });
-      await userEvent.click(btn);
-      expect(btn).toBeInTheDocument();
-    });
-  });
-
-  // ----------------------------------------------------------------
-  // チャットナビゲーション
-  // ----------------------------------------------------------------
-  describe('チャットナビゲーション', () => {
-    it('サイドバーに「チャット」へのナビリンクが表示される', () => {
-      renderLayout();
-      expect(screen.getByRole('button', { name: 'チャット' })).toBeInTheDocument();
+      const grid = screen.getByTestId('app-layout-grid');
+      expect(grid).toHaveStyle({ display: 'grid' });
+      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr' });
     });
 
-    it('チャットリンクをクリックしてもエラーにならない', async () => {
-      renderLayout();
-      const btn = screen.getByRole('button', { name: 'チャット' });
-      await userEvent.click(btn);
-      expect(btn).toBeInTheDocument();
+    it('sidebar prop に渡したコンテンツが Sidebar 列に表示される', () => {
+      renderLayout(<div data-testid="custom-sidebar">SIDEBAR</div>);
+      expect(screen.getByTestId('custom-sidebar')).toBeInTheDocument();
+    });
+
+    it('children に渡したコンテンツが Main 列に表示される', () => {
+      renderLayout(undefined, <div data-testid="custom-main">MAIN</div>);
+      expect(screen.getByTestId('custom-main')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * components/Layout/Rail.tsx のユニットテスト
+ *
+ * テスト対象: 左 64px のアイコンレール
+ * 戦略:
+ *   - MemoryRouter でラップして react-router の NavLink を動作させる
+ *   - AuthContext をモックして role 切替を検証する
+ *   - aria-label / role="link" を頼りに各ナビ項目を特定する
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Rail from '../components/Layout/Rail';
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+const mockUser = {
+  id: 1,
+  username: 'alice',
+  email: 'alice@example.com',
+  displayName: null as string | null,
+  role: 'user' as 'user' | 'admin',
+  location: null,
+  avatarUrl: null,
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  mockUser.role = 'user';
+});
+
+function renderRail(initialPath = '/', role: 'user' | 'admin' = 'user') {
+  mockUser.role = role;
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Rail />
+    </MemoryRouter>,
+  );
+}
+
+describe('Rail', () => {
+  describe('ナビゲーション項目の表示', () => {
+    it('上部にホーム / DM / カレンダー / タスク / ブックマークの 5 つのアイコンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'ホーム' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'DM' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'カレンダー' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'タスク' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'ブックマーク' })).toBeInTheDocument();
+    });
+
+    it('区切り線の下にテンプレートのアイコンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'テンプレート' })).toBeInTheDocument();
+    });
+
+    it('admin ロールのとき、下部に管理アイコンが表示される', () => {
+      renderRail('/', 'admin');
+      expect(screen.getByRole('link', { name: '管理' })).toBeInTheDocument();
+    });
+
+    it('user ロールのとき、下部に管理アイコンが表示されない', () => {
+      renderRail('/', 'user');
+      expect(screen.queryByRole('link', { name: '管理' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('リンク先', () => {
+    it('ホームアイコンは / にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'ホーム' })).toHaveAttribute('href', '/');
+    });
+
+    it('DM アイコンは /dm にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'DM' })).toHaveAttribute('href', '/dm');
+    });
+
+    it('カレンダーアイコンは /calendar にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'カレンダー' })).toHaveAttribute('href', '/calendar');
+    });
+
+    it('タスクアイコンは /tasks にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'タスク' })).toHaveAttribute('href', '/tasks');
+    });
+
+    it('ブックマークアイコンは /bookmarks にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'ブックマーク' })).toHaveAttribute(
+        'href',
+        '/bookmarks',
+      );
+    });
+
+    it('テンプレートアイコンは /templates にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: 'テンプレート' })).toHaveAttribute(
+        'href',
+        '/templates',
+      );
+    });
+
+    it('admin ロール時、管理アイコンは /admin にリンクする', () => {
+      renderRail('/', 'admin');
+      expect(screen.getByRole('link', { name: '管理' })).toHaveAttribute('href', '/admin');
+    });
+  });
+
+  describe('現在のパスのハイライト (aria-current)', () => {
+    it('現在のパスが /dm のとき、DM アイコンに aria-current="page" が付与される', () => {
+      renderRail('/dm');
+      expect(screen.getByRole('link', { name: 'DM' })).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('現在のパスが /calendar のとき、カレンダーアイコンに aria-current="page" が付与される', () => {
+      renderRail('/calendar');
+      expect(screen.getByRole('link', { name: 'カレンダー' })).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+    });
+
+    it('現在のパスが /tasks のとき、タスクアイコンに aria-current="page" が付与される', () => {
+      renderRail('/tasks');
+      expect(screen.getByRole('link', { name: 'タスク' })).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('現在のパスが /tasks のとき、ホームアイコンには aria-current が付与されない', () => {
+      renderRail('/tasks');
+      expect(screen.getByRole('link', { name: 'ホーム' })).not.toHaveAttribute('aria-current');
+    });
+
+    it('現在のパスが / のとき、ホームアイコンに aria-current="page" が付与される', () => {
+      renderRail('/');
+      expect(screen.getByRole('link', { name: 'ホーム' })).toHaveAttribute('aria-current', 'page');
+    });
+  });
+});

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -10,6 +10,7 @@
 
 import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Task } from '@chat-app/shared';
 
@@ -94,9 +95,15 @@ vi.mock('../hooks/usePushNotifications', () => ({
 }));
 
 const mockNavigate = vi.fn();
-vi.mock('react-router-dom', () => ({
-  useNavigate: () => mockNavigate,
-}));
+// AppLayout が Rail (NavLink を含む) をレンダーするため、react-router-dom の他の export
+// (NavLink / MemoryRouter / useLocation 等) は実体を残し、useNavigate のみ差し替える
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => null,
@@ -203,7 +210,11 @@ describe('TaskBoardPage', () => {
     it('「未着手」「進行中」「完了」の 3 列が表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('未着手')).toBeInTheDocument();
@@ -215,7 +226,11 @@ describe('TaskBoardPage', () => {
     it('各列にタスクカードが status に応じて振り分けられて表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('TODO タスク')).toBeInTheDocument();
@@ -228,7 +243,11 @@ describe('TaskBoardPage', () => {
       mockTasksList.mockResolvedValue({ tasks: [] });
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         const emptyMessages = screen.getAllByText('タスクなし');
@@ -245,7 +264,11 @@ describe('TaskBoardPage', () => {
       mockTasksList.mockReturnValue(pendingPromise);
 
       const TaskBoardPage = await importTaskBoardPage();
-      render(<TaskBoardPage />);
+      render(
+        <MemoryRouter>
+          <TaskBoardPage />
+        </MemoryRouter>,
+      );
       expect(screen.getByRole('progressbar')).toBeInTheDocument();
 
       // クリーンアップのため resolve
@@ -260,7 +283,11 @@ describe('TaskBoardPage', () => {
     it('タスクのタイトルが表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('TODO タスク')).toBeInTheDocument();
@@ -270,7 +297,11 @@ describe('TaskBoardPage', () => {
     it('担当者が設定されているとき担当者名が表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText(/担当: alice/)).toBeInTheDocument();
@@ -280,7 +311,11 @@ describe('TaskBoardPage', () => {
     it('期限が設定されているとき期限日が表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText(/期限:/)).toBeInTheDocument();
@@ -290,7 +325,11 @@ describe('TaskBoardPage', () => {
     it('期限が過ぎているタスクは視覚的に強調表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         // 期限切れタスクカード（id=3）はボーダー付きで表示される
@@ -302,7 +341,11 @@ describe('TaskBoardPage', () => {
     it('source_message_id があるタスクは元メッセージへのリンクが表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('元メッセージ')).toBeInTheDocument();
@@ -314,7 +357,11 @@ describe('TaskBoardPage', () => {
     it('チャンネル選択フィルタが表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByRole('combobox', { name: /チャンネルで絞り込み/ })).toBeInTheDocument();
@@ -324,7 +371,11 @@ describe('TaskBoardPage', () => {
     it('特定チャンネルを選択すると、そのチャンネル発のタスクのみ表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('完了タスク')).toBeInTheDocument();
@@ -342,7 +393,11 @@ describe('TaskBoardPage', () => {
     it('「すべて」を選択するとフィルタが解除されて全タスクが表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('TODO タスク')).toBeInTheDocument();
@@ -356,7 +411,11 @@ describe('TaskBoardPage', () => {
     it('「新規タスク作成」ボタンをクリックすると CreateTaskDialog が開く', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /新規タスク作成/ })).toBeInTheDocument();
@@ -368,7 +427,11 @@ describe('TaskBoardPage', () => {
     it('CreateTaskDialog でタスクを作成すると API が呼ばれてリストが更新される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /新規タスク作成/ })).toBeInTheDocument();
@@ -388,7 +451,11 @@ describe('TaskBoardPage', () => {
       const { useDroppable } = await import('@dnd-kit/core');
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('column-todo')).toBeInTheDocument();
@@ -419,7 +486,11 @@ describe('TaskBoardPage', () => {
     it('タスクカードの削除ボタンをクリックすると確認なしに DELETE API が呼ばれる', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
@@ -436,7 +507,11 @@ describe('TaskBoardPage', () => {
       mockTasksDelete.mockResolvedValue(undefined);
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByText('TODO タスク')).toBeInTheDocument();
@@ -454,7 +529,11 @@ describe('TaskBoardPage', () => {
     it('ページ描画時に api.auth.users が呼ばれる', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(mockAuthUsers).toHaveBeenCalled();
@@ -464,7 +543,11 @@ describe('TaskBoardPage', () => {
     it('ページ描画時に api.channels.list が呼ばれる', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(mockChannelsList).toHaveBeenCalled();
@@ -476,7 +559,11 @@ describe('TaskBoardPage', () => {
     it('編集ボタンをクリックすると EditTaskDialog が開く', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
@@ -490,7 +577,11 @@ describe('TaskBoardPage', () => {
     it('EditTaskDialog を閉じると編集ダイアログが消える', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
@@ -510,7 +601,11 @@ describe('TaskBoardPage', () => {
     it('「非表示も表示」スイッチがツールバーに表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByLabelText('非表示タスクも表示')).toBeInTheDocument();
@@ -520,7 +615,11 @@ describe('TaskBoardPage', () => {
     it('タスクカードに非表示切り替えアイコンボタンが表示される', async () => {
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
@@ -535,7 +634,11 @@ describe('TaskBoardPage', () => {
       });
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
@@ -553,7 +656,11 @@ describe('TaskBoardPage', () => {
       mockTasksList.mockResolvedValue({ tasks: hiddenTasks });
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () => {
-        render(<TaskBoardPage />);
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
       });
       await waitFor(() => {
         expect(screen.getByTestId('task-card-1')).toBeInTheDocument();

--- a/packages/client/src/components/Layout/AppLayout.tsx
+++ b/packages/client/src/components/Layout/AppLayout.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, useRef, useEffect, useState } from 'react';
 import {
   Box,
-  Drawer,
   Toolbar,
   AppBar,
   Typography,
@@ -12,22 +11,14 @@ import {
   Alert,
   InputBase,
   Paper,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
 } from '@mui/material';
 import LogoutIcon from '@mui/icons-material/Logout';
-import MenuIcon from '@mui/icons-material/Menu';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import SearchIcon from '@mui/icons-material/Search';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
-import AssignmentIcon from '@mui/icons-material/Assignment';
-import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
-import ChatIcon from '@mui/icons-material/Chat';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
@@ -35,8 +26,10 @@ import { usePushNotifications } from '../../hooks/usePushNotifications';
 import { useSocket } from '../../contexts/SocketContext';
 import { api } from '../../api/client';
 import StatusEditDialog from '../User/StatusEditDialog';
+import Rail from './Rail';
 
-const DRAWER_WIDTH = 240;
+const RAIL_WIDTH = 64;
+const SIDEBAR_WIDTH = 240;
 
 interface Props {
   sidebar: ReactNode;
@@ -53,7 +46,6 @@ export default function AppLayout({
   onSearchChange,
   onSearchFocus,
 }: Props) {
-  const [sidebarOpen, setSidebarOpen] = useState(true);
   const [reminderNotification, setReminderNotification] = useState<string | null>(null);
   const [statusDialogOpen, setStatusDialogOpen] = useState(false);
   const { user, logout, updateUser } = useAuth();
@@ -113,20 +105,9 @@ export default function AppLayout({
   }, [onSearchChange]);
 
   return (
-    <Box sx={{ display: 'flex', height: '100vh' }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
         <Toolbar sx={{ gap: 1 }}>
-          <Tooltip title="サイドバーを開閉する">
-            <IconButton
-              color="inherit"
-              aria-label="サイドバーを開閉する"
-              aria-expanded={sidebarOpen}
-              onClick={() => setSidebarOpen((prev) => !prev)}
-            >
-              <MenuIcon />
-            </IconButton>
-          </Tooltip>
-
           <Typography variant="h6" sx={{ flexShrink: 0 }}>
             Chat App
           </Typography>
@@ -237,47 +218,44 @@ export default function AppLayout({
         </Toolbar>
       </AppBar>
 
-      <Drawer
-        variant="persistent"
-        open={sidebarOpen}
+      {/* AppBar の高さ分のスペーサー */}
+      <Toolbar />
+
+      {/* 3 列グリッド: [Rail 64px] [Sidebar 240px] [Main 1fr]
+          Step 5 で右端に Context rail (320px) を追加予定 */}
+      <Box
+        data-testid="app-layout-grid"
         sx={{
-          width: sidebarOpen ? DRAWER_WIDTH : 0,
-          flexShrink: 0,
-          transition: (theme) => theme.transitions.create('width'),
-          '& .MuiDrawer-paper': { width: DRAWER_WIDTH, boxSizing: 'border-box' },
+          flex: 1,
+          display: 'grid',
+          gridTemplateColumns: `${RAIL_WIDTH}px ${SIDEBAR_WIDTH}px 1fr`,
+          overflow: 'hidden',
+          minHeight: 0,
         }}
       >
-        <Toolbar />
-        {/* チャット / タスクボード (#151) / カレンダー (#152) ナビゲーション */}
-        <List dense>
-          <ListItemButton onClick={() => navigate('/')} aria-label="チャット">
-            <ListItemIcon>
-              <ChatIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="チャット" />
-          </ListItemButton>
-          <ListItemButton onClick={() => navigate('/calendar')} aria-label="カレンダー">
-            <ListItemIcon>
-              <CalendarMonthIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="カレンダー" />
-          </ListItemButton>
-          <ListItemButton onClick={() => navigate('/tasks')} aria-label="タスクボード">
-            <ListItemIcon>
-              <AssignmentIcon fontSize="small" />
-            </ListItemIcon>
-            <ListItemText primary="タスクボード" />
-          </ListItemButton>
-        </List>
-        {sidebar}
-      </Drawer>
+        <Rail />
 
-      <Box
-        component="main"
-        sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
-      >
-        <Toolbar />
-        <Box sx={{ flexGrow: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+        <Box
+          data-testid="app-layout-sidebar"
+          sx={{
+            overflow: 'auto',
+            borderRight: '1px solid var(--border)',
+            background: 'var(--surface)',
+          }}
+        >
+          {sidebar}
+        </Box>
+
+        <Box
+          component="main"
+          data-testid="app-layout-main"
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            minWidth: 0,
+          }}
+        >
           {children}
         </Box>
       </Box>

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -1,0 +1,108 @@
+import { ReactNode } from 'react';
+import { Box, Tooltip, Divider } from '@mui/material';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
+import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
+import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
+import BookmarkBorderOutlinedIcon from '@mui/icons-material/BookmarkBorderOutlined';
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
+import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettingsOutlined';
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+
+interface NavItem {
+  label: string;
+  to: string;
+  icon: ReactNode;
+  /** ルートパス "/" の部分一致を防ぐため。NavLink の end prop に渡す */
+  end?: boolean;
+}
+
+const TOP_ITEMS: NavItem[] = [
+  { label: 'ホーム', to: '/', icon: <HomeOutlinedIcon />, end: true },
+  { label: 'DM', to: '/dm', icon: <MailOutlineIcon /> },
+  { label: 'カレンダー', to: '/calendar', icon: <CalendarMonthOutlinedIcon /> },
+  { label: 'タスク', to: '/tasks', icon: <AssignmentOutlinedIcon /> },
+  { label: 'ブックマーク', to: '/bookmarks', icon: <BookmarkBorderOutlinedIcon /> },
+];
+
+const BOTTOM_ITEMS: NavItem[] = [
+  { label: 'テンプレート', to: '/templates', icon: <ArticleOutlinedIcon /> },
+];
+
+const ADMIN_ITEM: NavItem = {
+  label: '管理',
+  to: '/admin',
+  icon: <AdminPanelSettingsOutlinedIcon />,
+};
+
+function RailLink({ item }: { item: NavItem }) {
+  return (
+    <Tooltip title={item.label} placement="right">
+      <Box
+        component={NavLink}
+        to={item.to}
+        end={item.end}
+        aria-label={item.label}
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 40,
+          height: 40,
+          mx: 'auto',
+          my: 0.5,
+          borderRadius: 'var(--radius-md)',
+          color: 'var(--text-muted)',
+          textDecoration: 'none',
+          transition: 'background 120ms, color 120ms',
+          '&:hover': {
+            background: 'var(--surface-hover)',
+            color: 'var(--text)',
+          },
+          '&.active, &[aria-current="page"]': {
+            color: 'var(--accent)',
+            background: 'var(--accent-soft)',
+          },
+        }}
+      >
+        {item.icon}
+      </Box>
+    </Tooltip>
+  );
+}
+
+export default function Rail() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === 'admin';
+
+  return (
+    <Box
+      component="nav"
+      aria-label="メインナビゲーション"
+      sx={{
+        width: 64,
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'stretch',
+        py: 1,
+        background: 'var(--bg-elev)',
+        borderRight: '1px solid var(--border)',
+      }}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        {TOP_ITEMS.map((item) => (
+          <RailLink key={item.to} item={item} />
+        ))}
+      </Box>
+      <Divider sx={{ width: 32, mx: 'auto', my: 1, borderColor: 'var(--border)' }} />
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        {BOTTOM_ITEMS.map((item) => (
+          <RailLink key={item.to} item={item} />
+        ))}
+        {isAdmin && <RailLink item={ADMIN_ITEM} />}
+      </Box>
+    </Box>
+  );
+}


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ計画 Step 2a。プロンプトの Step 2 を **2a / 2b に分割** し、本 PR では「3 列グリッドの土台 + Rail 新設」の最小機能のみを実装する。AppBar 撤去・検索/ロゴ/ユーザーメニューの Rail 移設・未読バッジは Step 2b で実施。

## 変更内容

### 新規 `packages/client/src/components/Layout/Rail.tsx`
- 64px 幅のアイコンレール
- 上部ナビ: ホーム(`/`) / DM(`/dm`) / カレンダー(`/calendar`) / タスク(`/tasks`) / ブックマーク(`/bookmarks`)
- 下部ナビ: テンプレート(`/templates`) / 管理(`/admin`、admin ロールのみ表示)
- `react-router-dom` の `NavLink` を使用、自動的に `aria-current="page"` が付与
- ホームは `end` prop で部分マッチを抑止（`/tasks` 等で `/` がアクティブになるのを防ぐ）
- Step 1 で導入した CSS 変数 (`--accent` / `--bg-elev` / `--border` / `--accent-soft` / `--surface-hover` / `--text-muted` 等) を本格使用開始
- 検索 / ファイル / チャットアイコンは未実装ルートのため本 PR では省略（後続 Step で追加）

### `packages/client/src/components/Layout/AppLayout.tsx`
- MUI `Drawer` (persistent variant) を **完全撤去**
- `[Rail 64px] [Sidebar 240px] [Main 1fr]` の自前 `display: grid` に置換
- ハンバーガーメニュー削除（Sidebar は常時表示。モバイル対応の折り畳み/ドロワー化は Step 8）
- Drawer 内に直書きしていたチャット/カレンダー/タスクボードナビは Rail に移譲
- AppBar (検索 box / ステータス絵文字 + 表示名 / テーマ切替 / 通知 / プロフィール / ログアウト) は **そのまま維持**
- `data-testid="app-layout-grid"` / `app-layout-sidebar` / `app-layout-main` を付与しテスト容易性を確保

### テスト
- **新規** `Rail.test.tsx`: 16 ケース（表示 4 / リンク先 7 / `aria-current` 5）
- **更新** `AppLayout.test.tsx`:
  - 旧「タスクボードナビゲーション」「チャットナビゲーション」を削除（Rail 側でカバー）
  - 新規「Rail との統合」(4 ケース) を追加
  - `MemoryRouter` でラップする形に変更
- **更新** `TaskBoardPage.test.tsx`:
  - `vi.mock('react-router-dom', ...)` を `importActual` パターンに変更（`NavLink` 等の export を残すため）
  - 全 25 箇所の `render(<TaskBoardPage />)` を `MemoryRouter` ラップに変更
  - **アサーションは一切変更していない**（仕様変更による追従のみ）

## 影響範囲

- AppLayout を使う 3 ページ（`ChatPage` / `CalendarPage` / `TaskBoardPage`）すべてで Rail が表示される
- Sidebar 列の幅は既存と同じ 240px を維持。`ChannelList` の見え方は変化なし
- Drawer の開閉状態 (`sidebarOpen` state) を撤去したため、ハンバーガーボタンは消失
- ChatPage / CalendarPage / TaskBoardPage の動作は維持（既存 1308 テスト全 pass）

## Step 2a のスコープ外（Step 2b で実施）

- AppBar の完全撤去
- ロゴを Rail 最上部の四角ロゴに移動
- 検索 box を Rail の検索アイコンに移設
- ユーザーメニュー（ステータス / プロフィール / ログアウト）を Sidebar 列フッターに移設
- 未読バッジ（メンション数 / DM 未読数）の実装
- 検索 / ファイル / チャット アイコンの追加

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1308 / 1308 pass)
- [x] バックエンドユニットテストがすべてパスする (本 PR はバックエンド未変更)
- [x] ビルドが正常に完了すること (`npm run build` 成功 / CSS 27.35 kB)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット
  - **未実施**: 実機での目視確認（3 列レイアウトの見え方、Rail のハイライト、Sidebar 内 ChannelList の動作、ChatPage / CalendarPage / TaskBoardPage への遷移動作）はマージ前にレビュアー側で確認をお願いします。

## 関連Issue
なし（UI/UX ブラッシュアップ計画 `doc/brushup-uiux-plan/PROGRESS.md` を参照）

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
  - 進捗管理は本 PR マージ後に統合ブランチで `PROGRESS.md` のステータスを更新する
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)