### PR TITLE
feat(message): バブル撤去 + 連投マージ + ホバーアクションバー (Step 4)

### DIFF
--- a/packages/client/src/__tests__/BookmarkPage.test.tsx
+++ b/packages/client/src/__tests__/BookmarkPage.test.tsx
@@ -208,20 +208,29 @@ describe('MessageItem ブックマークアクション', () => {
   describe('ブックマーク登録', () => {
     it('3点メニューを開くとブックマークメニュー項目が表示される', async () => {
       renderMessageItem();
-      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+      // Step 4: ホバー前のアクションバーは pointer-events:none のためチェックを外す
+      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+        pointerEventsCheck: 0,
+      });
       expect(screen.getByRole('menuitem', { name: 'ブックマーク' })).toBeInTheDocument();
     });
 
     it('3点メニューのブックマークをクリックすると POST /api/bookmarks/:messageId を呼び出す', async () => {
       renderMessageItem();
-      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+      // Step 4: ホバー前のアクションバーは pointer-events:none のためチェックを外す
+      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+        pointerEventsCheck: 0,
+      });
       await userEvent.click(screen.getByRole('menuitem', { name: 'ブックマーク' }));
       expect(mockApi.bookmarks.add).toHaveBeenCalledWith(10);
     });
 
     it('ブックマーク登録済みのメッセージでは3点メニューに「ブックマーク解除」項目を表示する', async () => {
       renderMessageItem(true);
-      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+      // Step 4: ホバー前のアクションバーは pointer-events:none のためチェックを外す
+      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+        pointerEventsCheck: 0,
+      });
       expect(screen.getByRole('menuitem', { name: 'ブックマーク解除' })).toBeInTheDocument();
     });
   });
@@ -229,17 +238,26 @@ describe('MessageItem ブックマークアクション', () => {
   describe('ブックマーク解除（MessageItemから）', () => {
     it('3点メニューのブックマーク解除をクリックすると DELETE /api/bookmarks/:messageId を呼び出す', async () => {
       renderMessageItem(true);
-      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+      // Step 4: ホバー前のアクションバーは pointer-events:none のためチェックを外す
+      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+        pointerEventsCheck: 0,
+      });
       await userEvent.click(screen.getByRole('menuitem', { name: 'ブックマーク解除' }));
       expect(mockApi.bookmarks.remove).toHaveBeenCalledWith(10);
     });
 
     it('ブックマーク解除成功後、メニューを再度開くと「ブックマーク」項目に戻る', async () => {
       renderMessageItem(true);
-      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+      // Step 4: ホバー前のアクションバーは pointer-events:none のためチェックを外す
+      await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+        pointerEventsCheck: 0,
+      });
       await userEvent.click(screen.getByRole('menuitem', { name: 'ブックマーク解除' }));
       await waitFor(async () => {
-        await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+        // Step 4: ホバー前のアクションバーは pointer-events:none のためチェックを外す
+        await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+          pointerEventsCheck: 0,
+        });
         expect(screen.getByRole('menuitem', { name: 'ブックマーク' })).toBeInTheDocument();
       });
     });

--- a/packages/client/src/__tests__/MessageItem.test.tsx
+++ b/packages/client/src/__tests__/MessageItem.test.tsx
@@ -227,7 +227,11 @@ describe('MessageItem', () => {
         <MessageItem message={makeMessage({ userId: 1 })} currentUserId={1} users={dummyUsers} />,
       );
 
-      await userEvent.click(screen.getByRole('button', { name: /edit/i }));
+      // Step 4 以降アクションバーはホバー前 pointer-events:none のため、ユニットテストでは
+      // チェックを外して直接クリックする（実機ではホバー → クリックの順で動作）
+      await userEvent.click(screen.getByRole('button', { name: /edit/i }), {
+        pointerEventsCheck: 0,
+      });
 
       expect(screen.getByTestId('rich-editor')).toBeInTheDocument();
     });
@@ -241,7 +245,9 @@ describe('MessageItem', () => {
         />,
       );
 
-      await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+      await userEvent.click(screen.getByRole('button', { name: /delete/i }), {
+        pointerEventsCheck: 0,
+      });
 
       expect(mockSocket.emit).toHaveBeenCalledWith('delete_message', 42);
     });
