### PR TITLE
feat(channel-list): ChannelMembersDialog 起動撤去 (Step 5c-2)

### DIFF
--- a/packages/client/src/__tests__/ChannelItem.test.tsx
+++ b/packages/client/src/__tests__/ChannelItem.test.tsx
@@ -37,6 +37,7 @@ const makeCategory = (id: number, name: string) => ({
   updatedAt: '2024-01-01T00:00:00Z',
 });
 
+// Step 5c-2: onOpenMembersDialog props は撤去 (メンバー管理は ContextRail メンバータブに統一)
 const defaultProps = {
   isActive: false,
   isPinned: false,
@@ -46,7 +47,6 @@ const defaultProps = {
   onClick: vi.fn(),
   onPin: vi.fn(),
   onUnpin: vi.fn(),
-  onOpenMembersDialog: vi.fn(),
 };
 
 /** 3点メニューを開くヘルパー */
@@ -336,7 +336,9 @@ describe('ChannelItem', () => {
     });
 
     describe('プライベートチャンネル（isPrivate=true）', () => {
-      it('「メンバー管理」が表示される', async () => {
+      // Step 5c-2: 「メンバー管理」MenuItem は ContextRail メンバータブに統一されたため、
+      // ChannelItem の 3 点メニューからは撤去する。private でも表示されないことを確認する。
+      it('Step 5c-2 後: プライベートチャンネルでも「メンバー管理」MenuItem は表示されない', async () => {
         render(
           <ChannelItem
             {...defaultProps}
@@ -345,7 +347,7 @@ describe('ChannelItem', () => {
           />,
         );
         await openMenu();
-        expect(screen.getByRole('menuitem', { name: 'メンバー管理' })).toBeInTheDocument();
+        expect(screen.queryByRole('menuitem', { name: 'メンバー管理' })).not.toBeInTheDocument();
       });
 
       it('「カテゴリへ移動」「通知レベル」「アーカイブ」「ピン留め」も表示される', async () => {
@@ -520,38 +522,8 @@ describe('ChannelItem', () => {
   // 3点メニュー: メンバー管理
   // ─────────────────────────────────────────────────────────
 
-  describe('3点メニュー: メンバー管理', () => {
-    it('「メンバー管理」をクリックすると onOpenMembersDialog が呼ばれる', async () => {
-      const onOpenMembersDialog = vi.fn();
-      const channel = makeChannel({ isPrivate: true });
-      render(
-        <ChannelItem
-          {...defaultProps}
-          channel={channel}
-          isHovered={true}
-          onOpenMembersDialog={onOpenMembersDialog}
-        />,
-      );
-      await openMenu();
-      await userEvent.click(screen.getByRole('menuitem', { name: 'メンバー管理' }));
-      expect(onOpenMembersDialog).toHaveBeenCalledWith(channel);
-    });
-
-    it('「メンバー管理」をクリックするとメニューが閉じる', async () => {
-      render(
-        <ChannelItem
-          {...defaultProps}
-          channel={makeChannel({ isPrivate: true })}
-          isHovered={true}
-        />,
-      );
-      await openMenu();
-      await userEvent.click(screen.getByRole('menuitem', { name: 'メンバー管理' }));
-      await waitFor(() => {
-        expect(screen.queryByRole('menuitem', { name: 'メンバー管理' })).not.toBeInTheDocument();
-      });
-    });
-  });
+  // Step 5c-2: 3点メニュー「メンバー管理」は撤去 (ContextRail メンバータブで代替)。
+  // メニュー項目自体が描画されないことの確認は上の「プライベートチャンネル」describe に移譲。
 
   // ─────────────────────────────────────────────────────────
   // 3点メニュー: アーカイブ

--- a/packages/client/src/components/Channel/ChannelCategorySection.tsx
+++ b/packages/client/src/components/Channel/ChannelCategorySection.tsx
@@ -18,7 +18,6 @@ interface ChannelCategorySectionProps {
   onPin: (channelId: number) => void;
   onUnpin: (channelId: number) => void;
   pinnedIds: number[];
-  onOpenMembersDialog: (channel: Channel) => void;
   onArchive: (channelId: number) => void;
   currentUserId?: number;
   userRole?: string;
@@ -44,7 +43,6 @@ export default function ChannelCategorySection({
   onPin,
   onUnpin,
   pinnedIds,
-  onOpenMembersDialog,
   onArchive,
   currentUserId,
   userRole,
@@ -194,7 +192,6 @@ export default function ChannelCategorySection({
               onClick={() => onSelect(ch.id, ch.name, ch)}
               onPin={onPin}
               onUnpin={onUnpin}
-              onOpenMembersDialog={onOpenMembersDialog}
               onArchive={onArchive}
               currentUserId={currentUserId}
               userRole={userRole}

--- a/packages/client/src/components/Channel/ChannelItem.tsx
+++ b/packages/client/src/components/Channel/ChannelItem.tsx
@@ -41,7 +41,6 @@ export interface ChannelItemProps {
   onClick: () => void;
   onPin: (channelId: number) => void;
   onUnpin: (channelId: number) => void;
-  onOpenMembersDialog: (channel: Channel) => void;
   onArchive?: (channelId: number) => void;
   currentUserId?: number;
   userRole?: string;
@@ -77,7 +76,6 @@ export default function ChannelItem({
   onClick,
   onPin,
   onUnpin,
-  onOpenMembersDialog,
   onArchive,
   currentUserId,
   userRole,
@@ -154,12 +152,6 @@ export default function ChannelItem({
     e.stopPropagation();
     handleMenuClose();
     onUnpin(channel.id);
-  };
-
-  const handleMembersClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    handleMenuClose();
-    onOpenMembersDialog(channel);
   };
 
   const handleAssignClick = (e: React.MouseEvent<HTMLElement>) => {
@@ -324,12 +316,7 @@ export default function ChannelItem({
           </MenuItem>
         )}
 
-        {/* メンバー管理（プライベートのみ） */}
-        {channel.isPrivate && (
-          <MenuItem aria-label="メンバー管理" onClick={handleMembersClick} sx={{ fontSize: 13 }}>
-            メンバー管理
-          </MenuItem>
-        )}
+        {/* Step 5c-2: 「メンバー管理」MenuItem は ContextRail メンバータブに統一したため撤去 */}
 
         {/* アーカイブ（権限保持者のみ） */}
         {canArchive && onArchive && (

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -30,7 +30,6 @@ import { useSocket } from '../../contexts/SocketContext';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSnackbar } from '../../contexts/SnackbarContext';
 import CreateChannelDialog from './CreateChannelDialog';
-import ChannelMembersDialog from './ChannelMembersDialog';
 import ChannelSearchBox from './ChannelSearchBox';
 import ChannelItem from './ChannelItem';
 import ChannelCategorySection from './ChannelCategorySection';
@@ -104,7 +103,6 @@ function UnassignedSection({
   onPin,
   onUnpin,
   pinnedIds,
-  onOpenMembersDialog,
   onArchive,
   currentUserId,
   userRole,
@@ -123,7 +121,6 @@ function UnassignedSection({
   onPin: (id: number) => void;
   onUnpin: (id: number) => void;
   pinnedIds: number[];
-  onOpenMembersDialog: (ch: Channel) => void;
   onArchive: (id: number) => void;
   currentUserId?: number;
   userRole?: string;
@@ -174,7 +171,6 @@ function UnassignedSection({
             onClick={() => onSelect(ch.id)}
             onPin={onPin}
             onUnpin={onUnpin}
-            onOpenMembersDialog={onOpenMembersDialog}
             onArchive={onArchive}
             currentUserId={currentUserId}
             userRole={userRole}
@@ -211,7 +207,6 @@ function ChannelListContent({
   const [channels, setChannels] = useState<Channel[]>(initialChannels);
   const [categories, setCategories] = useState<ChannelCategory[]>(initialCategories);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [membersDialogChannel, setMembersDialogChannel] = useState<Channel | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const socket = useSocket();
   const { user } = useAuth();
@@ -564,7 +559,6 @@ function ChannelListContent({
                   onClick={() => handleSelect(ch.id)}
                   onPin={handlePin}
                   onUnpin={handleUnpin}
-                  onOpenMembersDialog={setMembersDialogChannel}
                   onArchive={(id) => void handleArchive(id)}
                   currentUserId={user?.id}
                   userRole={user?.role}
@@ -601,7 +595,6 @@ function ChannelListContent({
                   onPin={handlePin}
                   onUnpin={handleUnpin}
                   pinnedIds={pinnedIds}
-                  onOpenMembersDialog={setMembersDialogChannel}
                   onArchive={(id) => void handleArchive(id)}
                   currentUserId={user?.id}
                   userRole={user?.role}
@@ -631,7 +624,6 @@ function ChannelListContent({
               onPin={handlePin}
               onUnpin={handleUnpin}
               pinnedIds={pinnedIds}
-              onOpenMembersDialog={setMembersDialogChannel}
               onArchive={(id) => void handleArchive(id)}
               currentUserId={user?.id}
               userRole={user?.role}
@@ -658,7 +650,6 @@ function ChannelListContent({
                   onClick={() => handleSelect(ch.id)}
                   onPin={handlePin}
                   onUnpin={handleUnpin}
-                  onOpenMembersDialog={setMembersDialogChannel}
                   onArchive={(id) => void handleArchive(id)}
                   currentUserId={user?.id}
                   userRole={user?.role}
@@ -708,13 +699,7 @@ function ChannelListContent({
           </DialogActions>
         </Dialog>
 
-        {membersDialogChannel && (
-          <ChannelMembersDialog
-            open={true}
-            channelId={membersDialogChannel.id}
-            onClose={() => setMembersDialogChannel(null)}
-          />
-        )}
+        {/* Step 5c-2: ChannelMembersDialog の Dialog 描画は ContextRail メンバータブに統一されたため撤去 */}
 
         {/* D&D ドラッグ中オーバーレイ */}
         <DragOverlay>


### PR DESCRIPTION
## 概要

Step 5c の後半 (5c-2)。`ChannelList` → `ChannelCategorySection` → `ChannelItem` の `onOpenMembersDialog` props 伝搬を全削除し、`ChannelList` の `<ChannelMembersDialog>` Dialog 描画を撤去する。メンバー管理動線は ContextRail のメンバータブ経由のみに統一。

これにより Step 5 (ContextRail) の全タスクが完了し、UI 重複が完全に解消される。

## 変更内容

### Props 伝搬削除
- **`components/Channel/ChannelItem.tsx`**
  - Props から `onOpenMembersDialog` を削除
  - `handleMembersClick` 関数を削除
  - 「メンバー管理」MenuItem (private チャンネル限定で表示されていた) を削除
- **`components/Channel/ChannelCategorySection.tsx`**
  - Props から `onOpenMembersDialog` を削除
  - ChannelItem への渡しを削除
- **`components/Channel/ChannelList.tsx`**
  - `ChannelMembersDialog` の import を削除
  - 内部 Channels サブコンポーネントの Props から `onOpenMembersDialog` を削除
  - `membersDialogChannel` state と `<ChannelMembersDialog>` 描画を削除
  - ChannelCategorySection / Channels への `onOpenMembersDialog` 渡し計 5 箇所を削除

### テスト整理
- **`__tests__/ChannelItem.test.tsx`**
  - `defaultProps` から `onOpenMembersDialog: vi.fn()` を削除
  - 「メンバー管理が表示される (private)」テストを「private でも表示されない」に反転
  - 「メンバー管理クリックで onOpenMembersDialog が呼ばれる」「メニューが閉じる」テスト 2 件を削除

### 残置するコンポーネント
- **`ChannelMembersDialog.tsx`** 自体は残す
  - ContextRail メンバータブが `MembersContent` を named export 経由で使っているため
  - `ChannelMembersDialog.test.tsx` (235 行) は変更なし (Dialog コンポーネント自体のテストとして機能)

## 影響範囲

- ChannelList の右クリックメニュー (private チャンネル) から「メンバー管理」項目が消える
- メンバー管理は **ContextRail メンバータブ** からアクセスする動線に統一
- ChannelList のレイアウト・操作性に他の変化はなし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1354 件 pass / 5 件 skip)
- [x] バックエンドユニットテストがすべてパスする (本 PR は client 側のみ変更)
- [x] ビルドが正常に完了すること (`tsc --noEmit` エラー 0)
- [x] ESLint エラー 0 (warnings は既存)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット ← 別途まとめて実施予定

## 関連Issue
PROGRESS.md ステップ #5c-2 / claude-code-prompt.md §3.6

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に統合ブランチで実施 (運用ルール準拠)
- [x] `it.todo` / 空ボディの `it` が残っていない (本 PR で追加した `it.todo` 1 件は実テストに書き換え済み)

## Step 5 完了

本 PR のマージで Step 5 (ContextRail) のすべてのサブステップ (5a / 5b / 5c-1 / 5c-2) が完了する。残り Step は 6 (InboxPage) / 7 (検索ページ) / 8 (モバイル)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)