### PR TITLE
feat(context-rail): ContextRail 新設 + AppLayout 4 列対応 + トグル/永続化 (Step 5a)

### DIFF
--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -100,4 +100,35 @@ describe('AppLayout', () => {
       expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument();
     });
   });
+
+  describe('rightPane prop による 4 列対応 (Step 5a)', () => {
+    it('rightPane を渡したとき grid が 4 列 (Rail / Sidebar / Main / RightPane 320px) になる', () => {
+      render(
+        <MemoryRouter>
+          <AppLayout sidebar={<div />} rightPane={<div data-testid="right-pane-content" />}>
+            <div />
+          </AppLayout>
+        </MemoryRouter>,
+      );
+      const grid = screen.getByTestId('app-layout-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr 320px' });
+    });
+
+    it('rightPane を渡さないとき grid は従来の 3 列構造のまま', () => {
+      renderLayout();
+      const grid = screen.getByTestId('app-layout-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr' });
+    });
+
+    it('rightPane に渡したコンテンツが Right 列に描画される', () => {
+      render(
+        <MemoryRouter>
+          <AppLayout sidebar={<div />} rightPane={<div data-testid="right-pane-content" />}>
+            <div />
+          </AppLayout>
+        </MemoryRouter>,
+      );
+      expect(screen.getByTestId('right-pane-content')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -28,13 +28,14 @@ vi.mock('../components/Channel/ChannelList', () => ({ default: MockChannelList }
 // SidebarDmList 自体の挙動は SidebarDmList.test.tsx で検証する。
 vi.mock('../components/Layout/SidebarDmList', () => ({ default: () => null }));
 
-// AppLayout スタブ — searchQuery/onSearchChange/onSearchFocus を子に露出する
+// AppLayout スタブ — searchQuery/onSearchChange/onSearchFocus に加え rightPane (Step 5a) も露出する
 vi.mock('../components/Layout/AppLayout', async () => {
   const React = (await import('react')) as typeof import('react');
   return {
     default: ({
       sidebar,
       children,
+      rightPane,
       searchQuery,
       onSearchChange,
       onSearchFocus,
@@ -42,6 +43,7 @@ vi.mock('../components/Layout/AppLayout', async () => {
     }: {
       sidebar: React.ReactNode;
       children: React.ReactNode;
+      rightPane?: React.ReactNode;
       searchQuery?: string;
       onSearchChange?: (q: string) => void;
       onSearchFocus?: () => void;
@@ -59,9 +61,15 @@ vi.mock('../components/Layout/AppLayout', async () => {
           onBlur: () => onSearchBlur?.(),
         }),
         children,
+        rightPane,
       ),
   };
 });
+
+// ContextRail スタブ — open 状態を data-testid で確認するため簡易表示にする (Step 5a)
+vi.mock('../components/Channel/ContextRail', () => ({
+  default: () => <div data-testid="context-rail-stub" />,
+}));
 
 vi.mock('../components/Chat/MessageList', () => ({ default: () => null }));
 // RichEditor を props キャプチャ可能なモックに差し替え（#113 で disabled prop を検証する）
@@ -528,6 +536,82 @@ describe('ChatPage', () => {
       expect(mockSnackbar.showInfo).toHaveBeenCalledWith(
         '投稿に注意ワードが含まれています: caution',
       );
+    });
+  });
+
+  describe('ContextRail トグル + 永続化 (Step 5a)', () => {
+    beforeEach(async () => {
+      const React = await import('react');
+      window.localStorage.clear();
+      // チャンネル選択状態にしておく (panelR ボタンはチャンネル選択時のみ表示する想定)
+      Object.defineProperty(window, 'location', {
+        value: { search: '?channel=1', hash: '', pathname: '/', origin: 'http://localhost' },
+        writable: true,
+        configurable: true,
+      });
+      // ChatPage は ChannelList の onSelect 経由でしか activeChannel (Channel オブジェクト) を
+      // セットしないため、テスト内では MockChannelList が即座に onSelect を発火させて
+      // activeChannel をセットする。
+      const mockChannel = {
+        id: 1,
+        name: 'general',
+        description: null,
+        topic: null,
+        createdBy: 1,
+        createdAt: '2024-01-01T00:00:00Z',
+        isPrivate: false,
+        postingPermission: 'everyone' as const,
+        unreadCount: 0,
+        isArchived: false,
+      };
+      // MockChannelList は vi.fn(() => null) で初期化されているため、引数を取る関数を
+      // mockImplementation で渡すと TS シグネチャ不一致になる。テスト用なので抑制する。
+      MockChannelList.mockImplementation(
+        // @ts-expect-error mockImplementation の引数シグネチャを差し替える (テスト専用)
+        ({
+          onSelect,
+        }: {
+          onSelect?: (id: number, name: string, channel: typeof mockChannel) => void;
+        }) => {
+          // onSelect は ChatPage で inline 関数として渡されるためレンダー毎に新しい参照になる。
+          // 依存配列に入れると無限ループするので mount 時のみ発火させる。
+
+          React.useEffect(() => {
+            onSelect?.(1, 'general', mockChannel);
+          }, []);
+          return null;
+        },
+      );
+    });
+
+    it('panelR トグルボタン (aria-label="コンテキストペインを開く") をクリックすると ContextRail が表示される', async () => {
+      render(<ChatPage users={[]} />);
+      expect(screen.queryByTestId('context-rail-stub')).not.toBeInTheDocument();
+      await userEvent.click(screen.getByRole('button', { name: 'コンテキストペインを開く' }));
+      expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
+    });
+
+    it('再度クリックすると ContextRail が非表示になる', async () => {
+      render(<ChatPage users={[]} />);
+      const button = screen.getByRole('button', { name: 'コンテキストペインを開く' });
+      await userEvent.click(button);
+      expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
+      await userEvent.click(button);
+      expect(screen.queryByTestId('context-rail-stub')).not.toBeInTheDocument();
+    });
+
+    it('開閉状態が localStorage["contextRail.open"] に保存される', async () => {
+      render(<ChatPage users={[]} />);
+      await userEvent.click(screen.getByRole('button', { name: 'コンテキストペインを開く' }));
+      await waitFor(() => {
+        expect(window.localStorage.getItem('contextRail.open')).toBe('true');
+      });
+    });
+
+    it('初期表示時 localStorage["contextRail.open"] が "true" のとき ContextRail が開いた状態で復元される', () => {
+      window.localStorage.setItem('contextRail.open', 'true');
+      render(<ChatPage users={[]} />);
+      expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/ContextRail.test.tsx
+++ b/packages/client/src/__tests__/ContextRail.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * components/Channel/ContextRail.tsx のユニットテスト (Step 5a)
+ *
+ * テスト対象:
+ *   - 概要 / ピン留め / メンバーの 3 タブ表示と切替
+ *   - close (×) ボタンによる onClose 呼び出し
+ *   - 各タブで対応するコンテンツが描画されること
+ *
+ * 戦略:
+ *   - 内部で利用する ChannelTopicBar / PinnedMessages / MembersContent は API 依存があるため
+ *     vi.mock でスタブ化し、ContextRail のタブ切替ロジックのみを検証する
+ *   - MUI Tabs の `role="tab"` / `aria-selected` を利用してタブ状態を確認
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import type { Channel } from '@chat-app/shared';
+import ContextRail from '../components/Channel/ContextRail';
+import { makeChannel } from './__fixtures__/channels';
+
+vi.mock('../components/Channel/ChannelTopicBar', () => ({
+  default: ({ channel }: { channel: Channel }) => (
+    <div data-testid="channel-topic-bar-stub">topic-bar:{channel.id}</div>
+  ),
+}));
+
+vi.mock('../components/Channel/PinnedMessages', () => ({
+  default: ({ channelId }: { channelId: number }) => (
+    <div data-testid="pinned-messages-stub">pinned:{channelId}</div>
+  ),
+}));
+
+vi.mock('../components/Channel/ChannelMembersDialog', () => ({
+  MembersContent: ({ channelId }: { channelId: number }) => (
+    <div data-testid="members-content-stub">members:{channelId}</div>
+  ),
+}));
+
+// ContextRail は内部で api.auth.users() / api.channels.getMembers() を呼んで Promise を生成する。
+// jsdom 環境では fetch が解決できず unhandled rejection になるため、api を stub にする
+vi.mock('../api/client', () => ({
+  api: {
+    auth: { users: vi.fn().mockResolvedValue({ users: [] }) },
+    channels: { getMembers: vi.fn().mockResolvedValue({ members: [] }) },
+  },
+}));
+
+interface RenderOpts {
+  topic?: string | null;
+  description?: string | null;
+  onClose?: () => void;
+}
+
+function renderRail(opts: RenderOpts = {}) {
+  const channel = makeChannel(42, 'design-review');
+  channel.topic = opts.topic === undefined ? 'プロダクトデザインのレビュー' : opts.topic;
+  channel.description =
+    opts.description === undefined ? 'レビュー依頼は火・木の朝に投稿' : opts.description;
+
+  return render(
+    <ContextRail
+      channel={channel}
+      currentUserId={1}
+      userRole="user"
+      onClose={opts.onClose ?? vi.fn()}
+      onTopicUpdated={vi.fn()}
+      onUnpin={vi.fn()}
+    />,
+  );
+}
+
+describe('ContextRail (Step 5a)', () => {
+  describe('初期表示', () => {
+    it('概要 / ピン留め / メンバーの 3 つのタブボタンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('tab', { name: '概要' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'ピン留め' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'メンバー' })).toBeInTheDocument();
+    });
+
+    it('初期表示時は概要タブが選択されている (aria-selected="true")', () => {
+      renderRail();
+      expect(screen.getByRole('tab', { name: '概要' })).toHaveAttribute('aria-selected', 'true');
+      expect(screen.getByRole('tab', { name: 'ピン留め' })).toHaveAttribute(
+        'aria-selected',
+        'false',
+      );
+      expect(screen.getByRole('tab', { name: 'メンバー' })).toHaveAttribute(
+        'aria-selected',
+        'false',
+      );
+    });
+
+    it('チャンネル名 (#xxx) がヘッダに表示される', () => {
+      renderRail();
+      expect(screen.getByText('#design-review')).toBeInTheDocument();
+    });
+
+    it('close (×) ボタンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('button', { name: '閉じる' })).toBeInTheDocument();
+    });
+  });
+
+  describe('タブ切替', () => {
+    it('ピン留めタブをクリックすると PinnedMessages 領域が描画される', async () => {
+      renderRail();
+      await userEvent.click(screen.getByRole('tab', { name: 'ピン留め' }));
+      expect(screen.getByTestId('pinned-messages-stub')).toBeInTheDocument();
+    });
+
+    it('メンバータブをクリックするとメンバー一覧領域が描画される', async () => {
+      renderRail();
+      await userEvent.click(screen.getByRole('tab', { name: 'メンバー' }));
+      expect(screen.getByTestId('members-content-stub')).toBeInTheDocument();
+    });
+
+    it('概要タブに戻ると channel の topic / description が描画される', async () => {
+      renderRail({ topic: 'プロダクトデザインのレビュー', description: '火・木に投稿' });
+      // 一度ピン留めタブに切替
+      await userEvent.click(screen.getByRole('tab', { name: 'ピン留め' }));
+      expect(screen.queryByText('プロダクトデザインのレビュー')).not.toBeInTheDocument();
+      // 概要タブに戻る
+      await userEvent.click(screen.getByRole('tab', { name: '概要' }));
+      expect(screen.getByText('プロダクトデザインのレビュー')).toBeInTheDocument();
+      expect(screen.getByText('火・木に投稿')).toBeInTheDocument();
+    });
+  });
+
+  describe('close ボタン', () => {
+    it('× ボタンをクリックすると onClose が呼ばれる', async () => {
+      const onClose = vi.fn();
+      renderRail({ onClose });
+      await userEvent.click(screen.getByRole('button', { name: '閉じる' }));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/client/src/components/Channel/ChannelMembersDialog.tsx
+++ b/packages/client/src/components/Channel/ChannelMembersDialog.tsx
@@ -28,14 +28,15 @@ interface Props {
   onClose: () => void;
 }
 
-type MembersData = [{ users: User[] }, { members: User[] }];
+export type MembersData = [{ users: User[] }, { members: User[] }];
 
 interface MembersContentProps {
   membersPromise: Promise<MembersData>;
   channelId: number;
 }
 
-function MembersContent({ membersPromise, channelId }: MembersContentProps) {
+// Step 5a: ContextRail のメンバータブから再利用するため named export を追加
+export function MembersContent({ membersPromise, channelId }: MembersContentProps) {
   const [{ users: allUsers }, { members }] = use(membersPromise);
   const [memberIds, setMemberIds] = useState<Set<number>>(() => new Set(members.map((m) => m.id)));
   const [loadingId, setLoadingId] = useState<number | null>(null);

--- a/packages/client/src/components/Channel/ContextRail.tsx
+++ b/packages/client/src/components/Channel/ContextRail.tsx
@@ -1,0 +1,126 @@
+import { useMemo, useState, Suspense } from 'react';
+import { Box, CircularProgress, IconButton, Tab, Tabs, Typography } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import type { Channel } from '@chat-app/shared';
+import ChannelTopicBar from './ChannelTopicBar';
+import PinnedMessages from './PinnedMessages';
+import { MembersContent, type MembersData } from './ChannelMembersDialog';
+import { api } from '../../api/client';
+
+type TabKey = 'summary' | 'pins' | 'members';
+
+interface Props {
+  channel: Channel;
+  currentUserId: number;
+  userRole: string;
+  onClose: () => void;
+  onTopicUpdated: (channel: Channel) => void;
+  pinRefreshKey?: number;
+  onUnpin: (messageId: number) => void;
+}
+
+/**
+ * Step 5a: チャンネル右側 320px の折り畳み可能ペイン。
+ * 概要 / ピン留め / メンバーの 3 タブを集約する。ファイル / 予定タブは Step 5b で追加予定。
+ *
+ * 既存の `ChannelTopicBar` / `PinnedMessages` / `ChannelMembersDialog#MembersContent` を再利用する形で実装。
+ * 開閉状態の永続化は呼び出し元 (ChatPage) で `localStorage["contextRail.open"]` に保存する。
+ */
+export default function ContextRail({
+  channel,
+  currentUserId,
+  userRole,
+  onClose,
+  onTopicUpdated,
+  pinRefreshKey = 0,
+  onUnpin,
+}: Props) {
+  const [tab, setTab] = useState<TabKey>('summary');
+
+  // メンバータブが選択されている間だけ Promise を生成して MembersContent に渡す
+  const membersPromise = useMemo<Promise<MembersData> | null>(() => {
+    if (tab !== 'members') return null;
+    return Promise.all([api.auth.users(), api.channels.getMembers(channel.id)]);
+  }, [tab, channel.id]);
+
+  return (
+    <Box
+      data-testid="context-rail"
+      sx={{
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        borderLeft: '1px solid var(--border)',
+        background: 'var(--surface)',
+        minHeight: 0,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          px: 1.5,
+          py: 1,
+          borderBottom: '1px solid var(--border)',
+        }}
+      >
+        <Typography sx={{ flexGrow: 1, fontWeight: 600, fontSize: 14 }}>#{channel.name}</Typography>
+        <IconButton size="small" aria-label="閉じる" onClick={onClose}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </Box>
+
+      <Tabs
+        value={tab}
+        onChange={(_, v: TabKey) => setTab(v)}
+        variant="fullWidth"
+        sx={{ minHeight: 36, borderBottom: '1px solid var(--border)' }}
+      >
+        <Tab value="summary" label="概要" sx={{ minHeight: 36, fontSize: 13 }} />
+        <Tab value="pins" label="ピン留め" sx={{ minHeight: 36, fontSize: 13 }} />
+        <Tab value="members" label="メンバー" sx={{ minHeight: 36, fontSize: 13 }} />
+      </Tabs>
+
+      <Box sx={{ flex: 1, overflow: 'auto', p: 1.5, minHeight: 0 }}>
+        {tab === 'summary' && (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+            {channel.topic && <Typography variant="body2">{channel.topic}</Typography>}
+            {channel.description && (
+              <Typography variant="body2" color="text.secondary">
+                {channel.description}
+              </Typography>
+            )}
+            <ChannelTopicBar
+              channel={channel}
+              currentUserId={currentUserId}
+              userRole={userRole}
+              onTopicUpdated={onTopicUpdated}
+            />
+          </Box>
+        )}
+
+        {tab === 'pins' && (
+          <PinnedMessages
+            channelId={channel.id}
+            currentUserId={currentUserId}
+            refreshKey={pinRefreshKey}
+            onUnpin={onUnpin}
+          />
+        )}
+
+        {tab === 'members' && membersPromise && (
+          <Suspense
+            fallback={
+              <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                <CircularProgress size={20} />
+              </Box>
+            }
+          >
+            <MembersContent membersPromise={membersPromise} channelId={channel.id} />
+          </Suspense>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/client/src/components/Layout/AppLayout.tsx
+++ b/packages/client/src/components/Layout/AppLayout.tsx
@@ -6,20 +6,24 @@ import SidebarFooter from './SidebarFooter';
 
 const RAIL_WIDTH = 64;
 const SIDEBAR_WIDTH = 240;
+const RIGHT_PANE_WIDTH = 320;
 
 interface Props {
   sidebar: ReactNode;
   children: ReactNode;
+  // Step 5a: ContextRail などの右ペインを表示するときに渡す。undefined のときは grid を従来の 3 列構造に保つ
+  rightPane?: ReactNode;
 }
 
 /**
- * 3 列グリッドの共通レイアウト。
+ * 3 列 / 4 列グリッドの共通レイアウト。
  * - Step 2a: Drawer 撤去 / 3 列 grid 化 / Rail 新設。
  * - Step 2b: AppBar 撤去 / SidebarFooter (ステータス・テーマ・通知・プロフィール・ログアウト)
  *           を Sidebar 列フッターに集約。検索 box は AppLayout 側からは撤去
  *           （PROGRESS.md 保留 TODO #2、Step 7 で検索ページ新設時に再構築）。
+ * - Step 5a: rightPane prop で 4 列構造をオプション対応 (Rail / Sidebar / Main / RightPane 320px)。
  */
-export default function AppLayout({ sidebar, children }: Props) {
+export default function AppLayout({ sidebar, children, rightPane }: Props) {
   const [reminderNotification, setReminderNotification] = useState<string | null>(null);
   const socket = useSocket();
 
@@ -65,7 +69,9 @@ export default function AppLayout({ sidebar, children }: Props) {
         sx={{
           flex: 1,
           display: 'grid',
-          gridTemplateColumns: `${RAIL_WIDTH}px ${SIDEBAR_WIDTH}px 1fr`,
+          gridTemplateColumns: rightPane
+            ? `${RAIL_WIDTH}px ${SIDEBAR_WIDTH}px 1fr ${RIGHT_PANE_WIDTH}px`
+            : `${RAIL_WIDTH}px ${SIDEBAR_WIDTH}px 1fr`,
           overflow: 'hidden',
           minHeight: 0,
         }}
@@ -99,6 +105,20 @@ export default function AppLayout({ sidebar, children }: Props) {
         >
           {children}
         </Box>
+
+        {rightPane && (
+          <Box
+            data-testid="app-layout-right"
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              minHeight: 0,
+            }}
+          >
+            {rightPane}
+          </Box>
+        )}
       </Box>
 
       <Snackbar

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -2,11 +2,13 @@ import { useState, useEffect, useCallback, useMemo, Suspense, useRef } from 'rea
 import { Box, IconButton, Tooltip, Typography, CircularProgress } from '@mui/material';
 import ScheduleSendIcon from '@mui/icons-material/ScheduleSend';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
+import ViewSidebarIcon from '@mui/icons-material/ViewSidebar';
 import AppLayout from '../components/Layout/AppLayout';
 import { ChannelFilesTab } from './FilesPage';
 import ChannelList from '../components/Channel/ChannelList';
 import SidebarDmList from '../components/Layout/SidebarDmList';
 import ChannelTopicBar from '../components/Channel/ChannelTopicBar';
+import ContextRail from '../components/Channel/ContextRail';
 import MessageList from '../components/Chat/MessageList';
 import RichEditor, { type QuotedMessagePreview } from '../components/Chat/RichEditor';
 import SearchResults from '../components/Chat/SearchResults';
@@ -53,6 +55,13 @@ export default function ChatPage({ users }: Props) {
     return true;
   })();
   const [pinRefreshKey, setPinRefreshKey] = useState(0);
+  // Step 5a: ContextRail の開閉状態 + localStorage 永続化
+  const [contextRailOpen, setContextRailOpen] = useState<boolean>(
+    () => window.localStorage.getItem('contextRail.open') === 'true',
+  );
+  useEffect(() => {
+    window.localStorage.setItem('contextRail.open', String(contextRailOpen));
+  }, [contextRailOpen]);
   const [bookmarkedMessageIds, setBookmarkedMessageIds] = useState<Set<number>>(new Set());
   const { messages, loading, loadMore, refetch } = useMessages(activeChannelId);
   const socket = useSocket();
@@ -309,6 +318,19 @@ export default function ChatPage({ users }: Props) {
           <SidebarDmList />
         </Box>
       }
+      rightPane={
+        contextRailOpen && activeChannel && user ? (
+          <ContextRail
+            channel={activeChannel}
+            currentUserId={user.id}
+            userRole={user.role}
+            onClose={() => setContextRailOpen(false)}
+            onTopicUpdated={(updated) => setActiveChannel(updated)}
+            pinRefreshKey={pinRefreshKey}
+            onUnpin={handleUnpinMessage}
+          />
+        ) : undefined
+      }
     >
       <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
         {/* メインエリア */}
@@ -364,6 +386,21 @@ export default function ChatPage({ users }: Props) {
                   sx={{ flexShrink: 0 }}
                 >
                   <ScheduleSendIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              {/* Step 5a: コンテキストペイン (ContextRail) のトグル */}
+              <Tooltip title="コンテキストペインを開く">
+                <IconButton
+                  size="small"
+                  aria-label="コンテキストペインを開く"
+                  onClick={() => setContextRailOpen((v) => !v)}
+                  data-active={contextRailOpen ? 'true' : undefined}
+                  sx={{
+                    bgcolor: contextRailOpen ? 'action.selected' : undefined,
+                    flexShrink: 0,
+                  }}
+                >
+                  <ViewSidebarIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
             </Box>


### PR DESCRIPTION
## 概要

モック (`doc/brushup-uiux-plan/UI改善モック.html` / `channel.jsx`) に沿って、チャンネル右側 320px の折り畳み可能ペイン (ContextRail) を新設する Step 5a。概要 / ピン留め / メンバーの 3 タブを集約し、AppLayout を rightPane prop で 4 列構造に対応させ、開閉状態を `localStorage["contextRail.open"]` で永続化する。

ファイル / 予定タブ追加と既存 UI 撤去は Step 5b に分離（PR スコープを絞るため）。

## 変更内容

### 新規コンポーネント
- **`components/Channel/ContextRail.tsx`** — 320px 折り畳みペイン (Tabs + TabPanel)
  - 概要タブ: `ChannelTopicBar` をそのまま埋め込み + topic / description 表示
  - ピン留めタブ: `PinnedMessages` を再利用
  - メンバータブ: `ChannelMembersDialog` から named export した `MembersContent` を再利用 (Suspense + Promise stable)
  - close (×) ボタンで `onClose` 呼出

### 変更
- **`components/Layout/AppLayout.tsx`** — `rightPane?: ReactNode` prop を追加
  - rightPane あり: grid を `64px 240px 1fr 320px` の 4 列に切替
  - なし: 従来の 3 列構造を維持
- **`components/Channel/ChannelMembersDialog.tsx`** — `MembersContent` / `MembersData` を named export に変更 (ContextRail のメンバータブから再利用するため)
- **`pages/ChatPage.tsx`**
  - panelR トグルボタン (`ViewSidebarIcon` / aria-label="コンテキストペインを開く") をトップバーに追加
  - `useState` + `useEffect` で `localStorage["contextRail.open"]` に開閉状態を永続化
  - AppLayout の rightPane に ContextRail を渡す (activeChannel + user が存在するときのみ)

### テスト追加 (15 件)
- **新規** `__tests__/ContextRail.test.tsx` (8 件) — 3 タブ表示 / 初期は概要タブ選択 / チャンネル名表示 / close ボタン / タブ切替で各コンテンツ描画 / onClose 呼出
- `__tests__/AppLayout.test.tsx` (+3 件) — rightPane あり 4 列 / なし 3 列 / Right 列描画
- `__tests__/ChatPage.test.tsx` (+4 件) — panelR トグル開 / 再クリックで閉 / localStorage 書込 / 初期表示時 localStorage から復元
  - AppLayout モックを `rightPane` 受け取り対応に拡張
  - ContextRail を `vi.mock` でスタブ化
  - Step 5a describe の beforeEach で MockChannelList の onSelect を mount 時に発火させて activeChannel をセット (ChatPage は ChannelList の onSelect 経由でしか activeChannel をセットしないため)

## 影響範囲

- チャンネル画面 (ChatPage) のレイアウトが 4 列対応へ拡張される
- 開閉状態は localStorage キー `contextRail.open` を新規消費
- AppLayout の `gridTemplateColumns` が rightPane の有無で切り替わる
- ChannelMembersDialog の export shape が増える (default + named)、既存 default import 利用箇所は影響なし
- 現状は ContextRail と既存 UI (TopicBar 編集 / PinnedMessages 上部バー / MembersDialog) が**併設**される (UI 重複あり、リリース・実装方針で許容)

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1359 件 pass / 5 件 skip)
- [x] バックエンドユニットテストがすべてパスする (本 PR は client 側のみ変更)
- [x] ビルドが正常に完了すること (`tsc --noEmit` エラー 0)
- [x] ESLint エラー 0 (warnings 69 はすべて既存)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット ← 別途まとめて実施予定

## 関連Issue
PROGRESS.md ステップ #5 / claude-code-prompt.md §3.6

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に統合ブランチで実施 (作業ブランチでステータス更新するとマージ時にコンフリクトするため運用ルール準拠)
- [x] `it.todo` / 空ボディの `it` が残っていない (本 PR で追加した `it.todo` 15 件はすべて実テストに書き換え済み)

## Step 5b 残タスク (マージ後別 PR で対応 / PROGRESS.md 保留 TODO に追記予定)
- ファイル / 予定タブの追加
- 既存 `ChannelTopicBar` 編集ボタン群 / `PinnedMessages` 上部バー / `ChannelMembersDialog` の撤去 (UI 重複解消)

🤖 Generated with [Claude Code](https://claude.com/claude-code)