### PR TITLE
feat(channel-item): 行コンパクト化 + ピン留めアイコン追加 (Step 3b)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -320,7 +320,7 @@ main
 | 2 | 検索 UI が画面から消失（AppBar 撤去）。ChatPage 内の検索 state / `SearchResults` / `SearchFilterPanel` の描画ロジック / `onSelectSavedView` handler が dead code として残置。Ctrl+F ショートカット撤去 | Step 2b / Step 3a | Step 7 (検索ページ新設時に再構築 or 撤去判断) | ⚪ 未解決 |
 | 3 | Rail の DM 未読バッジ未実装 | Step 2b | Step 2c | 🟢 解決済み |
 | 5 | Rail のメンション数バッジ未実装 (Inbox 連動) | Step 2b | Step 6 (InboxPage) | ⚪ 未解決 |
-| 6 | ChannelList の行コンパクト化 (28px / `#` 🔒 ピン アイコン整形) | Step 3a | Step 3b | ⚪ 未解決 |
+| 6 | ChannelList の行コンパクト化 (28px / `#` 🔒 ピン アイコン整形) | Step 3a | Step 3b | 🟢 解決済み |
 | 7 | ChannelList の未読数バッジ (メンション = accent / 通常 = muted) | Step 3a | Step 6 (InboxPage 連動) | ⚪ 未解決 |
 | 8 | Sidebar に DM 会話一覧ブロック未追加（プロンプト §3.3 の "DM" ブロック） | Step 3a | Step 3c | ⚪ 未解決 |
 | 4 | Rail 最上部のロゴが暫定デザイン（"C" の四角） | Step 2b | 任意 Step（最終デザイン調整時） | ⚪ 未解決 |

--- a/packages/client/src/__tests__/ChannelItem.test.tsx
+++ b/packages/client/src/__tests__/ChannelItem.test.tsx
@@ -690,4 +690,33 @@ describe('ChannelItem', () => {
       }
     });
   });
+
+  describe('行コンパクト化 (Step 3b)', () => {
+    it('ListItemButton の minHeight が 28px に設定されている', () => {
+      render(<ChannelItem {...defaultProps} channel={makeChannel({ name: 'general' })} />);
+      const button = screen.getByText('# general').closest('[role="button"]') as HTMLElement;
+      expect(button).toHaveStyle({ minHeight: '28px' });
+    });
+
+    it('ListItemButton の paddingTop / paddingBottom が 0 に設定されている', () => {
+      render(<ChannelItem {...defaultProps} channel={makeChannel({ name: 'general' })} />);
+      const button = screen.getByText('# general').closest('[role="button"]') as HTMLElement;
+      expect(button).toHaveStyle({ paddingTop: '0px', paddingBottom: '0px' });
+    });
+
+    it('isPinned=true のとき、行内にピン留めアイコン (aria-label="ピン留め済み") が表示される', () => {
+      render(<ChannelItem {...defaultProps} channel={makeChannel()} isPinned={true} />);
+      expect(screen.getByLabelText('ピン留め済み')).toBeInTheDocument();
+    });
+
+    it('isPinned=false のとき、行内にピン留めアイコンが表示されない', () => {
+      render(<ChannelItem {...defaultProps} channel={makeChannel()} isPinned={false} />);
+      expect(screen.queryByLabelText('ピン留め済み')).not.toBeInTheDocument();
+    });
+
+    it('既存の "# {name}" テキスト表示は維持される (regression)', () => {
+      render(<ChannelItem {...defaultProps} channel={makeChannel({ name: 'general' })} />);
+      expect(screen.getByText('# general')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/client/src/components/Channel/ChannelItem.tsx
+++ b/packages/client/src/components/Channel/ChannelItem.tsx
@@ -226,7 +226,17 @@ export default function ChannelItem({
               <DragIndicatorIcon sx={{ fontSize: 14 }} />
             </Box>
           )}
-          <ListItemButton selected={isActive} onClick={onClick}>
+          <ListItemButton
+            selected={isActive}
+            onClick={onClick}
+            style={{ minHeight: 28, paddingTop: 0, paddingBottom: 0 }}
+          >
+            {isPinned && (
+              <PushPinIcon
+                aria-label="ピン留め済み"
+                sx={{ fontSize: 12, mr: 0.5, color: 'text.secondary' }}
+              />
+            )}
             {channel.isPrivate && (
               <LockIcon
                 aria-label="private channel"


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 3b。プロンプト §3.3 後半「行はコンパクト表示（高さ 28px、左に `#` / 🔒 / ピンアイコン）」を実施する。保留 TODO #6 を解消。

## 変更内容

### `ChannelItem.tsx`
- `<ListItemButton>` に `style={{ minHeight: 28, paddingTop: 0, paddingBottom: 0 }}` を追加
  - `sx` ではなく `style` props を採用 → jsdom でも `toHaveStyle` で確実に検証可能
- `isPinned=true` のとき行内に `<PushPinIcon aria-label="ピン留め済み" sx={{ fontSize: 12 }}>` を追加
  - 配置順: ピン → 🔒 (private) → `# {name}` テキスト

### スコープ外（後続 Step / 保留 TODO 維持）

| 項目 | 理由・解決予定 |
|---|---|
| `# {name}` テキストのアイコン化 | 既存テスト 30+ ケースが `getByText('# general')` 形式に依存。本 PR では維持し、影響範囲の大きい変更は別途 |
| ホバー時アクションバーの絶対配置フロート（モック §2.4 相当） | Step 4 (MessageItem フラット化) 連動で扱う方が自然 |
| CSS 変数 (`var(--text)`) への置き換え | 任意の最終調整 Step |

## テスト

`ChannelItem.test.tsx` に「行コンパクト化 (Step 3b)」 describe を追加 (5 ケース):
1. `ListItemButton` の `minHeight` が **28px**
2. `ListItemButton` の `paddingTop` / `paddingBottom` が **0**
3. `isPinned=true` でピンアイコン (`aria-label="ピン留め済み"`) 表示
4. `isPinned=false` でピンアイコン非表示
5. `"# {name}"` テキスト表示の regression（テキスト形式維持）

## 影響範囲

- ChannelList の各チャンネル行が縦方向にやや詰まった見た目になる
- 既存のホバーアクション / 未読バッジ / ミュート表示は無影響
- API / Socket / 他コンポーネントへの波及なし

## 保留 TODO 更新

- 🟢 #6: ChannelList の行コンパクト化 → **解決済み**
- ⚪ #4: Rail ロゴ暫定 "C" / #1, #2: 検索系 / #5, #7: メンション系 / #8: DM 会話一覧 → 各 Step で対応

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1312 pass / 5 skip / 0 fail)
- [x] バックエンドユニットテストがすべてパスする (本 PR はバックエンド未変更)
- [x] ビルドが正常に完了すること (`npm run build` 成功 / CSS 27.35 kB / JS 2157.40 kB)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット
  - **未実施**: 行高 28px の見た目確認 / ピン留めセクションのアイコン表示確認 をマージ前にお願いします

## 関連Issue
なし（UI/UX ブラッシュアップ計画 `doc/brushup-uiux-plan/PROGRESS.md` を参照）

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
  - `PROGRESS.md` 保留 TODO #6 を解決済みに更新
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)