@@ -833,6 +839,83 @@ describe('MessageItem', () => {
       const indicator = screen.getByTestId('presence-indicator');
       expect(indicator).toBeInTheDocument();
       expect(indicator).toHaveAttribute('data-state', 'online');
+    });
+  });
+
+  // Step 4 — MessageBubble バブル撤去 + 連投マージ表示
+  describe('連投マージ表示 (Step 4)', () => {
+    it('isContinued=true のとき displayName ヘッダーが描画されない', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ userId: 1 })}
+          currentUserId={2}
+          users={dummyUsers}
+          isContinued={true}
+        />,
+      );
+      expect(screen.queryByText('alice')).not.toBeInTheDocument();
+    });
+
+    it('isContinued=true のとき投稿時刻 (HH:MM) が描画されない', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ userId: 1 })}
+          currentUserId={2}
+          users={dummyUsers}
+          isContinued={true}
+        />,
+      );
+      expect(screen.queryByText(/\d{1,2}:\d{2}/)).not.toBeInTheDocument();
+    });
+
+    it('isContinued=true のときアバター（user-avatar）が描画されない', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ userId: 1 })}
+          currentUserId={2}
+          users={dummyUsers}
+          isContinued={true}
+        />,
+      );
+      expect(screen.queryByTestId('user-avatar')).not.toBeInTheDocument();
+    });
+
+    it('isContinued=false のとき従来どおり displayName・時刻・アバターが描画される', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ userId: 1 })}
+          currentUserId={2}
+          users={dummyUsers}
+          isContinued={false}
+        />,
+      );
+      expect(screen.getByText('alice')).toBeInTheDocument();
+      expect(screen.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument();
+      expect(screen.getByTestId('user-avatar')).toBeInTheDocument();
+    });
+
+    it('isContinued props 省略時は default false として動作し、すべてのヘッダー要素が描画される', () => {
+      render(
+        <MessageItem message={makeMessage({ userId: 1 })} currentUserId={2} users={dummyUsers} />,
+      );
+      expect(screen.getByText('alice')).toBeInTheDocument();
+      expect(screen.getByText(/\d{1,2}:\d{2}/)).toBeInTheDocument();
+      expect(screen.getByTestId('user-avatar')).toBeInTheDocument();
+    });
+
+    it('isDeleted=true のメッセージは isContinued=true でも従来の削除済みレイアウトを表示する', () => {
+      render(
+        <MessageItem
+          message={makeMessage({ userId: 1, isDeleted: true })}
+          currentUserId={1}
+          users={dummyUsers}
+          isContinued={true}
+        />,
+      );
+      // 削除済みレイアウトの "This message was deleted." が表示される
+      expect(screen.getByText('This message was deleted.')).toBeInTheDocument();
+      // displayName も表示される（削除済みでも従来通り）
+      expect(screen.getByText('alice')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/MessageItemReaction.test.tsx
+++ b/packages/client/src/__tests__/MessageItemReaction.test.tsx
@@ -117,7 +117,9 @@ describe('MessageItem - リアクション機能', () => {
     it('絵文字ピッカー起動ボタンをクリックするとピッカーが表示される', async () => {
       render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
 
-      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }), {
+        pointerEventsCheck: 0,
+      });
 
       expect(screen.getByTestId('emoji-picker')).toBeInTheDocument();
     });
@@ -125,7 +127,9 @@ describe('MessageItem - リアクション機能', () => {
     it('絵文字ピッカーに固定の絵文字リストが表示される', async () => {
       render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
 
-      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }), {
+        pointerEventsCheck: 0,
+      });
 
       // 固定絵文字セットの一部が表示されていること
       expect(screen.getByRole('button', { name: '👍' })).toBeInTheDocument();
@@ -136,7 +140,9 @@ describe('MessageItem - リアクション機能', () => {
     it('ピッカー外をクリックするとピッカーが閉じる', async () => {
       render(<MessageItem message={makeMessage()} currentUserId={1} users={dummyUsers} />);
 
-      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }), {
+        pointerEventsCheck: 0,
+      });
       expect(screen.getByTestId('emoji-picker')).toBeInTheDocument();
 
       // ピッカー外をクリックして閉じる
@@ -152,7 +158,9 @@ describe('MessageItem - リアクション機能', () => {
         <MessageItem message={makeMessage({ id: 42 })} currentUserId={1} users={dummyUsers} />,
       );
 
-      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }));
+      await userEvent.click(screen.getByRole('button', { name: /リアクションを追加/i }), {
+        pointerEventsCheck: 0,
+      });
       await userEvent.click(screen.getByRole('button', { name: '👍' }));
 
       expect(mockSocket.emit).toHaveBeenCalledWith('add_reaction', {

--- a/packages/client/src/__tests__/MessageItemThread.test.tsx
+++ b/packages/client/src/__tests__/MessageItemThread.test.tsx
@@ -92,7 +92,9 @@ describe('MessageItem（スレッド機能）', () => {
           onOpenThread={onOpenThread}
         />,
       );
-      await userEvent.click(screen.getByRole('button', { name: '返信' }));
+      await userEvent.click(screen.getByRole('button', { name: '返信' }), {
+        pointerEventsCheck: 0,
+      });
       expect(onOpenThread).toHaveBeenCalledWith(7);
     });
   });

--- a/packages/client/src/__tests__/MessageList.test.tsx
+++ b/packages/client/src/__tests__/MessageList.test.tsx
@@ -10,7 +10,7 @@
  *   - window.location.hash を各テストで設定し afterEach でリセットする
  */
 
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import MessageList from '../components/Chat/MessageList';
 import { makeMessage } from './__fixtures__/messages';
@@ -29,9 +29,14 @@ vi.mock('../contexts/AuthContext', () => ({
 }));
 
 // MessageItem スタブ — id 属性だけ持つ div にして DOM にアンカーを作る
+// Step 4: 連投マージ判定の検証用に isContinued props を data-continued で公開する
 vi.mock('../components/Chat/MessageItem', () => ({
-  default: ({ message }: { message: { id: number } }) => (
-    <div id={`message-${message.id}`} data-testid={`message-${message.id}`} />
+  default: ({ message, isContinued }: { message: { id: number }; isContinued?: boolean }) => (
+    <div
+      id={`message-${message.id}`}
+      data-testid={`message-${message.id}`}
+      data-continued={isContinued ? 'true' : 'false'}
+    />
   ),
 }));
 
@@ -284,6 +289,105 @@ describe('MessageList', () => {
 
       // 初回ロードの 1 回のみ（新着では呼ばれない）
       expect(scrollIntoView).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('連投マージ判定 (Step 4)', () => {
+    it('同送信者で 5 分以内に投稿された 2 件目の MessageItem に isContinued=true が渡る', () => {
+      render(
+        <MessageList
+          messages={[
+            makeMessage({ id: 1, userId: 1, createdAt: '2024-06-01T12:00:00Z' }),
+            makeMessage({ id: 2, userId: 1, createdAt: '2024-06-01T12:03:00Z' }),
+          ]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+      expect(screen.getByTestId('message-2')).toHaveAttribute('data-continued', 'true');
+    });
+
+    it('同送信者でも 5 分を超えた 2 件目の MessageItem は isContinued=false', () => {
+      render(
+        <MessageList
+          messages={[
+            makeMessage({ id: 1, userId: 1, createdAt: '2024-06-01T12:00:00Z' }),
+            makeMessage({ id: 2, userId: 1, createdAt: '2024-06-01T12:06:00Z' }),
+          ]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+      expect(screen.getByTestId('message-2')).toHaveAttribute('data-continued', 'false');
+    });
+
+    it('異なる送信者の MessageItem は isContinued=false', () => {
+      render(
+        <MessageList
+          messages={[
+            makeMessage({ id: 1, userId: 1, createdAt: '2024-06-01T12:00:00Z' }),
+            makeMessage({ id: 2, userId: 2, createdAt: '2024-06-01T12:01:00Z' }),
+          ]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+      expect(screen.getByTestId('message-2')).toHaveAttribute('data-continued', 'false');
+    });
+
+    it('直前メッセージが isDeleted=true のとき、次のメッセージは isContinued=false（チェーン切断）', () => {
+      render(
+        <MessageList
+          messages={[
+            makeMessage({
+              id: 1,
+              userId: 1,
+              isDeleted: true,
+              createdAt: '2024-06-01T12:00:00Z',
+            }),
+            makeMessage({ id: 2, userId: 1, createdAt: '2024-06-01T12:01:00Z' }),
+          ]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+      expect(screen.getByTestId('message-2')).toHaveAttribute('data-continued', 'false');
+    });
+
+    it('isDeleted=true のメッセージ自身は常に isContinued=false', () => {
+      render(
+        <MessageList
+          messages={[
+            makeMessage({ id: 1, userId: 1, createdAt: '2024-06-01T12:00:00Z' }),
+            makeMessage({
+              id: 2,
+              userId: 1,
+              isDeleted: true,
+              createdAt: '2024-06-01T12:01:00Z',
+            }),
+          ]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+      expect(screen.getByTestId('message-2')).toHaveAttribute('data-continued', 'false');
+    });
+
+    it('配列の 1 件目は常に isContinued=false', () => {
+      render(
+        <MessageList
+          messages={[makeMessage({ id: 1, userId: 1, createdAt: '2024-06-01T12:00:00Z' })]}
+          loading={false}
+          onLoadMore={vi.fn()}
+          currentUserId={1}
+        />,
+      );
+      expect(screen.getByTestId('message-1')).toHaveAttribute('data-continued', 'false');
     });
   });
 });

--- a/packages/client/src/__tests__/QuoteReply.test.tsx
+++ b/packages/client/src/__tests__/QuoteReply.test.tsx
@@ -59,7 +59,9 @@ describe('MessageItem — 引用返信ボタン', () => {
         users={dummyUsers}
       />,
     );
-    await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+    await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+      pointerEventsCheck: 0,
+    });
     expect(screen.getByRole('menuitem', { name: /引用返信/ })).toBeInTheDocument();
   });
 
@@ -71,7 +73,9 @@ describe('MessageItem — 引用返信ボタン', () => {
         users={dummyUsers}
       />,
     );
-    await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+    await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+      pointerEventsCheck: 0,
+    });
     expect(screen.getByRole('menuitem', { name: /引用返信/ })).toBeInTheDocument();
   });
 
@@ -97,7 +101,9 @@ describe('MessageItem — 引用返信ボタン', () => {
         onQuoteReply={onQuoteReply}
       />,
     );
-    await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }));
+    await userEvent.click(screen.getByRole('button', { name: 'その他のアクション' }), {
+      pointerEventsCheck: 0,
+    });
     await userEvent.click(screen.getByRole('menuitem', { name: /引用返信/ }));
     expect(onQuoteReply).toHaveBeenCalledWith(message);
   });
@@ -185,7 +191,9 @@ describe('RichEditor — 引用元情報の表示', () => {
       />,
     );
     // Edit ボタンをクリックして RichEditor を表示
-    await userEvent.click(screen.getByRole('button', { name: /edit/i }));
+    await userEvent.click(screen.getByRole('button', { name: /edit/i }), {
+      pointerEventsCheck: 0,
+    });
     expect(screen.getByTestId('rich-editor')).toBeInTheDocument();
     // Cancel ボタンをクリックしてエディタを閉じる（RichEditorスタブの中のボタンを探す）
     const richEditor = screen.getByTestId('rich-editor');

--- a/packages/client/src/__tests__/ReactionBadge.test.tsx
+++ b/packages/client/src/__tests__/ReactionBadge.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * components/Chat/ReactionBadge.tsx のユニットテスト
+ *
+ * テスト対象: Step 4 で導入したピル形状とアクセント色化
+ *   - 高さ 22px / borderRadius 11px のピル形状
+ *   - 自分がリアクション済みのとき accent 色枠 + accent 色文字
+ *   - 他人のリアクション時は neutral カラー（既存挙動）
+ *   - クリックで onClick(emoji) が呼ばれる（既存挙動）
+ *
+ * MUI の sx は jsdom 環境では `toHaveStyle` で値が取れないことがあるため、
+ * 検証したい値は inline `style={{ ... }}` で渡してテスト容易性を確保する方針。
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import ReactionBadge from '../components/Chat/ReactionBadge';
+import { dummyUsers } from './__fixtures__/users';
+import type { Reaction } from '@chat-app/shared';
+
+const baseReaction: Reaction = { emoji: '👍', count: 1, userIds: [2] };
+
+const renderBadge = (overrides: {
+  reaction?: Reaction;
+  currentUserId?: number;
+  onClick?: (emoji: string) => void;
+}) =>
+  render(
+    <ReactionBadge
+      reaction={overrides.reaction ?? baseReaction}
+      currentUserId={overrides.currentUserId ?? 1}
+      users={dummyUsers}
+      onClick={overrides.onClick ?? vi.fn()}
+    />,
+  );
+
+// jsdom の toHaveStyle は CSS カスタムプロパティ (var(--xxx)) を解決した値で比較するため
+// 値が空文字に解決されてしまう。inline `style` 属性は HTMLElement.style.* で直接読み取れるので
+// そちらで比較する。
+const getBadge = (): HTMLElement => screen.getByTestId('reaction-badge');
+
+describe('ReactionBadge (Step 4)', () => {
+  describe('ピル形状', () => {
+    it('バッジの高さが 22px で表示される (inline style)', () => {
+      renderBadge({});
+      expect(getBadge().style.height).toBe('22px');
+    });
+
+    it('バッジの borderRadius が 11px で表示される (inline style)', () => {
+      renderBadge({});
+      expect(getBadge().style.borderRadius).toBe('11px');
+    });
+  });
+
+  describe('リアクション済み判定', () => {
+    it('userIds に currentUserId が含まれるとき data-reacted="true" が付与される', () => {
+      renderBadge({
+        reaction: { emoji: '👍', count: 1, userIds: [1] },
+        currentUserId: 1,
+      });
+      expect(getBadge()).toHaveAttribute('data-reacted', 'true');
+    });
+
+    it('userIds に currentUserId が含まれないとき data-reacted="false" が付与される', () => {
+      renderBadge({
+        reaction: { emoji: '👍', count: 1, userIds: [2] },
+        currentUserId: 1,
+      });
+      expect(getBadge()).toHaveAttribute('data-reacted', 'false');
+    });
+  });
+
+  describe('スタイル分岐 (Step 4 アクセント色化)', () => {
+    it('自分のリアクション時、borderColor に accent 色 (var(--accent)) が適用される', () => {
+      renderBadge({
+        reaction: { emoji: '👍', count: 1, userIds: [1] },
+        currentUserId: 1,
+      });
+      expect(getBadge().style.borderColor).toBe('var(--accent)');
+    });
+
+    it('自分のリアクション時、文字色 (color) に accent 色 (var(--accent)) が適用される', () => {
+      renderBadge({
+        reaction: { emoji: '👍', count: 1, userIds: [1] },
+        currentUserId: 1,
+      });
+      expect(getBadge().style.color).toBe('var(--accent)');
+    });
+
+    it('他人のリアクション時、border は neutral カラー (var(--border)) のまま', () => {
+      renderBadge({
+        reaction: { emoji: '👍', count: 1, userIds: [2] },
+        currentUserId: 1,
+      });
+      expect(getBadge().style.borderColor).toBe('var(--border)');
+    });
+  });
+
+  describe('クリック挙動 (既存挙動の維持)', () => {
+    it('クリックで onClick が emoji を引数に呼ばれる', async () => {
+      const onClick = vi.fn();
+      renderBadge({
+        reaction: { emoji: '🎉', count: 1, userIds: [2] },
+        currentUserId: 1,
+        onClick,
+      });
+      await userEvent.click(screen.getByTestId('reaction-badge'));
+      expect(onClick).toHaveBeenCalledWith('🎉');
+    });
+  });
+});

--- a/packages/client/src/components/Chat/MessageActions.tsx
+++ b/packages/client/src/components/Chat/MessageActions.tsx
@@ -95,11 +95,11 @@ export default function MessageActions({
 
   return (
     <>
+      {/* Step 4: フロート化により可視性は外側 (.msg-actions-floating) の display で制御するため
+          opacity 切り替えは撤去。常に display:flex で並べる */}
       <Box
         className="msg-actions"
         sx={{
-          opacity: 0,
-          transition: 'opacity 0.15s',
           display: 'flex',
           flexDirection: 'row',
           gap: 0.25,

--- a/packages/client/src/components/Chat/MessageBubble.tsx
+++ b/packages/client/src/components/Chat/MessageBubble.tsx
@@ -24,7 +24,6 @@ interface Props {
   reactions: Reaction[];
   currentUserId: number;
   users: User[];
-  isOwn: boolean;
   onReactionClick: (emoji: string) => void;
   onOpenThread?: (messageId: number) => void;
 }
@@ -34,11 +33,11 @@ export default function MessageBubble({
   reactions,
   currentUserId,
   users,
-  isOwn,
   onReactionClick,
   onOpenThread,
 }: Props) {
   return (
+    // Step 4: バブル装飾 (角丸 / 背景色 / パディング) を撤去しプレーンな縦組みに変更
     <Box
       sx={{
         maxWidth: '100%',
@@ -46,11 +45,7 @@ export default function MessageBubble({
         overflowWrap: 'break-word',
         whiteSpace: 'pre-wrap',
         fontSize: '0.875rem',
-        lineHeight: 1.5,
-        borderRadius: isOwn ? '12px 12px 0 12px' : '12px 12px 12px 0',
-        px: 1.5,
-        py: 0.75,
-        bgcolor: isOwn ? '#dbeafe' : 'grey.100',
+        lineHeight: 1.55,
         color: 'text.primary',
       }}
     >

--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -28,6 +28,8 @@ interface Props {
   onBookmarkChange?: (messageId: number, bookmarked: boolean) => void;
   onQuoteReply?: (message: Message) => void;
   onTagClick?: (tagName: string) => void;
+  // Step 4: 直前メッセージとの連投マージ状態（同送信者 + 5 分以内）。MessageList 側で計算する
+  isContinued?: boolean;
 }
 
 function formatTime(dateStr: string): string {
@@ -45,6 +47,7 @@ export default function MessageItem({
   onBookmarkChange,
   onQuoteReply,
   onTagClick,
+  isContinued = false,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [profileAnchor, setProfileAnchor] = useState<HTMLElement | null>(null);
@@ -149,52 +152,62 @@ export default function MessageItem({
   }
 
   return (
+    // Step 4: バブル撤去 + フラット表示。自分メッセージの右寄せ (row-reverse) を撤去し全行左揃えに統一。
+    // ホバー時にアクションバーをフロート (`position: absolute; top: -12; right: 24;`) で浮上させる。
     <Box
       id={`message-${message.id}`}
       data-own={isOwn ? 'true' : 'false'}
       sx={{
         display: 'flex',
-        flexDirection: isOwn ? 'row-reverse' : 'row',
         gap: 1.5,
         px: 2,
         py: 0.5,
-        '&:hover .msg-actions': { opacity: 1 },
         position: 'relative',
         alignItems: 'flex-start',
+        // display:none だと accessibility tree からアクション (Edit/Delete 等) が消えてしまうため、
+        // opacity + pointer-events で見た目とクリックだけを抑制する
+        '& .msg-actions-floating': { opacity: 0, pointerEvents: 'none' },
+        '&:hover .msg-actions-floating': { opacity: 1, pointerEvents: 'auto' },
       }}
     >
-      {/* アバター（ホバーでプロフィールポップアップ） */}
-      <Box
-        data-testid="user-avatar"
-        onMouseEnter={(e) => setProfileAnchor(e.currentTarget)}
-        onMouseLeave={() => setProfileAnchor(null)}
-        sx={{ flexShrink: 0, cursor: 'pointer', position: 'relative', width: 36, height: 36 }}
-      >
-        <Avatar
-          src={author?.avatarUrl ?? message.avatarUrl ?? undefined}
-          alt={displayName}
-          sx={{
-            width: 36,
-            height: 36,
-            ...(!(author?.avatarUrl ?? message.avatarUrl) && {
-              bgcolor: getAvatarColor(author?.email ?? ''),
-            }),
-          }}
+      {/* アバター（連投マージ時は描画せず、36px のスペーサーで本文の左端位置を維持する） */}
+      {isContinued ? (
+        <Box sx={{ flexShrink: 0, width: 36, height: 0 }} aria-hidden="true" />
+      ) : (
+        <Box
+          data-testid="user-avatar"
+          onMouseEnter={(e) => setProfileAnchor(e.currentTarget)}
+          onMouseLeave={() => setProfileAnchor(null)}
+          sx={{ flexShrink: 0, cursor: 'pointer', position: 'relative', width: 36, height: 36 }}
         >
-          {displayName[0].toUpperCase()}
-        </Avatar>
-        <PresenceIndicator state={userState} size={9} />
-      </Box>
+          <Avatar
+            src={author?.avatarUrl ?? message.avatarUrl ?? undefined}
+            alt={displayName}
+            sx={{
+              width: 36,
+              height: 36,
+              ...(!(author?.avatarUrl ?? message.avatarUrl) && {
+                bgcolor: getAvatarColor(author?.email ?? ''),
+              }),
+            }}
+          >
+            {displayName[0].toUpperCase()}
+          </Avatar>
+          <PresenceIndicator state={userState} size={9} />
+        </Box>
+      )}
 
-      {/* プロフィールポップアップ */}
-      <UserProfilePopover
-        user={author}
-        displayName={displayName}
-        anchorEl={profileAnchor}
-        open={Boolean(profileAnchor)}
-        onClose={() => setProfileAnchor(null)}
-        state={userState}
-      />
+      {/* プロフィールポップアップ（連投マージ時は anchor が無いので描画しない） */}
+      {!isContinued && (
+        <UserProfilePopover
+          user={author}
+          displayName={displayName}
+          anchorEl={profileAnchor}
+          open={Boolean(profileAnchor)}
+          onClose={() => setProfileAnchor(null)}
+          state={userState}
+        />
+      )}
 
       <Box
         sx={{
@@ -202,29 +215,30 @@ export default function MessageItem({
           minWidth: 0,
           display: 'flex',
           flexDirection: 'column',
-          alignItems: isOwn ? 'flex-end' : 'flex-start',
+          alignItems: 'flex-start',
         }}
       >
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: isOwn ? 'row-reverse' : 'row',
-            alignItems: 'baseline',
-            gap: 1,
-          }}
-        >
-          <Typography variant="subtitle2" fontWeight="bold">
-            {displayName}
-          </Typography>
-          <Typography variant="caption" color="text.secondary">
-            {formatTime(message.createdAt)}
-          </Typography>
-          {message.isEdited && (
-            <Typography variant="caption" color="text.secondary">
-              (edited)
+        {!isContinued && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'baseline',
+              gap: 1,
+            }}
+          >
+            <Typography variant="subtitle2" fontWeight="bold">
+              {displayName}
             </Typography>
-          )}
-        </Box>
+            <Typography variant="caption" color="text.secondary">
+              {formatTime(message.createdAt)}
+            </Typography>
+            {message.isEdited && (
+              <Typography variant="caption" color="text.secondary">
+                (edited)
+              </Typography>
+            )}
+          </Box>
+        )}
 
         {editing ? (
           <Box sx={{ mt: 0.5, width: '100%' }}>
@@ -237,124 +251,130 @@ export default function MessageItem({
             />
           </Box>
         ) : (
-          /* バブルとアクションを横並びにして、バブルのすぐ隣にボタンを配置する */
           <Box
             sx={{
               display: 'flex',
-              flexDirection: isOwn ? 'row-reverse' : 'row',
-              alignItems: 'flex-end',
+              flexDirection: 'column',
               gap: 0.5,
-              mt: 0.25,
+              minWidth: 0,
+              mt: isContinued ? 0 : 0.25,
+              alignItems: 'flex-start',
             }}
           >
-            <Box
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 0.5,
-                minWidth: 0,
-                maxWidth: '75%',
-                alignItems: isOwn ? 'flex-end' : 'flex-start',
-              }}
-            >
-              {message.event ? (
-                <EventCard event={message.event} />
-              ) : message.forwardedFromMessage?.event ? (
-                /*
-                 * #107 + #108 — イベント投稿の転送
-                 * 元メッセージの event を転送先で再利用してフル EventCard を描画する。
-                 * これにより転送先チャンネルからも RSVP 投票が可能になる。
-                 * 転送ヘッダー（MessageBubble の compact preview）はそのまま上部に残し、
-                 * 「誰が転送したか + 元イベントの概要」を示すラベルとして機能させる。
-                 */
-                <>
-                  <MessageBubble
-                    message={message}
-                    reactions={reactions}
-                    currentUserId={currentUserId}
-                    users={users}
-                    isOwn={isOwn}
-                    onReactionClick={handleReactionClick}
-                    onOpenThread={onOpenThread}
-                  />
-                  <EventCard event={message.forwardedFromMessage.event} />
-                </>
-              ) : (
+            {message.event ? (
+              <EventCard event={message.event} />
+            ) : message.forwardedFromMessage?.event ? (
+              /*
+               * #107 + #108 — イベント投稿の転送
+               * 元メッセージの event を転送先で再利用してフル EventCard を描画する。
+               * これにより転送先チャンネルからも RSVP 投票が可能になる。
+               * 転送ヘッダー（MessageBubble の compact preview）はそのまま上部に残し、
+               * 「誰が転送したか + 元イベントの概要」を示すラベルとして機能させる。
+               */
+              <>
                 <MessageBubble
                   message={message}
                   reactions={reactions}
                   currentUserId={currentUserId}
                   users={users}
-                  isOwn={isOwn}
                   onReactionClick={handleReactionClick}
                   onOpenThread={onOpenThread}
                 />
-              )}
+                <EventCard event={message.forwardedFromMessage.event} />
+              </>
+            ) : (
+              <MessageBubble
+                message={message}
+                reactions={reactions}
+                currentUserId={currentUserId}
+                users={users}
+                onReactionClick={handleReactionClick}
+                onOpenThread={onOpenThread}
+              />
+            )}
 
-              {/* タグ表示・編集エリア */}
-              {tagEditing ? (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
-                  <TagInput value={tagNames} onChange={setTagNames} />
-                  <Box sx={{ display: 'flex', gap: 1 }}>
-                    <Button
-                      size="small"
-                      variant="contained"
-                      onClick={() => void handleTagSave(tagNames)}
-                    >
-                      保存
-                    </Button>
-                    <Button
-                      size="small"
-                      onClick={() => {
-                        setTagEditing(false);
-                        setTagNames((message.tags ?? []).map((t) => t.name));
-                      }}
-                    >
-                      キャンセル
-                    </Button>
-                  </Box>
-                </Box>
-              ) : (
-                tagNames.length > 0 && (
-                  <Box
-                    sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.25 }}
-                    data-testid="tag-chips"
+            {/* タグ表示・編集エリア */}
+            {tagEditing ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, mt: 0.5 }}>
+                <TagInput value={tagNames} onChange={setTagNames} />
+                <Box sx={{ display: 'flex', gap: 1 }}>
+                  <Button
+                    size="small"
+                    variant="contained"
+                    onClick={() => void handleTagSave(tagNames)}
                   >
-                    {tagNames.map((name) => {
-                      const tag = (message.tags ?? []).find((t) => t.name === name);
-                      if (!tag) return null;
-                      return (
-                        <TagChip key={tag.id} tag={tag} onClick={onTagClick} readOnly={true} />
-                      );
-                    })}
-                    <Button
-                      size="small"
-                      aria-label="タグを編集"
-                      sx={{ fontSize: '0.65rem', height: 20, px: 0.5 }}
-                      onClick={() => setTagEditing(true)}
-                    >
-                      タグを編集
-                    </Button>
-                  </Box>
-                )
-              )}
-            </Box>
-
-            <MessageActions
-              message={message}
-              isOwn={isOwn}
-              isPinned={isPinned}
-              isBookmarked={isBookmarked}
-              onBookmarkChange={onBookmarkChange}
-              onQuoteReply={onQuoteReply}
-              onOpenThread={onOpenThread}
-              onPinMessage={onPinMessage}
-              onEdit={() => setEditing(true)}
-              onEditTags={() => setTagEditing(true)}
-            />
+                    保存
+                  </Button>
+                  <Button
+                    size="small"
+                    onClick={() => {
+                      setTagEditing(false);
+                      setTagNames((message.tags ?? []).map((t) => t.name));
+                    }}
+                  >
+                    キャンセル
+                  </Button>
+                </Box>
+              </Box>
+            ) : (
+              tagNames.length > 0 && (
+                <Box
+                  sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.25 }}
+                  data-testid="tag-chips"
+                >
+                  {tagNames.map((name) => {
+                    const tag = (message.tags ?? []).find((t) => t.name === name);
+                    if (!tag) return null;
+                    return <TagChip key={tag.id} tag={tag} onClick={onTagClick} readOnly={true} />;
+                  })}
+                  <Button
+                    size="small"
+                    aria-label="タグを編集"
+                    sx={{ fontSize: '0.65rem', height: 20, px: 0.5 }}
+                    onClick={() => setTagEditing(true)}
+                  >
+                    タグを編集
+                  </Button>
+                </Box>
+              )
+            )}
           </Box>
         )}
       </Box>
+
+      {/* ホバー時にフロートするアクションバー（編集中は非表示） */}
+      {!editing && (
+        <Box
+          className="msg-actions-floating"
+          sx={{
+            position: 'absolute',
+            top: -12,
+            right: 24,
+            display: 'flex',
+            bgcolor: 'background.paper',
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+            boxShadow: 2,
+            zIndex: 1,
+            padding: 0.25,
+            transition: 'opacity 0.15s',
+          }}
+        >
+          <MessageActions
+            message={message}
+            isOwn={isOwn}
+            isPinned={isPinned}
+            isBookmarked={isBookmarked}
+            onBookmarkChange={onBookmarkChange}
+            onQuoteReply={onQuoteReply}
+            onOpenThread={onOpenThread}
+            onPinMessage={onPinMessage}
+            onEdit={() => setEditing(true)}
+            onEditTags={() => setTagEditing(true)}
+          />
+        </Box>
+      )}
 
       {editing && (
         <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'flex-start', flexShrink: 0 }}>

--- a/packages/client/src/components/Chat/MessageList.tsx
+++ b/packages/client/src/components/Chat/MessageList.tsx
@@ -18,6 +18,26 @@ interface Props {
   onQuoteReply?: (message: Message) => void;
 }
 
+// Step 4: 連投マージ境界（5 分未満で同送信者なら継続）
+const CONTINUED_THRESHOLD_MS = 5 * 60 * 1000;
+
+/**
+ * 直前メッセージと比較して連投マージ対象か判定する。
+ * - 配列先頭は常に false
+ * - 自身が削除済み or 直前が削除済みのときチェーン切断
+ * - 異なる送信者は false
+ * - 同送信者でも 5 分以上経過していれば false
+ */
+function isContinuedMessage(messages: Message[], idx: number): boolean {
+  if (idx === 0) return false;
+  const current = messages[idx];
+  const prev = messages[idx - 1];
+  if (current.isDeleted || prev.isDeleted) return false;
+  if (current.userId !== prev.userId) return false;
+  const diff = Math.abs(new Date(current.createdAt).getTime() - new Date(prev.createdAt).getTime());
+  return diff < CONTINUED_THRESHOLD_MS;
+}
+
 export default function MessageList({
   messages,
   loading,
@@ -95,7 +115,7 @@ export default function MessageList({
 
       <Box sx={{ flexGrow: 1 }} />
 
-      {messages.map((msg) => (
+      {messages.map((msg, idx) => (
         <MessageItem
           key={msg.id}
           message={msg}
@@ -107,6 +127,7 @@ export default function MessageList({
           isBookmarked={bookmarkedMessageIds.has(msg.id)}
           onBookmarkChange={onBookmarkChange}
           onQuoteReply={onQuoteReply}
+          isContinued={isContinuedMessage(messages, idx)}
         />
       ))}
 

--- a/packages/client/src/components/Chat/ReactionBadge.tsx
+++ b/packages/client/src/components/Chat/ReactionBadge.tsx
@@ -8,6 +8,7 @@ interface Props {
   onClick: (emoji: string) => void;
 }
 
+// Step 4: 22px ピル形状 + accent 色化 を inline style で渡してテスト容易性を確保する
 export default function ReactionBadge({ reaction, currentUserId, users, onClick }: Props) {
   const reacted = reaction.userIds.includes(currentUserId);
 
@@ -27,21 +28,27 @@ export default function ReactionBadge({ reaction, currentUserId, users, onClick 
         data-testid="reaction-badge"
         data-reacted={reacted ? 'true' : 'false'}
         onClick={() => onClick(reaction.emoji)}
+        style={{
+          height: '22px',
+          borderRadius: '11px',
+          borderWidth: '1px',
+          borderStyle: 'solid',
+          borderColor: reacted ? 'var(--accent)' : 'var(--border)',
+          background: reacted ? 'var(--accent-soft)' : 'var(--surface)',
+          color: reacted ? 'var(--accent)' : 'var(--text-muted)',
+          fontWeight: reacted ? 600 : 400,
+        }}
         sx={{
           display: 'inline-flex',
           alignItems: 'center',
           gap: 0.5,
-          border: '1px solid',
-          borderColor: reacted ? 'primary.main' : 'divider',
-          bgcolor: reacted ? 'primary.50' : 'background.paper',
-          borderRadius: 3,
-          px: 0.75,
-          py: 0.25,
+          px: 0.875,
+          py: 0,
           cursor: 'pointer',
-          fontSize: '0.8rem',
-          lineHeight: 1.4,
-          fontWeight: reacted ? 600 : 400,
-          '&:hover': { bgcolor: reacted ? 'primary.100' : 'action.hover' },
+          fontSize: '0.72rem',
+          lineHeight: 1,
+          transition: 'background 0.1s, border-color 0.1s',
+          '&:hover': { background: 'var(--surface-hover)' },
         }}
       >
         <span>{reaction.emoji}</span>


### PR DESCRIPTION
## 概要

モック (`doc/brushup-uiux-plan/UI改善モック.html` / `channel.jsx`) のチャット画面方向性に合わせ、`MessageItem` 周辺をフラット表示に作り変える Step 4。バブル装飾を撤去し、連投マージ・ホバー時アクションバーのフロート化・リアクションピル形状を実装した。

PROGRESS.md / claude-code-prompt.md §3.5 の Step 4 に対応。

## 変更内容

### プロダクションコード
- **`MessageBubble.tsx`**: 角丸 (`borderRadius: '12px 12px 0 12px'`) / 背景色 (`bgcolor: '#dbeafe' / 'grey.100'`) / `px,py` パディングを撤去し、プレーンな縦組みへ。`isOwn` props も不要になったため削除
- **`MessageItem.tsx`**:
  - 自分メッセージの右寄せ (`flexDirection: 'row-reverse'`) を撤去し全行左揃え統一
  - `maxWidth: '75%'` 撤去
  - `isContinued?: boolean` props を新設し、true のとき avatar・displayName・時刻ヘッダーを描画しない (gutter は 36px スペーサーで本文の左端位置を維持)
  - アクションバーをバブル横並びから外し、`position: absolute; top: -12px; right: 24px;` でフロート化 (モック準拠)
  - 表示制御は `display: none` ではなく `opacity: 0; pointer-events: none;` を採用 — display:none だと a11y tree から Edit/Delete ボタンが消えてしまうため
- **`MessageList.tsx`**: `isContinuedMessage(messages, idx)` を実装し各 MessageItem に `isContinued` を渡す。境界は **5 分未満で同送信者**、片方でも削除済みならチェーン切断
- **`MessageActions.tsx`**: 自前の `opacity: 0` / `transition` 制御を撤去 (外側 `.msg-actions-floating` の opacity に統一)
- **`ReactionBadge.tsx`**: 高さ 22px / `borderRadius: 11px` のピル形状に変更。自分のリアクションは `var(--accent)` 枠 + 文字色、他人は `var(--border)` neutral。inline `style` で渡してテスト容易性を確保

### テスト
- **新規** `ReactionBadge.test.tsx` (8 ケース) — ピル形状 / `data-reacted` / accent 色化 / クリック挙動
- `MessageList.test.tsx` (+6 ケース) — 連投マージ判定: 同送信者5分以内/5分超 / 異送信者 / 削除済み前後 / 1件目
- `MessageItem.test.tsx` (+6 ケース) — 連投マージ表示: アバター/名前/時刻の有無 / `isDeleted=true` 時は連投無視
- 既存 4 ファイル (BookmarkPage / MessageItemReaction / MessageItemThread / QuoteReply) のアクションバー内ボタンクリックテスト 14 件で `userEvent.click(..., { pointerEventsCheck: 0 })` を付与 — フロート化により実機ではホバー → クリックの順だが、ユニットテストでは pointer-events チェックを外す形で互換性を維持

## 影響範囲

- チャット画面 (`ChatPage`) のメッセージ表示全般
- `MessageItem` を使用する画面: スレッドドロワー (`ThreadDrawer`) / DM (`DMPage`) / ブックマーク (`BookmarkPage`) / Inbox 系 (現状未実装) / その他検索結果プレビュー
- リアクション表示 (`ReactionBadge`) を使う全箇所
- `MessageBubble` の `isOwn` props 削除に伴い、呼び出し側 (MessageItem) のみ修正

### 振る舞いの変更点
- 自分メッセージの右寄せが廃止される (Slack/Discord 寄りの全行左揃えに変更)
- 連続投稿のヘッダーが省略される (5 分未満閾値)
- アクションバーは行ホバー時のみ表示 (従来も同じだが、位置がバブル隣接からフロート絶対配置に変わる)

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1344 件 pass / 5 件 skip — `ScheduledMessagesDialog` 既存スキップ)
- [x] バックエンドユニットテストがすべてパスする (本 PR は client 側のみ変更だが既存テストへの波及なし)
- [x] ビルドが正常に完了すること (`tsc --noEmit` エラー 0)
- [x] ESLint エラー 0 (warnings 68 はすべて既存)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット ← 別途まとめて実施予定

## 関連Issue
PROGRESS.md ステップ #4 / claude-code-prompt.md §3.5

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に統合ブランチで実施 (作業ブランチで触ると PROGRESS.md がコンフリクトするため運用ルール準拠)
- [x] `it.todo` / 空ボディの `it` が残っていない (本 PR で追加した `it.todo` 20 件はすべて実テストに書き換え済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)