### PR TITLE
feat(rail): DM 未読バッジを Rail に実装 (Step 2c)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -275,7 +275,8 @@ main
 |---|------|---------|---------------|------|
 | 1 | Rail の検索アイコンが disabled（クリックしても何も起きない） | Step 2b | Step 7 | ⚪ 未解決 |
 | 2 | 検索 UI が画面から消失（AppBar 撤去）。ChatPage 内の検索 state / `SearchResults` / `SearchFilterPanel` の描画ロジックは dead code として残置。Ctrl+F ショートカットも撤去 | Step 2b | Step 7 (検索ページ新設時に再構築 or 撤去判断) | ⚪ 未解決 |
-| 3 | Rail の未読バッジ未実装（メンション数 / DM 未読数） | Step 2b | Step 2c | ⚪ 未解決 |
+| 3 | Rail の DM 未読バッジ未実装 | Step 2b | Step 2c | 🟢 解決済み |
+| 5 | Rail のメンション数バッジ未実装 (Inbox 連動) | Step 2b | Step 6 (InboxPage) | ⚪ 未解決 |
 | 4 | Rail 最上部のロゴが暫定デザイン（"C" の四角） | Step 2b | 任意 Step（最終デザイン調整時） | ⚪ 未解決 |
 
 凡例: ⚪ 未解決 / 🟢 解決済み

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -17,6 +17,11 @@ vi.mock('../contexts/AuthContext', () => ({
   useAuth: () => ({ user: mockUser }),
 }));
 
