### PR TITLE
feat(context-rail): ファイル/予定タブ追加 + Main 上部 PinnedMessages バー撤去 (Step 5b)

### DIFF
--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -92,7 +92,9 @@ vi.mock('../components/Chat/SearchFilterPanel', () => ({
 vi.mock('../components/Chat/SearchResults', () => ({ default: () => null }));
 vi.mock('../components/Chat/ThreadPanel', () => ({ default: () => null }));
 vi.mock('../components/Channel/ChannelTopicBar', () => ({ default: () => null }));
-vi.mock('../components/Channel/PinnedMessages', () => ({ default: () => null }));
+// Step 5b: PinnedMessages の Main 上部バー撤去確認のため呼び出しを track できるよう vi.fn にする
+const MockPinnedMessages = vi.hoisted(() => vi.fn(() => null));
+vi.mock('../components/Channel/PinnedMessages', () => ({ default: MockPinnedMessages }));
 vi.mock('../components/Channel/ArchivedBanner', () => ({ default: () => null }));
 // ScheduledMessagesDialog: open prop を data-testid で確認可能にする
 vi.mock('../components/Chat/ScheduledMessagesDialog', () => ({
@@ -612,6 +614,23 @@ describe('ChatPage', () => {
       window.localStorage.setItem('contextRail.open', 'true');
       render(<ChatPage users={[]} />);
       expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
+    });
+  });
+
+  describe('PinnedMessages 上部バー撤去 (Step 5b)', () => {
+    beforeEach(() => {
+      // チャンネル選択済みの状態にする (PinnedMessages はチャンネル選択時のみ Main 上部に描画されていた)
+      Object.defineProperty(window, 'location', {
+        value: { search: '?channel=1', hash: '', pathname: '/', origin: 'http://localhost' },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('ChatPage の Main エリアに PinnedMessages の上部バーが描画されない (ContextRail 経由のみで表示)', () => {
+      // ContextRail は vi.mock でスタブ化されているため、ChatPage 直接の呼び出しのみ MockPinnedMessages がカウントする
+      render(<ChatPage users={[]} />);
+      expect(MockPinnedMessages).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/client/src/__tests__/ContextRail.test.tsx
+++ b/packages/client/src/__tests__/ContextRail.test.tsx
@@ -46,6 +46,13 @@ vi.mock('../api/client', () => ({
   },
 }));
 
+// Step 5b: ファイルタブで ChannelFilesTab を再利用する。テストではスタブ化する
+vi.mock('../pages/FilesPage', () => ({
+  ChannelFilesTab: ({ channelId }: { channelId: number }) => (
+    <div data-testid="channel-files-tab-stub">files:{channelId}</div>
+  ),
+}));
+
 interface RenderOpts {
   topic?: string | null;
   description?: string | null;
@@ -134,6 +141,30 @@ describe('ContextRail (Step 5a)', () => {
       renderRail({ onClose });
       await userEvent.click(screen.getByRole('button', { name: '閉じる' }));
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('タブ拡張 (Step 5b)', () => {
+    it('ファイルタブが「ファイル」というラベルで表示される', () => {
+      renderRail();
+      expect(screen.getByRole('tab', { name: 'ファイル' })).toBeInTheDocument();
+    });
+
+    it('ファイルタブをクリックすると ChannelFilesTab 領域が描画される', async () => {
+      renderRail();
+      await userEvent.click(screen.getByRole('tab', { name: 'ファイル' }));
+      expect(screen.getByTestId('channel-files-tab-stub')).toBeInTheDocument();
+    });
+
+    it('予定タブが「予定」というラベルで表示される', () => {
+      renderRail();
+      expect(screen.getByRole('tab', { name: '予定' })).toBeInTheDocument();
+    });
+
+    it('予定タブをクリックすると「準備中」プレースホルダが描画される', async () => {
+      renderRail();
+      await userEvent.click(screen.getByRole('tab', { name: '予定' }));
+      expect(screen.getByText('準備中')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/components/Channel/ContextRail.tsx
+++ b/packages/client/src/components/Channel/ContextRail.tsx
@@ -5,9 +5,10 @@ import type { Channel } from '@chat-app/shared';
 import ChannelTopicBar from './ChannelTopicBar';
 import PinnedMessages from './PinnedMessages';
 import { MembersContent, type MembersData } from './ChannelMembersDialog';
+import { ChannelFilesTab } from '../../pages/FilesPage';
 import { api } from '../../api/client';
 
-type TabKey = 'summary' | 'pins' | 'members';
+type TabKey = 'summary' | 'pins' | 'members' | 'files' | 'events';
 
 interface Props {
   channel: Channel;
@@ -20,11 +21,15 @@ interface Props {
 }
 
 /**
- * Step 5a: チャンネル右側 320px の折り畳み可能ペイン。
- * 概要 / ピン留め / メンバーの 3 タブを集約する。ファイル / 予定タブは Step 5b で追加予定。
+ * チャンネル右側 320px の折り畳み可能ペイン。
  *
- * 既存の `ChannelTopicBar` / `PinnedMessages` / `ChannelMembersDialog#MembersContent` を再利用する形で実装。
+ * 既存の `ChannelTopicBar` / `PinnedMessages` / `ChannelMembersDialog#MembersContent` /
+ * `ChannelFilesTab` を再利用する形で実装。
  * 開閉状態の永続化は呼び出し元 (ChatPage) で `localStorage["contextRail.open"]` に保存する。
+ *
+ * - Step 5a: 概要 / ピン留め / メンバーの 3 タブを集約。
+ * - Step 5b: ファイル / 予定タブを追加（予定タブはサーバー側にチャンネル別イベント一覧 API が
+ *   未実装のため「準備中」プレースホルダで暫定対応。実機データ化は Step 5c 以降に保留 TODO #12 として残す）。
  */
 export default function ContextRail({
   channel,
@@ -79,6 +84,8 @@ export default function ContextRail({
       >
         <Tab value="summary" label="概要" sx={{ minHeight: 36, fontSize: 13 }} />
         <Tab value="pins" label="ピン留め" sx={{ minHeight: 36, fontSize: 13 }} />
+        <Tab value="files" label="ファイル" sx={{ minHeight: 36, fontSize: 13 }} />
+        <Tab value="events" label="予定" sx={{ minHeight: 36, fontSize: 13 }} />
         <Tab value="members" label="メンバー" sx={{ minHeight: 36, fontSize: 13 }} />
       </Tabs>
 
@@ -107,6 +114,31 @@ export default function ContextRail({
             refreshKey={pinRefreshKey}
             onUnpin={onUnpin}
           />
+        )}
+
+        {tab === 'files' && (
+          <Suspense
+            fallback={
+              <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                <CircularProgress size={20} />
+              </Box>
+            }
+          >
+            <ChannelFilesTab channelId={channel.id} />
+          </Suspense>
+        )}
+
+        {tab === 'events' && (
+          <Box
+            sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1, p: 2 }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              準備中
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              チャンネル別の予定一覧は今後のアップデートで対応予定です。
+            </Typography>
+          </Box>
         )}
 
         {tab === 'members' && membersPromise && (

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -27,7 +27,6 @@ import type {
   Channel,
   RateLimitSocketError,
 } from '@chat-app/shared';
-import PinnedMessages from '../components/Channel/PinnedMessages';
 import ArchivedBanner from '../components/Channel/ArchivedBanner';
 import { useAuth } from '../contexts/AuthContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
@@ -477,14 +476,7 @@ export default function ChatPage({ users }: Props) {
                 </Box>
               ) : (
                 <>
-                  {activeChannelId && user && (
-                    <PinnedMessages
-                      channelId={activeChannelId}
-                      currentUserId={user.id}
-                      refreshKey={pinRefreshKey}
-                      onUnpin={handleUnpinMessage}
-                    />
-                  )}
+                  {/* Step 5b: Main 上部の PinnedMessages バーは ContextRail のピン留めタブに集約したため撤去 */}
                   {activeChannel?.isArchived && <ArchivedBanner />}
                   <MessageList
                     messages={messages}


### PR DESCRIPTION
## 概要

Step 5a で導入した ContextRail に「ファイル」「予定」タブを追加し、Main エリア上部の `<PinnedMessages>` バーを撤去する Step 5b。スコープは事前合意した「案 1: ミニマム」の A + B + C のみ。

ChannelTopicBar 編集系撤去 / ChannelMembersDialog 起動撤去 / 予定タブ実機データ化は Step 5c 以降に分離。

## 変更内容

### ContextRail にタブ追加
- **`components/Channel/ContextRail.tsx`**
  - `TabKey` を `'summary' | 'pins' | 'members' | 'files' | 'events'` に拡張
  - ファイルタブ: 既存 `ChannelFilesTab` (`pages/FilesPage` の named export) を Suspense でラップして再利用
  - 予定タブ: サーバー側にチャンネル別イベント一覧 API が未実装のため「準備中」プレースホルダで暫定対応 (実機データ化は保留 TODO #12)
  - Tab の並び順: 概要 / ピン留め / **ファイル / 予定** / メンバー

### Main 上部 PinnedMessages バー撤去
- **`pages/ChatPage.tsx`**
  - Main エリア上部の `<PinnedMessages>` 描画を撤去 (ContextRail のピン留めタブに集約済み)
  - `PinnedMessages` の import も削除
  - `pinRefreshKey` / `handleUnpinMessage` は ContextRail へ渡しているため維持

### テスト追加 (5 件)
- `__tests__/ContextRail.test.tsx` (+4 件)
  - ファイル/予定タブのラベル表示
  - ファイルタブクリックで `ChannelFilesTab` 領域描画
  - 予定タブクリックで「準備中」プレースホルダ描画
  - `vi.mock('../pages/FilesPage', ...)` で `ChannelFilesTab` をスタブ化
- `__tests__/ChatPage.test.tsx` (+1 件)
  - Main エリアに `PinnedMessages` の上部バーが描画されない
  - 既存 `vi.mock('../components/Channel/PinnedMessages', ...)` を `vi.hoisted` の `vi.fn` に変更し呼び出し track 可能化

## 影響範囲

- ContextRail のタブ数が 3 → 5 に増える (タブごとの幅は `variant="fullWidth"` で自動調整)
- ContextRail を表示している間、メンバータブ + ファイルタブの両方で API 呼び出し (`api.auth.users` / `api.channels.getMembers` / `api.channels.getAttachments`) が発生する可能性 (タブ切替で都度生成)
- Main エリア上部の Pinned バー表示が無くなる → ピン留めは ContextRail のピン留めタブから確認する動線に統一
- ContextRail を**閉じている**場合、ピン留めへのアクセスは ContextRail を開く必要がある (動線が一段増える)

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1364 件 pass / 5 件 skip)
- [x] バックエンドユニットテストがすべてパスする (本 PR は client 側のみ変更)
- [x] ビルドが正常に完了すること (`tsc --noEmit` エラー 0)
- [x] ESLint エラー 0 (warnings は既存)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット ← 別途まとめて実施予定

## 関連Issue
PROGRESS.md ステップ #5b / claude-code-prompt.md §3.6

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に統合ブランチで実施 (運用ルール準拠)
- [x] `it.todo` / 空ボディの `it` が残っていない (本 PR で追加した `it.todo` 5 件はすべて実テストに書き換え済み)

## Step 5c 残タスク (マージ後別 PR で対応 / 保留 TODO #9 #10 #11 #12 を更新予定)
- `ChannelTopicBar` 編集ボタン群 (招待/ゲスト/編集) の Main トップバーからの撤去 (ContextRail 概要タブに移譲)
- `ChannelList` からの `ChannelMembersDialog` 起動撤去 (ContextRail メンバータブで代替)
- 予定タブの実機データ化 (チャンネル別イベント一覧 API の追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)