### PR TITLE
feat(inbox): InboxPage 新設 + ルート / 差し替え + サマリーカード/リマインダー/下書きタブ (Step 6a)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -15,6 +15,7 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import LoginPage from './pages/LoginPage';
 import RegisterPage from './pages/RegisterPage';
 import ChatPage from './pages/ChatPage';
+import InboxPage from './pages/InboxPage';
 import ProfilePage from './pages/ProfilePage';
 import AdminPage from './pages/AdminPage';
 import BookmarkPage from './pages/BookmarkPage';
@@ -237,13 +238,24 @@ function AppRoutes() {
             </RequireAuth>
           }
         />
+        {/* Step 6a: チャット画面は /chat/* に移動。ルート / は InboxPage が担当 */}
         <Route
-          path="/*"
+          path="/chat/*"
           element={
             <RequireAuth>
               <SocketProvider>
                 {/* key={user.id} でユーザー切替時にコンポーネントを再マウントし useState を初期化する */}
                 {user && <ChatWithUsers key={user.id} currentUser={user} />}
+              </SocketProvider>
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/*"
+          element={
+            <RequireAuth>
+              <SocketProvider>
+                <InboxPage />
               </SocketProvider>
             </RequireAuth>
           }

--- a/packages/client/src/__tests__/DraftsList.test.tsx
+++ b/packages/client/src/__tests__/DraftsList.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * components/Inbox/DraftsList.tsx のユニットテスト (Step 6a)
+ *
+ * 純粋コンポーネントとして drafts 配列を直接渡してテストする。
+ * Promise の解決は親 (InboxPage) で行うため Suspense は不要。
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import DraftsList from '../components/Inbox/DraftsList';
+import type { Draft } from '@chat-app/shared';
+
+function makeDraft(overrides: Partial<Draft> = {}): Draft {
+  return {
+    id: 1,
+    userId: 1,
+    channelId: 5,
+    dmConversationId: null,
+    content: 'まだ送ってない下書き',
+    updatedAt: '2026-05-01T12:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('DraftsList (Step 6a)', () => {
+  it('drafts が空のとき「下書きはありません」と表示される', () => {
+    render(<DraftsList drafts={[]} />);
+    expect(screen.getByText('下書きはありません')).toBeInTheDocument();
+  });
+
+  it('drafts[].content をテキストとして表示する', () => {
+    render(<DraftsList drafts={[makeDraft()]} />);
+    expect(screen.getByText(/まだ送ってない下書き/)).toBeInTheDocument();
+  });
+
+  it('複数の drafts が並んで表示される', () => {
+    const drafts = [
+      makeDraft({ id: 1, content: '下書き1' }),
+      makeDraft({ id: 2, content: '下書き2' }),
+    ];
+    render(<DraftsList drafts={drafts} />);
+    expect(screen.getAllByTestId('draft-card')).toHaveLength(2);
+  });
+});

--- a/packages/client/src/__tests__/InboxPage.test.tsx
+++ b/packages/client/src/__tests__/InboxPage.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * pages/InboxPage.tsx のユニットテスト (Step 6a)
+ *
+ * テスト対象:
+ *   - サマリーカード 3 連 (未読 / 今日の予定 / 未完タスク)
+ *   - タブ切替 (?tab=mentions|threads|reminders|drafts|all)
+ *   - リマインダー / 下書き / すべて タブの実機データ表示
+ *   - メンション / スレッドタブの「準備中」プレースホルダ
+ *   - `?channel=X` クエリ付きアクセス時の /chat へのリダイレクト動作
+ *
+ * 戦略:
+ *   - api.channels.list / calendar.events.list / tasks.list / reminders.list / drafts.getAll を vi.mock
+ *   - AppLayout / Rail / SidebarFooter は最小スタブ
+ *   - react-router-dom は importActual + MemoryRouter で初期 URL を制御
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import InboxPage from '../pages/InboxPage';
+
+// AppLayout は最小スタブ — children を直接 render する
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
+
+// 表示用の純粋コンポーネントは個別テスト (SummaryCards.test.tsx / RemindersList.test.tsx /
+// DraftsList.test.tsx) で検証する。InboxPage のテストではスタブ化して Suspense 解決の
+// 影響を切り離し、ルーティング / タブ切替 / プレースホルダの挙動だけを検証する
+vi.mock('../components/Inbox/SummaryCards', () => ({
+  default: () => <div data-testid="summary-cards-stub" />,
+}));
+vi.mock('../components/Inbox/RemindersList', () => ({
+  default: () => <div data-testid="reminders-list-stub" />,
+}));
+vi.mock('../components/Inbox/DraftsList', () => ({
+  default: () => <div data-testid="drafts-list-stub" />,
+}));
+
+// AuthContext: useAuth が毎回新しいオブジェクトを返すと InboxPage の useMemo([user])
+// が再計算されて Suspense が無限ループするので vi.hoisted で参照を固定する
+const mockAuthValue = vi.hoisted(() => ({
+  user: { id: 1, username: 'alice', email: 'alice@example.com', role: 'user' },
+}));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => mockAuthValue,
+}));
+
+// API モック (hoisted で各テストから操作可能に)
+const mockChannelsList = vi.hoisted(() => vi.fn());
+const mockCalendarEventsList = vi.hoisted(() => vi.fn());
+const mockTasksList = vi.hoisted(() => vi.fn());
+const mockRemindersList = vi.hoisted(() => vi.fn());
+const mockDraftsGetAll = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/client', () => ({
+  api: {
+    channels: { list: mockChannelsList },
+    calendar: { events: { list: mockCalendarEventsList } },
+    tasks: { list: mockTasksList },
+    reminders: { list: mockRemindersList },
+    drafts: { getAll: mockDraftsGetAll },
+  },
+}));
+
+beforeEach(() => {
+  mockChannelsList.mockReset();
+  mockCalendarEventsList.mockReset();
+  mockTasksList.mockReset();
+  mockRemindersList.mockReset();
+  mockDraftsGetAll.mockReset();
+  // 既定: 空応答
+  mockChannelsList.mockResolvedValue({ channels: [] });
+  mockCalendarEventsList.mockResolvedValue({ events: [] });
+  mockTasksList.mockResolvedValue({ tasks: [] });
+  mockRemindersList.mockResolvedValue({ reminders: [] });
+  mockDraftsGetAll.mockResolvedValue({ drafts: [] });
+});
+
+function renderInbox(initialPath: string = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/" element={<InboxPage />} />
+        <Route path="/chat" element={<div data-testid="chat-page-stub" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('InboxPage (Step 6a)', () => {
+  describe('ルーティング', () => {
+    it('「/」 で InboxPage が表示される', async () => {
+      renderInbox('/');
+      // Suspense fallback 解決後に Inbox の見出しが表示される
+      expect(await screen.findByText('受信箱')).toBeInTheDocument();
+    });
+
+    it('「/?channel=5」 でアクセスすると「/chat?channel=5」 にリダイレクトされる', async () => {
+      renderInbox('/?channel=5');
+      // リダイレクト後のスタブが表示される
+      expect(await screen.findByTestId('chat-page-stub')).toBeInTheDocument();
+    });
+  });
+
+  // サマリーカードのロジック検証は SummaryCards.test.tsx に責務移譲。
+  // InboxPage 内の Suspense 解決はユニットテストで再現困難（Promise.all + use(promise) が
+  // jsdom + vitest 環境で解決されないことがある）ため、サマリー描画のテストは E2E に逃がす。
+
+  describe('タブ切替', () => {
+    it('クエリなしのときデフォルトでメンションタブが選択されている', async () => {
+      renderInbox('/');
+      expect(await screen.findByRole('tab', { name: 'メンション' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+    });
+
+    it('?tab=reminders でリマインダータブが選択される', async () => {
+      renderInbox('/?tab=reminders');
+      expect(await screen.findByRole('tab', { name: 'リマインダー' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+    });
+
+    it('?tab=drafts で下書きタブが選択される', async () => {
+      renderInbox('/?tab=drafts');
+      expect(await screen.findByRole('tab', { name: '下書き' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+    });
+
+    it('タブクリックで URL の ?tab= クエリが更新される', async () => {
+      renderInbox('/');
+      await userEvent.click(await screen.findByRole('tab', { name: 'リマインダー' }));
+      expect(screen.getByRole('tab', { name: 'リマインダー' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+    });
+  });
+
+  describe('タブ内容', () => {
+    // RemindersList / DraftsList の表示検証は各々の単体テストに責務移譲。
+    // リマインダー/下書き/すべてタブは Suspense 内で描画されるため、ユニットテストで
+    // jsdom + vitest 環境では Suspense 解決が再現困難 → 検証は E2E に逃がす。
+    // メンション/スレッドタブは Suspense なし（プレースホルダのみ）なので確認可能。
+    it('メンションタブで「準備中」プレースホルダ (Step 6b で実装) が表示される', async () => {
+      renderInbox('/?tab=mentions');
+      expect(await screen.findByText(/準備中/)).toBeInTheDocument();
+    });
+
+    it('スレッドタブで「準備中」プレースホルダ (Step 6c で実装) が表示される', async () => {
+      renderInbox('/?tab=threads');
+      expect(await screen.findByText(/準備中/)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/RemindersList.test.tsx
+++ b/packages/client/src/__tests__/RemindersList.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * components/Inbox/RemindersList.tsx のユニットテスト (Step 6a)
+ *
+ * 純粋コンポーネントとして reminders 配列を直接渡してテストする。
+ * Promise の解決は親 (InboxPage) で行うため Suspense は不要。
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import RemindersList from '../components/Inbox/RemindersList';
+import type { Reminder } from '@chat-app/shared';
+
+function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
+  return {
+    id: 1,
+    userId: 1,
+    messageId: 10,
+    remindAt: '2026-05-10T09:00:00Z',
+    isSent: false,
+    createdAt: '2026-05-01T00:00:00Z',
+    message: {
+      id: 10,
+      channelId: 1,
+      userId: 1,
+      username: 'alice',
+      avatarUrl: null,
+      content: JSON.stringify({ ops: [{ insert: 'スプリントレビュー\n' }] }),
+      isEdited: false,
+      isDeleted: false,
+      createdAt: '2026-05-01T00:00:00Z',
+      updatedAt: '2026-05-01T00:00:00Z',
+      mentions: [],
+      reactions: [],
+      parentMessageId: null,
+      rootMessageId: null,
+      replyCount: 0,
+      quotedMessageId: null,
+      quotedMessage: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('RemindersList (Step 6a)', () => {
+  it('reminders が空のとき「リマインダーはありません」と表示される', () => {
+    render(<RemindersList reminders={[]} />);
+    expect(screen.getByText('リマインダーはありません')).toBeInTheDocument();
+  });
+
+  it('reminders[].message.content (Quill Delta JSON) をプレーンテキストに変換して表示する', () => {
+    render(<RemindersList reminders={[makeReminder()]} />);
+    expect(screen.getByText(/スプリントレビュー/)).toBeInTheDocument();
+  });
+
+  it('複数の reminders が並んで表示される', () => {
+    const reminders = [
+      makeReminder({ id: 1 }),
+      makeReminder({
+        id: 2,
+        message: {
+          ...makeReminder().message!,
+          content: 'プレーンテキスト本文',
+        },
+      }),
+    ];
+    render(<RemindersList reminders={reminders} />);
+    expect(screen.getAllByTestId('reminder-card')).toHaveLength(2);
+  });
+});

--- a/packages/client/src/__tests__/SummaryCards.test.tsx
+++ b/packages/client/src/__tests__/SummaryCards.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * components/Inbox/SummaryCards.tsx のユニットテスト (Step 6a)
+ *
+ * 純粋コンポーネントとして data を直接渡してテストする。
+ * Promise 解決は親 (InboxPage 内 Suspense ラッパー) で行うため Suspense は不要。
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import SummaryCards, { type SummaryData } from '../components/Inbox/SummaryCards';
+
+describe('SummaryCards (Step 6a)', () => {
+  it('未読数: channels の unreadCount 合計が表示される', () => {
+    const data = [
+      {
+        channels: [
+          { id: 1, name: 'a', unreadCount: 3 },
+          { id: 2, name: 'b', unreadCount: 5 },
+          { id: 3, name: 'c', unreadCount: 0 },
+        ],
+      },
+      { events: [] },
+      { tasks: [] },
+    ] as unknown as SummaryData;
+    render(<SummaryCards data={data} />);
+    expect(screen.getByTestId('summary-unread')).toHaveTextContent('8');
+  });
+
+  it('今日の予定: events 件数が表示される', () => {
+    const data = [
+      { channels: [] },
+      {
+        events: [
+          { id: 1, title: 'a' },
+          { id: 2, title: 'b' },
+        ],
+      },
+      { tasks: [] },
+    ] as unknown as SummaryData;
+    render(<SummaryCards data={data} />);
+    expect(screen.getByTestId('summary-events')).toHaveTextContent('2');
+  });
+
+  it('未完タスク: status !== "done" のタスク数が表示される', () => {
+    const data = [
+      { channels: [] },
+      { events: [] },
+      {
+        tasks: [
+          { id: 1, status: 'todo' },
+          { id: 2, status: 'in_progress' },
+          { id: 3, status: 'done' },
+        ],
+      },
+    ] as unknown as SummaryData;
+    render(<SummaryCards data={data} />);
+    expect(screen.getByTestId('summary-tasks')).toHaveTextContent('2');
+  });
+});

--- a/packages/client/src/components/Inbox/DraftsList.tsx
+++ b/packages/client/src/components/Inbox/DraftsList.tsx
@@ -1,0 +1,59 @@
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import type { Draft } from '@chat-app/shared';
+
+interface Props {
+  drafts: Draft[];
+}
+
+function parseMessageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
+    return (
+      parsed.ops
+        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
+        .join('')
+        .trim() ?? raw
+    );
+  } catch {
+    return raw;
+  }
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString([], {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Step 6a: Inbox の「下書き」タブ表示用の純粋コンポーネント。
+ * Promise の解決は親 (InboxPage) の Suspense で行い、ここには配列を受け取って描画するだけにする。
+ */
+export default function DraftsList({ drafts }: Props) {
+  if (drafts.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+        下書きはありません
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {drafts.map((d) => (
+        <Card key={d.id} variant="outlined" data-testid="draft-card">
+          <CardContent>
+            <Typography variant="caption" color="text.secondary">
+              📝 {formatDateTime(d.updatedAt)}
+            </Typography>
+            <Typography variant="body2">{parseMessageContent(d.content)}</Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/packages/client/src/components/Inbox/RemindersList.tsx
+++ b/packages/client/src/components/Inbox/RemindersList.tsx
@@ -1,0 +1,61 @@
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import type { Reminder } from '@chat-app/shared';
+
+interface Props {
+  reminders: Reminder[];
+}
+
+function parseMessageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
+    return (
+      parsed.ops
+        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
+        .join('')
+        .trim() ?? raw
+    );
+  } catch {
+    return raw;
+  }
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString([], {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Step 6a: Inbox の「リマインダー」タブ表示用の純粋コンポーネント。
+ * Promise の解決は親 (InboxPage) の Suspense で行い、ここには配列を受け取って描画するだけにする。
+ */
+export default function RemindersList({ reminders }: Props) {
+  if (reminders.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+        リマインダーはありません
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {reminders.map((r) => (
+        <Card key={r.id} variant="outlined" data-testid="reminder-card">
+          <CardContent>
+            <Typography variant="caption" color="text.secondary">
+              ⏰ {formatDateTime(r.remindAt)}
+            </Typography>
+            <Typography variant="body2">
+              {r.message ? parseMessageContent(r.message.content) : '(メッセージが見つかりません)'}
+            </Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/packages/client/src/components/Inbox/SummaryCards.tsx
+++ b/packages/client/src/components/Inbox/SummaryCards.tsx
@@ -1,0 +1,57 @@
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import type { CalendarEvent, Channel, Task } from '@chat-app/shared';
+
+export type SummaryData = [{ channels: Channel[] }, { events: CalendarEvent[] }, { tasks: Task[] }];
+
+interface Props {
+  data: SummaryData;
+}
+
+/**
+ * Step 6a: Inbox 上部のサマリーカード 3 連 (未読 / 今日の予定 / 未完タスク)。
+ *
+ * 純粋コンポーネントとして data 配列を受け取って描画するだけにし、Promise の解決は
+ * 親 (InboxPage 内の Suspense ラッパー) で行う。テスト容易性のためこの分離を採用。
+ */
+export default function SummaryCards({ data }: Props) {
+  const [{ channels }, { events }, { tasks }] = data;
+
+  const unreadTotal = channels.reduce((sum, ch) => sum + (ch.unreadCount ?? 0), 0);
+  const eventsCount = events.length;
+  const todoCount = tasks.filter((t) => t.status !== 'done').length;
+
+  return (
+    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 2 }}>
+      <Card data-testid="summary-unread" variant="outlined">
+        <CardContent>
+          <Typography variant="caption" color="text.secondary">
+            未読
+          </Typography>
+          <Typography variant="h4" fontWeight={600}>
+            {unreadTotal}
+          </Typography>
+        </CardContent>
+      </Card>
+      <Card data-testid="summary-events" variant="outlined">
+        <CardContent>
+          <Typography variant="caption" color="text.secondary">
+            今日の予定
+          </Typography>
+          <Typography variant="h4" fontWeight={600}>
+            {eventsCount}
+          </Typography>
+        </CardContent>
+      </Card>
+      <Card data-testid="summary-tasks" variant="outlined">
+        <CardContent>
+          <Typography variant="caption" color="text.secondary">
+            未完タスク
+          </Typography>
+          <Typography variant="h4" fontWeight={600}>
+            {todoCount}
+          </Typography>
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -1,0 +1,197 @@
+import { use, useEffect, useMemo, useState, Suspense } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Box, CircularProgress, Tab, Tabs, Typography } from '@mui/material';
+import AppLayout from '../components/Layout/AppLayout';
+import SummaryCards, { type SummaryData } from '../components/Inbox/SummaryCards';
+import RemindersList from '../components/Inbox/RemindersList';
+import DraftsList from '../components/Inbox/DraftsList';
+import { api } from '../api/client';
+import { useAuth } from '../contexts/AuthContext';
+import type { Draft, Reminder } from '@chat-app/shared';
+
+type TabKey = 'mentions' | 'threads' | 'reminders' | 'drafts' | 'all';
+
+const VALID_TABS: TabKey[] = ['mentions', 'threads', 'reminders', 'drafts', 'all'];
+
+function isValidTab(v: string | null): v is TabKey {
+  return v !== null && (VALID_TABS as string[]).includes(v);
+}
+
+function SummarySection({ promise }: { promise: Promise<SummaryData> }) {
+  const data = use(promise);
+  return <SummaryCards data={data} />;
+}
+
+function RemindersSection({ promise }: { promise: Promise<{ reminders: Reminder[] }> }) {
+  const { reminders } = use(promise);
+  return <RemindersList reminders={reminders} />;
+}
+
+function DraftsSection({ promise }: { promise: Promise<{ drafts: Draft[] }> }) {
+  const { drafts } = use(promise);
+  return <DraftsList drafts={drafts} />;
+}
+
+function AllSection({
+  remindersPromise,
+  draftsPromise,
+}: {
+  remindersPromise: Promise<{ reminders: Reminder[] }>;
+  draftsPromise: Promise<{ drafts: Draft[] }>;
+}) {
+  const { reminders } = use(remindersPromise);
+  const { drafts } = use(draftsPromise);
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <RemindersList reminders={reminders} />
+      <DraftsList drafts={drafts} />
+    </Box>
+  );
+}
+
+function PlaceholderTab({ note }: { note: string }) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1, p: 3 }}>
+      <Typography variant="body2" color="text.secondary">
+        準備中
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {note}
+      </Typography>
+    </Box>
+  );
+}
+
+/**
+ * Step 6a: Focus Inbox 画面。
+ * ルート `/` を InboxPage に切替え、サマリーカード 3 連 + 5 タブ (メンション / スレッド /
+ * リマインダー / 下書き / すべて) を表示する。
+ *
+ * メンション・スレッドタブは Step 6b / 6c でサーバー API を追加してから実機データ化する予定で、
+ * 本 Step では「準備中」プレースホルダで暫定対応。
+ *
+ * 後方互換: `/?channel=X` でアクセスされた場合は `/chat?channel=X` にリダイレクトし、
+ * 既存のチャンネル復元動線を維持する。
+ *
+ * テスト容易性のため、表示用の純粋コンポーネント (SummaryCards / RemindersList / DraftsList) を
+ * 別ファイルに切り出し、本ファイルでは `use(promise)` で Promise を解決して配列を渡すラッパーを定義する。
+ */
+export default function InboxPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  // 後方互換: ?channel= クエリがある場合は ChatPage に逃がす
+  const channelParam = searchParams.get('channel');
+  useEffect(() => {
+    if (channelParam) {
+      navigate(`/chat?channel=${channelParam}`, { replace: true });
+    }
+  }, [channelParam, navigate]);
+
+  const rawTab = searchParams.get('tab');
+  const tab: TabKey = isValidTab(rawTab) ? rawTab : 'mentions';
+
+  // React 19 Concurrent モード対策: promise の安定化には useState の初期化関数（1 度だけ評価）を使う。
+  // 3 つの API を Promise.all で 1 本にまとめて Suspense 解決を 1 サイクルで完了させる。
+  const [summaryPromise] = useState<Promise<SummaryData>>(() => {
+    const now = new Date();
+    const from = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+    const to = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1).toISOString();
+    return Promise.all([
+      api.channels.list(),
+      api.calendar.events.list({ from, to }),
+      user ? api.tasks.list({ assigneeId: user.id }) : Promise.resolve({ tasks: [] }),
+    ]);
+  });
+
+  const remindersPromise = useMemo(
+    () => (tab === 'reminders' || tab === 'all' ? api.reminders.list() : null),
+    [tab],
+  );
+  const draftsPromise = useMemo(
+    () => (tab === 'drafts' || tab === 'all' ? api.drafts.getAll() : null),
+    [tab],
+  );
+
+  // リダイレクト中はコンテンツを描画しない
+  if (channelParam) return null;
+
+  const handleTabChange = (_: React.SyntheticEvent, newTab: TabKey) => {
+    setSearchParams({ tab: newTab });
+  };
+
+  return (
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ p: 3, overflow: 'auto', height: '100%' }}>
+        <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
+          受信箱
+        </Typography>
+
+        <Suspense
+          fallback={
+            <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          }
+        >
+          <SummarySection promise={summaryPromise} />
+        </Suspense>
+
+        <Tabs
+          value={tab}
+          onChange={handleTabChange}
+          sx={{ mt: 3, borderBottom: 1, borderColor: 'divider' }}
+        >
+          <Tab value="mentions" label="メンション" />
+          <Tab value="threads" label="スレッド" />
+          <Tab value="reminders" label="リマインダー" />
+          <Tab value="drafts" label="下書き" />
+          <Tab value="all" label="すべて" />
+        </Tabs>
+
+        <Box sx={{ mt: 2 }}>
+          {tab === 'mentions' && (
+            <PlaceholderTab note="メンション一覧は Step 6b で実装予定です。" />
+          )}
+          {tab === 'threads' && (
+            <PlaceholderTab note="購読中スレッド一覧は Step 6c で実装予定です。" />
+          )}
+          {tab === 'reminders' && remindersPromise && (
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                  <CircularProgress size={20} />
+                </Box>
+              }
+            >
+              <RemindersSection promise={remindersPromise} />
+            </Suspense>
+          )}
+          {tab === 'drafts' && draftsPromise && (
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                  <CircularProgress size={20} />
+                </Box>
+              }
+            >
+              <DraftsSection promise={draftsPromise} />
+            </Suspense>
+          )}
+          {tab === 'all' && remindersPromise && draftsPromise && (
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                  <CircularProgress size={20} />
+                </Box>
+              }
+            >
+              <AllSection remindersPromise={remindersPromise} draftsPromise={draftsPromise} />
+            </Suspense>
+          )}
+        </Box>
+      </Box>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
## 概要

ルート \`/\` を新規 InboxPage に切替え、サマリーカード 3 連 + 5 タブ (メンション / スレッド / リマインダー / 下書き / すべて) を実装する Step 6 の前半 (6a)。事前合意した「案 B」の 6a 部分。

メンション / スレッドタブはサーバー API 追加が必要なため Step 6b / 6c へ繰り延べ、本 PR では「準備中」プレースホルダで暫定対応。バッジ連携・クイックアクションは Step 6d。

## 変更内容

### 新規ファイル
- **\`pages/InboxPage.tsx\`** — Focus Inbox 画面本体
  - 後方互換: \`?channel=X\` クエリで \`/chat?channel=X\` にリダイレクト (既存リンクの動線維持)
  - サマリー: \`Promise.all([api.channels.list, api.calendar.events.list, api.tasks.list])\` を \`useState\` で安定化、Suspense ラッパー \`SummarySection\` で \`use(promise)\` → \`SummaryCards\` に \`data\` 渡し
  - 各タブ: \`useMemo\` で tab 依存 promise 生成、Suspense ラッパー (\`RemindersSection\` / \`DraftsSection\` / \`AllSection\`) で \`use(promise)\` → 配列を純粋コンポーネントに渡す
  - URL クエリ \`?tab=mentions|threads|reminders|drafts|all\` でタブ切替
- **\`components/Inbox/SummaryCards.tsx\`** — 純粋コンポーネント (data props)
- **\`components/Inbox/RemindersList.tsx\`** — 純粋コンポーネント (reminders props)
- **\`components/Inbox/DraftsList.tsx\`** — 純粋コンポーネント (drafts props)
- 各テストファイル

### 変更
- **\`App.tsx\`** — ルーティング追加
  - \`/chat/*\` を新設し ChatPage を移動 (旧 \`/*\`)
  - \`/*\` を InboxPage に変更

## 設計判断

### Suspense ラッパーと純粋コンポーネントの分離
当初は \`SummaryCards\` 等が直接 \`use(promise)\` していたが、jsdom + vitest 環境で **Promise.all + use(promise) の Suspense 解決が再現困難**だったため、以下の構造に変更:
- 純粋コンポーネント (data 配列を props で受け取り render)
- InboxPage 内の Suspense ラッパー (\`use(promise)\` で配列を取り出して純粋コンポーネントに渡す)

これにより:
- 純粋コンポーネントの単体テストが Suspense 不要で書ける (data 直接渡し)
- React 19 ルール (\`use(promise)\` + Suspense) は維持
- InboxPage の Suspense 経由表示テストは E2E に逃がす方針 (PROGRESS.md ハマりどころ追記予定)

### React 19 Concurrent モード対策
\`useMemo\` はレンダー中に複数回評価されうるため、サマリーの 3 系統 promise は \`useState\` の初期化関数で 1 度だけ評価する形に変更。

## 影響範囲

- ルート \`/\` の挙動が **チャット画面 → Inbox 画面**に変わる
- 既存 \`/?channel=X\` リンクは InboxPage で検出して \`/chat?channel=X\` にリダイレクト (動線維持)
- \`/dm\` \`/profile\` 等の既存ルートは無影響
- ChatPage 自体のロジックは変更なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1371 件 pass / 5 件 skip)
- [x] バックエンドユニットテストがすべてパスする (本 PR は client 側のみ変更)
- [x] ビルドが正常に完了すること (\`tsc --noEmit\` エラー 0)
- [x] ESLint エラー 0 (warnings は既存)
- [ ] (手動確認の場合) 確認した手順やスクリーンショット ← 別途まとめて実施予定

### テスト追加内訳 (17 件)
- \`SummaryCards.test.tsx\` 3 件 (純粋コンポーネント、data 直接渡し)
- \`RemindersList.test.tsx\` 3 件 (純粋コンポーネント)
- \`DraftsList.test.tsx\` 3 件 (純粋コンポーネント)
- \`InboxPage.test.tsx\` 8 件
  - ルーティング 2 件 (/ → InboxPage 表示 / ?channel=X → /chat リダイレクト)
  - タブ切替 4 件 (デフォルト/?tab=reminders/?tab=drafts/click 後)
  - メンション/スレッドプレースホルダ 2 件

## 関連Issue
PROGRESS.md ステップ #6a / claude-code-prompt.md §3.4 / §6

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に統合ブランチで実施 (運用ルール準拠)
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

## Step 6b 残タスク (次の PR)
- メンションタブの実機データ化 (サーバー側 search API に \`mentionedToMe\` / \`unreadOnly\` フィルタ追加)

🤖 Generated with [Claude Code](https://claude.com/claude-code)