+let mockDmUnreadCount = 0;
+vi.mock('../hooks/useDmUnreadCount', () => ({
+  useDmUnreadCount: () => mockDmUnreadCount,
+}));
+
 const mockUser = {
   id: 1,
   username: 'alice',
@@ -30,6 +35,7 @@ const mockUser = {
 
 beforeEach(() => {
   mockUser.role = 'user';
+  mockDmUnreadCount = 0;
 });
 
 function renderRail(initialPath = '/', role: 'user' | 'admin' = 'user') {
@@ -126,6 +132,34 @@ describe('Rail', () => {
       renderRail();
       const searchButton = screen.getByRole('button', { name: '検索' });
       expect(searchButton).toBeDisabled();
+    });
+  });
+
+  describe('DM 未読バッジ (Step 2c)', () => {
+    it('useDmUnreadCount が 0 を返すとき、DM アイコンにバッジは表示されない', () => {
+      mockDmUnreadCount = 0;
+      renderRail();
+      expect(screen.queryByText('5')).not.toBeInTheDocument();
+      expect(screen.queryByText('9+')).not.toBeInTheDocument();
+    });
+
+    it('useDmUnreadCount が 5 を返すとき、DM アイコンに "5" のバッジが表示される', () => {
+      mockDmUnreadCount = 5;
+      renderRail();
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('useDmUnreadCount が 12 を返すとき、DM アイコンに "9+" のバッジが表示される (max=9)', () => {
+      mockDmUnreadCount = 12;
+      renderRail();
+      expect(screen.getByText('9+')).toBeInTheDocument();
+    });
+
+    it('未読があるとき、DM アイコンの aria-label に未読数の情報が含まれる', () => {
+      mockDmUnreadCount = 3;
+      renderRail();
+      const dmLink = screen.getByRole('link', { name: /DM.*3.*未読/ });
+      expect(dmLink).toBeInTheDocument();
     });
   });
 

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -69,6 +69,10 @@ vi.mock('../api/client', () => ({
     channels: {
       list: (...args: unknown[]) => mockChannelsList(...args),
     },
+    // Step 2c: Rail 内 useDmUnreadCount が api.dm.listConversations を呼ぶため
+    dm: {
+      listConversations: () => Promise.resolve({ conversations: [] }),
+    },
   },
 }));
 

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Box, IconButton, Tooltip, Divider } from '@mui/material';
+import { Badge, Box, IconButton, Tooltip, Divider } from '@mui/material';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
@@ -10,6 +10,7 @@ import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettin
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
+import { useDmUnreadCount } from '../../hooks/useDmUnreadCount';
 
 interface NavItem {
   label: string;
@@ -37,14 +38,15 @@ const ADMIN_ITEM: NavItem = {
   icon: <AdminPanelSettingsOutlinedIcon />,
 };
 
-function RailLink({ item }: { item: NavItem }) {
+function RailLink({ item, badgeCount = 0 }: { item: NavItem; badgeCount?: number }) {
+  const ariaLabel = badgeCount > 0 ? `${item.label} (${badgeCount} 件未読)` : item.label;
   return (
-    <Tooltip title={item.label} placement="right">
+    <Tooltip title={ariaLabel} placement="right">
       <Box
         component={NavLink}
         to={item.to}
         end={item.end}
-        aria-label={item.label}
+        aria-label={ariaLabel}
         sx={{
           display: 'flex',
           alignItems: 'center',
@@ -67,7 +69,9 @@ function RailLink({ item }: { item: NavItem }) {
           },
         }}
       >
-        {item.icon}
+        <Badge badgeContent={badgeCount} max={9} color="error">
+          {item.icon}
+        </Badge>
       </Box>
     </Tooltip>
   );
@@ -76,6 +80,7 @@ function RailLink({ item }: { item: NavItem }) {
 export default function Rail() {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
+  const dmUnreadCount = useDmUnreadCount();
 
   return (
     <Box
@@ -120,7 +125,7 @@ export default function Rail() {
 
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
         {TOP_ITEMS.map((item) => (
-          <RailLink key={item.to} item={item} />
+          <RailLink key={item.to} item={item} badgeCount={item.to === '/dm' ? dmUnreadCount : 0} />
         ))}
 
         {/* 検索アイコン (Step 2b で配置だけ追加、Step 7 で検索ページ新設時に有効化)

--- a/packages/client/src/hooks/__tests__/useDmUnreadCount.test.tsx
+++ b/packages/client/src/hooks/__tests__/useDmUnreadCount.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * テスト対象: hooks/useDmUnreadCount.ts (Rail の DM 未読バッジ用集計フック)
+ * 戦略:
+ *   - api.dm.listConversations をモックして初期未読数を制御する
+ *   - SocketContext をモックして dm_notification を任意のタイミングで発火させる
+ *   - MemoryRouter で initialEntries を切り替え、現在パスによる挙動を検証する
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { useDmUnreadCount } from '../useDmUnreadCount';
+
+const mockListConversations = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    dm: {
+      listConversations: () => mockListConversations(),
+    },
+  },
+}));
+
+type SocketEventHandler = (data: { conversationId: number; unreadCount: number }) => void;
+
+const mockSocket = {
+  on: vi.fn<(event: string, handler: SocketEventHandler) => void>(),
+  off: vi.fn<(event: string, handler: SocketEventHandler) => void>(),
+};
+
+let socketReturnValue: typeof mockSocket | null = mockSocket;
+
+vi.mock('../../contexts/SocketContext', () => ({
+  useSocket: () => socketReturnValue,
+}));
+
+function wrapperFactory(initialPath: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>;
+  };
+}
+
+beforeEach(() => {
+  mockListConversations.mockReset();
+  mockSocket.on.mockReset();
+  mockSocket.off.mockReset();
+  socketReturnValue = mockSocket;
+});
+
+describe('useDmUnreadCount', () => {
+  describe('初期取得', () => {
+    it('マウント時に api.dm.listConversations が呼ばれる', async () => {
+      mockListConversations.mockResolvedValue({ conversations: [] });
+      renderHook(() => useDmUnreadCount(), { wrapper: wrapperFactory('/') });
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('listConversations の各 conversation.unreadCount を合計した値が count として返る', async () => {
+      mockListConversations.mockResolvedValue({
+        conversations: [
+          { id: 1, unreadCount: 3 },
+          { id: 2, unreadCount: 2 },
+          { id: 3, unreadCount: 0 },
+        ],
+      });
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/'),
+      });
+      await waitFor(() => {
+        expect(result.current).toBe(5);
+      });
+    });
+
+    it('listConversations が失敗した場合は count が 0 のまま例外を伝播しない', async () => {
+      mockListConversations.mockRejectedValue(new Error('network error'));
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/'),
+      });
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalled();
+      });
+      expect(result.current).toBe(0);
+    });
+  });
+
+  describe('Socket 受信', () => {
+    it('dm_notification を受信すると count が unreadCount 分増加する', async () => {
+      mockListConversations.mockResolvedValue({ conversations: [] });
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/'),
+      });
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('dm_notification', expect.any(Function));
+      });
+      const handler = mockSocket.on.mock.calls.find(([e]) => e === 'dm_notification')?.[1];
+      expect(handler).toBeDefined();
+      act(() => {
+        handler!({ conversationId: 1, unreadCount: 3 });
+      });
+      expect(result.current).toBe(3);
+    });
+
+    it('dm_notification を複数回受信すると累積される', async () => {
+      mockListConversations.mockResolvedValue({ conversations: [] });
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/'),
+      });
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalled();
+      });
+      const handler = mockSocket.on.mock.calls.find(([e]) => e === 'dm_notification')?.[1];
+      act(() => {
+        handler!({ conversationId: 1, unreadCount: 2 });
+        handler!({ conversationId: 2, unreadCount: 1 });
+        handler!({ conversationId: 1, unreadCount: 3 });
+      });
+      expect(result.current).toBe(6);
+    });
+
+    it('socket が null のとき購読は行わない', async () => {
+      socketReturnValue = null;
+      mockListConversations.mockResolvedValue({ conversations: [] });
+      renderHook(() => useDmUnreadCount(), { wrapper: wrapperFactory('/') });
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalled();
+      });
+      expect(mockSocket.on).not.toHaveBeenCalled();
+    });
+
+    it('unmount 時に dm_notification の購読が解除される', async () => {
+      mockListConversations.mockResolvedValue({ conversations: [] });
+      const { unmount } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/'),
+      });
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalled();
+      });
+      unmount();
+      expect(mockSocket.off).toHaveBeenCalledWith('dm_notification', expect.any(Function));
+    });
+  });
+
+  describe('現在パスによる挙動', () => {
+    it('現在のパスが /dm のときは 0 を返す（集計値は内部状態として保持される）', async () => {
+      mockListConversations.mockResolvedValue({
+        conversations: [{ id: 1, unreadCount: 5 }],
+      });
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/dm'),
+      });
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalled();
+      });
+      expect(result.current).toBe(0);
+    });
+
+    it('現在のパスが /dm/123 のときも 0 を返す', async () => {
+      mockListConversations.mockResolvedValue({
+        conversations: [{ id: 1, unreadCount: 5 }],
+      });
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/dm/123'),
+      });
+      await waitFor(() => {
+        expect(mockListConversations).toHaveBeenCalled();
+      });
+      expect(result.current).toBe(0);
+    });
+
+    it('現在のパスが /dm 以外（例: /tasks）のときは集計値を返す', async () => {
+      mockListConversations.mockResolvedValue({
+        conversations: [{ id: 1, unreadCount: 4 }],
+      });
+      const { result } = renderHook(() => useDmUnreadCount(), {
+        wrapper: wrapperFactory('/tasks'),
+      });
+      await waitFor(() => {
+        expect(result.current).toBe(4);
+      });
+    });
+  });
+});

--- a/packages/client/src/hooks/useDmUnreadCount.ts
+++ b/packages/client/src/hooks/useDmUnreadCount.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { api } from '../api/client';
+import { useSocket } from '../contexts/SocketContext';
+
+/**
+ * Rail の DM 未読バッジ用の集計フック。
+ *
+ * - 初回マウント時に GET /dm/conversations で各会話の unreadCount を合計する
+ * - Socket イベント `dm_notification` を購読し、受信のたび count を加算する
+ * - 現在のパスが /dm 配下のときは 0 を返す（内部 state は保持される）
+ */
+export function useDmUnreadCount(): number {
+  const [count, setCount] = useState(0);
+  const socket = useSocket();
+  const location = useLocation();
+
+  useEffect(() => {
+    let cancelled = false;
+    api.dm
+      .listConversations()
+      .then(({ conversations }) => {
+        if (cancelled) return;
+        const sum = conversations.reduce((acc, c) => acc + (c.unreadCount ?? 0), 0);
+        setCount(sum);
+      })
+      .catch(() => {
+        // 取得失敗時は 0 のまま（次回 Socket 受信で増分のみ反映）
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = (data: { conversationId: number; unreadCount: number }) => {
+      setCount((prev) => prev + data.unreadCount);
+    };
+    socket.on('dm_notification', handler);
+    return () => {
+      socket.off('dm_notification', handler);
+    };
+  }, [socket]);
+
+  if (location.pathname.startsWith('/dm')) return 0;
+  return count;
+}


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 2c。Rail の DM アイコンに未読数バッジを実装。

メンション数バッジは Step 6 (InboxPage) で Inbox 連動として実装するため、本 PR では DM のみ対応。

## 変更内容

### 新規 `hooks/useDmUnreadCount.ts`
- 初回マウント時に `api.dm.listConversations()` で `sum(unreadCount)` を取得
- Socket `dm_notification` イベントで受信するたび count を加算
- 現在のパスが `/dm` 配下のときは 0 を返す（内部 state は保持、離脱時に再表示）

### `Rail.tsx`
- `RailLink` に `badgeCount` prop を追加し、`<Badge max={9} color="error">` でアイコンをラップ
- DM アイテムにのみ `useDmUnreadCount()` の値を渡す
- 未読時は `aria-label` が `"DM (3 件未読)"` 形式に動的変化（screen reader 対応）

### `TaskBoardPage.test.tsx`
- `api.dm.listConversations` を mock に追加（Rail が AppLayout 経由でレンダーされるため）

## テスト

### 新規 `useDmUnreadCount.test.tsx` (10 ケース)
- 初期取得 (3): `listConversations` 呼び出し / 合計値返却 / 失敗時の 0 fallback
- Socket 受信 (4): 1 件加算 / 累積 / null socket / unmount cleanup
- 現在パスによる挙動 (3): `/dm` で 0 / `/dm/123` で 0 / `/tasks` で集計値

### `Rail.test.tsx` (+4 ケース)
- 未読 0 でバッジ非表示 / 5 で "5" / 12 で "9+" / aria-label に未読数反映

## 影響範囲

- Rail を含む全ページ（ChatPage / CalendarPage / TaskBoardPage）で DM アイコンに未読バッジが表示される
- 既存の `ChannelList` 内 `DmNavigationItems` の DM 未読バッジはそのまま（Step 3 で削除予定 → 一時的に Sidebar と Rail で重複表示）
- `useDmUnreadCount` は `/dm` 配下で 0 を返すため、DM 画面に居る間は Rail バッジも消える

## 保留 TODO 更新

- 🟢 #3: Rail の DM 未読バッジ未実装 → **解決済み**
- ⚪ #5: Rail のメンション数バッジ未実装 (Inbox 連動) → Step 6 で解決予定（新設）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1332 pass / 5 skip / 0 fail)
- [x] バックエンドユニットテストがすべてパスする (本 PR はバックエンド未変更)
- [x] ビルドが正常に完了すること (`npm run build` 成功)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット
  - **未実施**: 実機で DM 未読時のバッジ表示 / `/dm` 遷移時のバッジ消失 / 9+ 表示 をマージ前に確認お願いします

## 関連Issue
なし（UI/UX ブラッシュアップ計画 `doc/brushup-uiux-plan/PROGRESS.md` を参照）

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
  - `PROGRESS.md` 保留 TODO #3 を解決済み、#5 を新設
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)