### PR TITLE
feat(inbox): メンションタブ実機データ化 + search API mentionedToMe/unreadOnly フィルタ追加 (Step 6b)

### DIFF
--- a/packages/client/src/__tests__/InboxPage.test.tsx
+++ b/packages/client/src/__tests__/InboxPage.test.tsx
@@ -55,6 +55,7 @@ const mockCalendarEventsList = vi.hoisted(() => vi.fn());
 const mockTasksList = vi.hoisted(() => vi.fn());
 const mockRemindersList = vi.hoisted(() => vi.fn());
 const mockDraftsGetAll = vi.hoisted(() => vi.fn());
+const mockMessagesSearch = vi.hoisted(() => vi.fn());
 
 vi.mock('../api/client', () => ({
   api: {
@@ -63,6 +64,7 @@ vi.mock('../api/client', () => ({
     tasks: { list: mockTasksList },
     reminders: { list: mockRemindersList },
     drafts: { getAll: mockDraftsGetAll },
+    messages: { search: mockMessagesSearch },
   },
 }));
 
@@ -78,6 +80,7 @@ beforeEach(() => {
   mockTasksList.mockResolvedValue({ tasks: [] });
   mockRemindersList.mockResolvedValue({ reminders: [] });
   mockDraftsGetAll.mockResolvedValue({ drafts: [] });
+  mockMessagesSearch.mockResolvedValue({ messages: [] });
 });
 
 function renderInbox(initialPath: string = '/') {
@@ -146,15 +149,11 @@ describe('InboxPage (Step 6a)', () => {
   });
 
   describe('タブ内容', () => {
-    // RemindersList / DraftsList の表示検証は各々の単体テストに責務移譲。
-    // リマインダー/下書き/すべてタブは Suspense 内で描画されるため、ユニットテストで
+    // 各タブの表示検証は対応する純粋コンポーネント (RemindersList / DraftsList / MentionsList) の
+    // 単体テストに責務移譲。
+    // メンション/リマインダー/下書き/すべてタブは Suspense 内で描画されるため、ユニットテストで
     // jsdom + vitest 環境では Suspense 解決が再現困難 → 検証は E2E に逃がす。
-    // メンション/スレッドタブは Suspense なし（プレースホルダのみ）なので確認可能。
-    it('メンションタブで「準備中」プレースホルダ (Step 6b で実装) が表示される', async () => {
-      renderInbox('/?tab=mentions');
-      expect(await screen.findByText(/準備中/)).toBeInTheDocument();
-    });
-
+    // スレッドタブは Suspense なし（プレースホルダのみ）なので確認可能。
     it('スレッドタブで「準備中」プレースホルダ (Step 6c で実装) が表示される', async () => {
       renderInbox('/?tab=threads');
       expect(await screen.findByText(/準備中/)).toBeInTheDocument();

--- a/packages/client/src/__tests__/MentionsList.test.tsx
+++ b/packages/client/src/__tests__/MentionsList.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * components/Inbox/MentionsList.tsx のユニットテスト (Step 6b)
+ *
+ * 純粋コンポーネントとして messages 配列を直接渡してテストする。
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import MentionsList from '../components/Inbox/MentionsList';
+import type { MessageSearchResult } from '@chat-app/shared';
+
+function makeSearchResult(overrides: Partial<MessageSearchResult> = {}): MessageSearchResult {
+  return {
+    id: 1,
+    channelId: 1,
+    channelName: 'general',
+    userId: 2,
+    username: 'bob',
+    avatarUrl: null,
+    content: JSON.stringify({ ops: [{ insert: '@alice こんにちは\n' }] }),
+    isEdited: false,
+    isDeleted: false,
+    createdAt: '2026-05-02T10:00:00Z',
+    updatedAt: '2026-05-02T10:00:00Z',
+    mentions: [],
+    reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
+    rootMessageContent: null,
+    ...overrides,
+  };
+}
+
+describe('MentionsList (Step 6b)', () => {
+  it('messages が空のとき「未読のメンションはありません」と表示される', () => {
+    render(<MentionsList messages={[]} />);
+    expect(screen.getByText('未読のメンションはありません')).toBeInTheDocument();
+  });
+
+  it('messages の本文 (Quill Delta JSON) をプレーンテキストに変換して表示する', () => {
+    render(<MentionsList messages={[makeSearchResult()]} />);
+    expect(screen.getByText(/@alice こんにちは/)).toBeInTheDocument();
+  });
+
+  it('チャンネル名と投稿者名が表示される', () => {
+    render(
+      <MentionsList
+        messages={[makeSearchResult({ channelName: 'design-review', username: 'matsuda' })]}
+      />,
+    );
+    // メタ情報行に「📨 #design-review · matsuda · ...」の形式で表示される
+    expect(screen.getByText(/#design-review/)).toBeInTheDocument();
+    expect(screen.getByText(/matsuda/)).toBeInTheDocument();
+  });
+
+  it('複数の messages が並んで表示される', () => {
+    const messages = [
+      makeSearchResult({ id: 1 }),
+      makeSearchResult({ id: 2, content: 'プレーンテキスト本文' }),
+    ];
+    render(<MentionsList messages={messages} />);
+    expect(screen.getAllByTestId('mention-card')).toHaveLength(2);
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -222,6 +222,9 @@ export const api = {
         params.set('hasAttachment', String(filters.hasAttachment));
       if (filters?.tagIds && filters.tagIds.length > 0)
         params.set('tagIds', filters.tagIds.join(','));
+      // Step 6b: 自分宛メンションのみ / 未読のみフィルタ
+      if (filters?.mentionedToMe) params.set('mentionedToMe', 'true');
+      if (filters?.unreadOnly) params.set('unreadOnly', 'true');
       return request<{ messages: MessageSearchResult[] }>(`/messages/search?${params.toString()}`);
     },
     getReplies: (messageId: number) =>

--- a/packages/client/src/components/Inbox/MentionsList.tsx
+++ b/packages/client/src/components/Inbox/MentionsList.tsx
@@ -1,0 +1,62 @@
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import type { MessageSearchResult } from '@chat-app/shared';
+
+interface Props {
+  messages: MessageSearchResult[];
+}
+
+function parseMessageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
+    return (
+      parsed.ops
+        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
+        .join('')
+        .trim() ?? raw
+    );
+  } catch {
+    return raw;
+  }
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString([], {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Step 6b: Inbox の「メンション」タブ表示用の純粋コンポーネント。
+ * Promise の解決は親 (InboxPage) の Suspense で行い、ここには配列を受け取って描画するだけにする。
+ *
+ * MessageSearchResult はメッセージ本体に加えて channelName / rootMessageContent を持つので、
+ * 送信元チャンネル名 / 投稿者名 / 本文を一覧表示する。
+ */
+export default function MentionsList({ messages }: Props) {
+  if (messages.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+        未読のメンションはありません
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {messages.map((m) => (
+        <Card key={m.id} variant="outlined" data-testid="mention-card">
+          <CardContent>
+            <Typography variant="caption" color="text.secondary">
+              📨 #{m.channelName} · {m.username} · {formatDateTime(m.createdAt)}
+            </Typography>
+            <Typography variant="body2">{parseMessageContent(m.content)}</Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -5,9 +5,10 @@ import AppLayout from '../components/Layout/AppLayout';
 import SummaryCards, { type SummaryData } from '../components/Inbox/SummaryCards';
 import RemindersList from '../components/Inbox/RemindersList';
 import DraftsList from '../components/Inbox/DraftsList';
+import MentionsList from '../components/Inbox/MentionsList';
 import { api } from '../api/client';
 import { useAuth } from '../contexts/AuthContext';
-import type { Draft, Reminder } from '@chat-app/shared';
+import type { Draft, MessageSearchResult, Reminder } from '@chat-app/shared';
 
 type TabKey = 'mentions' | 'threads' | 'reminders' | 'drafts' | 'all';
 
@@ -32,17 +33,26 @@ function DraftsSection({ promise }: { promise: Promise<{ drafts: Draft[] }> }) {
   return <DraftsList drafts={drafts} />;
 }
 
+function MentionsSection({ promise }: { promise: Promise<{ messages: MessageSearchResult[] }> }) {
+  const { messages } = use(promise);
+  return <MentionsList messages={messages} />;
+}
+
 function AllSection({
+  mentionsPromise,
   remindersPromise,
   draftsPromise,
 }: {
+  mentionsPromise: Promise<{ messages: MessageSearchResult[] }>;
   remindersPromise: Promise<{ reminders: Reminder[] }>;
   draftsPromise: Promise<{ drafts: Draft[] }>;
 }) {
+  const { messages } = use(mentionsPromise);
   const { reminders } = use(remindersPromise);
   const { drafts } = use(draftsPromise);
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <MentionsList messages={messages} />
       <RemindersList reminders={reminders} />
       <DraftsList drafts={drafts} />
     </Box>
@@ -105,6 +115,13 @@ export default function InboxPage() {
     ]);
   });
 
+  const mentionsPromise = useMemo(
+    () =>
+      tab === 'mentions' || tab === 'all'
+        ? api.messages.search('', { mentionedToMe: true, unreadOnly: true })
+        : null,
+    [tab],
+  );
   const remindersPromise = useMemo(
     () => (tab === 'reminders' || tab === 'all' ? api.reminders.list() : null),
     [tab],
@@ -151,8 +168,16 @@ export default function InboxPage() {
         </Tabs>
 
         <Box sx={{ mt: 2 }}>
-          {tab === 'mentions' && (
-            <PlaceholderTab note="メンション一覧は Step 6b で実装予定です。" />
+          {tab === 'mentions' && mentionsPromise && (
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                  <CircularProgress size={20} />
+                </Box>
+              }
+            >
+              <MentionsSection promise={mentionsPromise} />
+            </Suspense>
           )}
           {tab === 'threads' && (
             <PlaceholderTab note="購読中スレッド一覧は Step 6c で実装予定です。" />
@@ -179,7 +204,7 @@ export default function InboxPage() {
               <DraftsSection promise={draftsPromise} />
             </Suspense>
           )}
-          {tab === 'all' && remindersPromise && draftsPromise && (
+          {tab === 'all' && mentionsPromise && remindersPromise && draftsPromise && (
             <Suspense
               fallback={
                 <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
@@ -187,7 +212,11 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <AllSection remindersPromise={remindersPromise} draftsPromise={draftsPromise} />
+              <AllSection
+                mentionsPromise={mentionsPromise}
+                remindersPromise={remindersPromise}
+                draftsPromise={draftsPromise}
+              />
             </Suspense>
           )}
         </Box>

--- a/packages/server/src/__tests__/integration/search.test.ts
+++ b/packages/server/src/__tests__/integration/search.test.ts
@@ -176,4 +176,93 @@ describe('GET /api/messages/search', () => {
       expect(Array.isArray(res.body.messages)).toBe(true);
     });
   });
+
+  describe('Step 6b: mentionedToMe / unreadOnly フィルタ', () => {
+    it('mentionedToMe=true で自分宛メンションのみが返される', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'mfilter_alice',
+        'mfilter_alice@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'mfilter_bob', 'mfilter_bob@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'mfilter-ch1');
+
+      // bob から alice へのメンション
+      const msgToAlice = await insertMessage(channelId, bobId, '@alice チェックお願いします');
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, $4)',
+        [msgToAlice, aliceId, channelId, false],
+      );
+
+      // alice 自身の発言（メンション無し）
+      await insertMessage(channelId, aliceId, 'メモ書き');
+
+      const res = await request(app)
+        .get('/api/messages/search?q=&mentionedToMe=true')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.messages).toHaveLength(1);
+      expect(res.body.messages[0].id).toBe(msgToAlice);
+    });
+
+    it('unreadOnly=true で未読メンションのみが返される', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'mfilter_alice2',
+        'mfilter_alice2@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'mfilter_bob2', 'mfilter_bob2@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'mfilter-ch2');
+
+      // bob → alice のメンション 2 件 (1 件は既読、1 件は未読)
+      const readMsg = await insertMessage(channelId, bobId, '@alice 既読のメンション');
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, $4)',
+        [readMsg, aliceId, channelId, true],
+      );
+      const unreadMsg = await insertMessage(channelId, bobId, '@alice 未読のメンション');
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, $4)',
+        [unreadMsg, aliceId, channelId, false],
+      );
+
+      const res = await request(app)
+        .get('/api/messages/search?q=&mentionedToMe=true&unreadOnly=true')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.messages).toHaveLength(1);
+      expect(res.body.messages[0].id).toBe(unreadMsg);
+    });
+
+    it('他人宛のメンションは mentionedToMe=true で返らない', async () => {
+      const { token: aliceToken } = await registerUser(
+        app,
+        'mfilter_alice3',
+        'mfilter_alice3@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'mfilter_bob3', 'mfilter_bob3@example.com');
+      const { userId: charlieId } = await registerUser(
+        app,
+        'mfilter_charlie3',
+        'mfilter_charlie3@example.com',
+      );
+      const channelId = await createChannelReq(app, aliceToken, 'mfilter-ch3');
+
+      // bob から charlie へのメンション
+      const msgToCharlie = await insertMessage(channelId, bobId, '@charlie 確認');
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, $4)',
+        [msgToCharlie, charlieId, channelId, false],
+      );
+
+      const res = await request(app)
+        .get('/api/messages/search?q=&mentionedToMe=true')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.messages).toHaveLength(0);
+    });
+  });
 });

--- a/packages/server/src/controllers/messageController.ts
+++ b/packages/server/src/controllers/messageController.ts
@@ -14,7 +14,8 @@ export async function searchMessages(
     const qRaw = req.query.q;
     const q = typeof qRaw === 'string' ? qRaw.trim() : '';
 
-    const { dateFrom, dateTo, userId, hasAttachment, tagIds } = req.query;
+    const { dateFrom, dateTo, userId, hasAttachment, tagIds, mentionedToMe, unreadOnly } =
+      req.query;
 
     const filters = {
       dateFrom: typeof dateFrom === 'string' && dateFrom ? dateFrom : undefined,
@@ -34,6 +35,9 @@ export async function searchMessages(
           : Array.isArray(tagIds)
             ? (tagIds as string[]).map(Number).filter((n) => !isNaN(n))
             : undefined,
+      // Step 6b: 自分宛メンションのみ / 未読のみフィルタ
+      mentionedToMe: mentionedToMe === 'true' ? true : undefined,
+      unreadOnly: unreadOnly === 'true' ? true : undefined,
     };
 
     const hasAnyFilter =
@@ -41,7 +45,8 @@ export async function searchMessages(
       filters.dateTo !== undefined ||
       filters.userId !== undefined ||
       filters.hasAttachment !== undefined ||
-      (filters.tagIds !== undefined && filters.tagIds.length > 0);
+      (filters.tagIds !== undefined && filters.tagIds.length > 0) ||
+      filters.mentionedToMe === true;
 
     // q が空でフィルターも未指定なら 400
     if (q === '' && !hasAnyFilter) {
@@ -49,7 +54,8 @@ export async function searchMessages(
       return;
     }
 
-    res.json({ messages: await messageService.searchMessages(q, filters) });
+    const currentUserId = (req as AuthenticatedRequest).userId;
+    res.json({ messages: await messageService.searchMessages(q, filters, currentUserId) });
   } catch (err) {
     next(err);
   }

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -369,8 +369,9 @@ export async function restoreMessage(messageId: number, userId: number): Promise
 export async function searchMessages(
   q: string,
   filters: MessageSearchFilters = {},
+  currentUserId?: number,
 ): Promise<MessageSearchResult[]> {
-  const { dateFrom, dateTo, userId, hasAttachment, tagIds } = filters;
+  const { dateFrom, dateTo, userId, hasAttachment, tagIds, mentionedToMe, unreadOnly } = filters;
 
   // dateFrom > dateTo の場合は空を返す（早期リターン）
   if (
@@ -413,6 +414,19 @@ export async function searchMessages(
     }
   }
 
+  // Step 6b: メンションフィルタ
+  // mentionedToMe = true なら mentions テーブルを JOIN して mentioned_user_id = currentUserId で絞る
+  // unreadOnly = true なら mn.is_read = false 条件も追加（mentionedToMe が無いと作用しない）
+  let mentionsJoin = '';
+  let mentionsWhere = '';
+  if (mentionedToMe && currentUserId !== undefined) {
+    mentionsJoin = `JOIN mentions mn ON mn.message_id = m.id AND mn.mentioned_user_id = $${idx++}`;
+    params.push(currentUserId);
+    if (unreadOnly) {
+      mentionsWhere = 'AND mn.is_read = false';
+    }
+  }
+
   let sql = `SELECT DISTINCT m.id, m.channel_id, m.user_id, u.username, u.avatar_url,
             m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at,
             m.parent_message_id, m.root_message_id, m.quoted_message_id, m.forwarded_from_message_id,
@@ -424,8 +438,10 @@ export async function searchMessages(
      LEFT JOIN messages rm ON m.root_message_id = rm.id
      ${attachJoin}
      ${tagJoin}
+     ${mentionsJoin}
      WHERE m.is_deleted = false ${keywordWhere}
-     ${attachWhere}`;
+     ${attachWhere}
+     ${mentionsWhere}`;
 
   if (dateFrom && isValidDate(dateFrom)) {
     sql += ` AND m.created_at >= $${idx++}`;

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -62,6 +62,10 @@ export interface MessageSearchFilters {
   userId?: number;
   hasAttachment?: boolean;
   tagIds?: number[];
+  /** Step 6b: 現在のユーザー (AuthenticatedRequest.user.id) にメンションされたメッセージのみに絞る */
+  mentionedToMe?: boolean;
+  /** Step 6b: mentionedToMe と組み合わせて、is_read = false のメンションのみに絞る */
+  unreadOnly?: boolean;
 }
 
 export interface SendMessageInput {


### PR DESCRIPTION
## 概要

InboxPage のメンションタブを実機データ化する Step 6b。サーバー側 `searchMessages` を拡張して `mentionedToMe` / `unreadOnly` フィルタを追加し、フロントから `api.messages.search('', { mentionedToMe: true, unreadOnly: true })` で取得する。

**重要発見**: DB の `mentions` テーブルに既に `is_read` フラグがあるため、DB スキーマ変更不要。サーバー側は既存 `searchMessages` の責務拡張のみで完了。

## 変更内容

### Shared
- **`packages/shared/src/types/message.ts`**: `MessageSearchFilters` に `mentionedToMe?: boolean` / `unreadOnly?: boolean` を追加

### Server
- **`services/messageService.ts`**: `searchMessages(q, filters, currentUserId?)` のシグネチャ拡張
  - `mentionedToMe=true` のとき `mentions` テーブルを JOIN (`mn.message_id = m.id AND mn.mentioned_user_id = $currentUserId`)
  - `unreadOnly=true` のとき `mn.is_read = false` を追加
- **`controllers/messageController.ts`**:
  - クエリから `mentionedToMe` / `unreadOnly` を抽出
  - `AuthenticatedRequest.userId` を `currentUserId` として渡す
  - `q` 空でも `mentionedToMe=true` だけで 200 を返すよう `hasAnyFilter` 判定を拡張
- **`__tests__/integration/search.test.ts`**: テスト 3 件追加
  - mentionedToMe=true で自分宛メンションのみが返される
  - unreadOnly=true で未読メンションのみが返される
  - 他人宛のメンションは返らない

### Client
- **`api/client.ts`**: `search()` の URLSearchParams に `mentionedToMe` / `unreadOnly` を渡すロジック追加
- **`components/Inbox/MentionsList.tsx`** (新規): 純粋コンポーネント (messages props)
  - チャンネル名 / 投稿者 / 投稿時刻 + 本文を表示。0 件時「未読のメンションはありません」
- **`pages/InboxPage.tsx`**:
  - `mentionsPromise` を useMemo で生成 (tab='mentions' or 'all' のとき)
  - `MentionsSection` (Suspense ラッパー) で `use(promise)` → MentionsList に渡す
  - `AllSection` も mentions を含めるよう拡張
  - 「準備中」プレースホルダ撤去
- **`__tests__/MentionsList.test.tsx`** (新規): 4 件 (空表示 / 本文パース / メタ情報 / 複数表示)
- **`__tests__/InboxPage.test.tsx`**: api mock に messages.search 追加、メンション「準備中」テスト削除

## 影響範囲

- 既存 \`/api/messages/search\` の挙動が拡張される (新フィルタは optional なので破壊性なし)
- フロント側の \`api.messages.search\` の型シグネチャは互換性維持 (新フィルタは optional)
- InboxPage のメンションタブが「準備中」から実機データに切替

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (1374 件 pass / 5 件 skip)
- [x] バックエンドユニットテストがすべてパスする (1363 件 pass)
- [x] ビルドが正常に完了すること (server / client 両方の \`tsc --noEmit\` エラー 0)
- [x] ESLint エラー 0
- [ ] (手動確認の場合) 確認した手順やスクリーンショット ← 別途まとめて実施予定

## 関連Issue
PROGRESS.md ステップ #6b / claude-code-prompt.md §3.4

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に統合ブランチで実施 (運用ルール準拠)
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

## Step 6c 残タスク (次の PR)
- 購読中スレッド一覧 API (\`GET /api/threads/subscribed\`) の新設
- スレッドタブ実機データ化

🤖 Generated with [Claude Code](https://claude.com/claude-code)