### PR TITLE
feat(inbox): スレッドタブ実機データ化 + GET /api/threads/subscribed 新設 (Step 6c)

### DIFF
--- a/packages/client/src/__tests__/InboxPage.test.tsx
+++ b/packages/client/src/__tests__/InboxPage.test.tsx
@@ -39,6 +39,9 @@ vi.mock('../components/Inbox/RemindersList', () => ({
 vi.mock('../components/Inbox/DraftsList', () => ({
   default: () => <div data-testid="drafts-list-stub" />,
 }));
+vi.mock('../components/Inbox/ThreadsList', () => ({
+  default: () => <div data-testid="threads-list-stub" />,
+}));
 
 // AuthContext: useAuth が毎回新しいオブジェクトを返すと InboxPage の useMemo([user])
 // が再計算されて Suspense が無限ループするので vi.hoisted で参照を固定する
@@ -56,6 +59,7 @@ const mockTasksList = vi.hoisted(() => vi.fn());
 const mockRemindersList = vi.hoisted(() => vi.fn());
 const mockDraftsGetAll = vi.hoisted(() => vi.fn());
 const mockMessagesSearch = vi.hoisted(() => vi.fn());
+const mockThreadsListSubscribed = vi.hoisted(() => vi.fn());
 
 vi.mock('../api/client', () => ({
   api: {
@@ -65,6 +69,7 @@ vi.mock('../api/client', () => ({
     reminders: { list: mockRemindersList },
     drafts: { getAll: mockDraftsGetAll },
     messages: { search: mockMessagesSearch },
+    threads: { listSubscribed: mockThreadsListSubscribed },
   },
 }));
 
@@ -81,6 +86,8 @@ beforeEach(() => {
   mockRemindersList.mockResolvedValue({ reminders: [] });
   mockDraftsGetAll.mockResolvedValue({ drafts: [] });
   mockMessagesSearch.mockResolvedValue({ messages: [] });
+  mockThreadsListSubscribed.mockReset();
+  mockThreadsListSubscribed.mockResolvedValue({ threads: [] });
 });
 
 function renderInbox(initialPath: string = '/') {
@@ -153,10 +160,13 @@ describe('InboxPage (Step 6a)', () => {
     // 単体テストに責務移譲。
     // メンション/リマインダー/下書き/すべてタブは Suspense 内で描画されるため、ユニットテストで
     // jsdom + vitest 環境では Suspense 解決が再現困難 → 検証は E2E に逃がす。
-    // スレッドタブは Suspense なし（プレースホルダのみ）なので確認可能。
-    it('スレッドタブで「準備中」プレースホルダ (Step 6c で実装) が表示される', async () => {
+    // スレッドタブも Step 6c で Suspense 内に実機データを描画する形に変わるため、
+    // 描画ではなく API 呼び出しが行われることのみ確認する（実描画は ThreadsList.test.tsx に責務移譲）。
+    it('スレッドタブを開くと api.threads.listSubscribed が呼ばれる', async () => {
       renderInbox('/?tab=threads');
-      expect(await screen.findByText(/準備中/)).toBeInTheDocument();
+      // 遅延を許容するため findBy を介して 1 度マウントが完了するのを待つ
+      await screen.findByRole('tab', { name: 'スレッド' });
+      expect(mockThreadsListSubscribed).toHaveBeenCalled();
     });
   });
 });

--- a/packages/client/src/__tests__/ThreadsList.test.tsx
+++ b/packages/client/src/__tests__/ThreadsList.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * components/Inbox/ThreadsList.tsx のユニットテスト (Step 6c)
+ *
+ * テスト対象:
+ *   - InboxPage の「スレッド」タブで使う表示用の純粋コンポーネント
+ *   - 親 (InboxPage) の Suspense 内で `use(promise)` を解決して配列を渡す責務分離パターン
+ *
+ * 戦略:
+ *   - 配列を直接 props で渡して描画結果を検証する (ネットワーク呼び出しなし)
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { ThreadSummary, Message } from '@chat-app/shared';
+import ThreadsList from '../components/Inbox/ThreadsList';
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 1,
+    channelId: 100,
+    userId: 1,
+    username: 'alice',
+    avatarUrl: null,
+    content: 'ルート本文',
+    isEdited: false,
+    isDeleted: false,
+    createdAt: '2026-05-01T10:00:00Z',
+    updatedAt: '2026-05-01T10:00:00Z',
+    mentions: [],
+    reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
+    ...overrides,
+  };
+}
+
+function makeThread(overrides: Partial<ThreadSummary> = {}): ThreadSummary {
+  return {
+    rootMessage: makeMessage(),
+    channelName: 'general',
+    replyCount: 1,
+    lastReplyAt: '2026-05-02T12:30:00Z',
+    unreadCount: 0,
+    ...overrides,
+  };
+}
+
+describe('ThreadsList (Step 6c)', () => {
+  it('配列が空のとき「購読中スレッドはありません」と表示される', () => {
+    render(<ThreadsList threads={[]} />);
+    expect(screen.getByText('購読中スレッドはありません')).toBeInTheDocument();
+  });
+
+  it('スレッドが渡されたとき、各カードにルートメッセージ本文・チャンネル名・返信件数が表示される', () => {
+    const thread = makeThread({
+      rootMessage: makeMessage({ id: 42, content: '今夜のリリース大丈夫？' }),
+      channelName: 'release',
+      replyCount: 3,
+    });
+    render(<ThreadsList threads={[thread]} />);
+    expect(screen.getByText(/今夜のリリース大丈夫？/)).toBeInTheDocument();
+    expect(screen.getByText(/#release/)).toBeInTheDocument();
+    expect(screen.getByText(/返信 3 件/)).toBeInTheDocument();
+  });
+
+  it('複数のスレッドが配列順で表示される', () => {
+    const threads: ThreadSummary[] = [
+      makeThread({ rootMessage: makeMessage({ id: 1, content: '一番目' }) }),
+      makeThread({ rootMessage: makeMessage({ id: 2, content: '二番目' }) }),
+      makeThread({ rootMessage: makeMessage({ id: 3, content: '三番目' }) }),
+    ];
+    render(<ThreadsList threads={threads} />);
+    const cards = screen.getAllByTestId('thread-card');
+    expect(cards).toHaveLength(3);
+    expect(cards[0]).toHaveTextContent('一番目');
+    expect(cards[1]).toHaveTextContent('二番目');
+    expect(cards[2]).toHaveTextContent('三番目');
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -60,6 +60,7 @@ import type {
   UpdateCalendarEventInput,
   CreateCalendarPollInput,
   CastCalendarVoteInput,
+  ThreadSummary,
 } from '@chat-app/shared';
 import type { AdminUser, AdminChannel, AdminStats, AuditLogListResponse } from '../types/admin';
 
@@ -686,5 +687,8 @@ export const api = {
           body: JSON.stringify({ candidateId }),
         }),
     },
+  },
+  threads: {
+    listSubscribed: () => request<{ threads: ThreadSummary[] }>('/threads/subscribed'),
   },
 };

--- a/packages/client/src/components/Inbox/ThreadsList.tsx
+++ b/packages/client/src/components/Inbox/ThreadsList.tsx
@@ -1,0 +1,62 @@
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import type { ThreadSummary } from '@chat-app/shared';
+
+interface Props {
+  threads: ThreadSummary[];
+}
+
+function parseMessageContent(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
+    return (
+      parsed.ops
+        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
+        .join('')
+        .trim() ?? raw
+    );
+  } catch {
+    return raw;
+  }
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString([], {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Step 6c: Inbox の「スレッド」タブ表示用の純粋コンポーネント。
+ * 親 (InboxPage) の Suspense 内で `use(promise)` を解決し、配列を渡して描画する責務分離パターン。
+ *
+ * 各カードはスレッドのルートメッセージ本文・送信元チャンネル名・返信件数・最終返信時刻を表示する。
+ */
+export default function ThreadsList({ threads }: Props) {
+  if (threads.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
+        購読中スレッドはありません
+      </Typography>
+    );
+  }
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {threads.map((t) => (
+        <Card key={t.rootMessage.id} variant="outlined" data-testid="thread-card">
+          <CardContent>
+            <Typography variant="caption" color="text.secondary">
+              🧵 #{t.channelName} · {t.rootMessage.username} · 返信 {t.replyCount} 件 ·{' '}
+              {formatDateTime(t.lastReplyAt)}
+            </Typography>
+            <Typography variant="body2">{parseMessageContent(t.rootMessage.content)}</Typography>
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+}

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -6,9 +6,10 @@ import SummaryCards, { type SummaryData } from '../components/Inbox/SummaryCards
 import RemindersList from '../components/Inbox/RemindersList';
 import DraftsList from '../components/Inbox/DraftsList';
 import MentionsList from '../components/Inbox/MentionsList';
+import ThreadsList from '../components/Inbox/ThreadsList';
 import { api } from '../api/client';
 import { useAuth } from '../contexts/AuthContext';
-import type { Draft, MessageSearchResult, Reminder } from '@chat-app/shared';
+import type { Draft, MessageSearchResult, Reminder, ThreadSummary } from '@chat-app/shared';
 
 type TabKey = 'mentions' | 'threads' | 'reminders' | 'drafts' | 'all';
 
@@ -38,6 +39,11 @@ function MentionsSection({ promise }: { promise: Promise<{ messages: MessageSear
   return <MentionsList messages={messages} />;
 }
 
+function ThreadsSection({ promise }: { promise: Promise<{ threads: ThreadSummary[] }> }) {
+  const { threads } = use(promise);
+  return <ThreadsList threads={threads} />;
+}
+
 function AllSection({
   mentionsPromise,
   remindersPromise,
@@ -59,26 +65,12 @@ function AllSection({
   );
 }
 
-function PlaceholderTab({ note }: { note: string }) {
-  return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1, p: 3 }}>
-      <Typography variant="body2" color="text.secondary">
-        準備中
-      </Typography>
-      <Typography variant="caption" color="text.secondary">
-        {note}
-      </Typography>
-    </Box>
-  );
-}
-
 /**
  * Step 6a: Focus Inbox 画面。
  * ルート `/` を InboxPage に切替え、サマリーカード 3 連 + 5 タブ (メンション / スレッド /
  * リマインダー / 下書き / すべて) を表示する。
  *
- * メンション・スレッドタブは Step 6b / 6c でサーバー API を追加してから実機データ化する予定で、
- * 本 Step では「準備中」プレースホルダで暫定対応。
+ * メンションタブ (Step 6b) / スレッドタブ (Step 6c) はそれぞれサーバー API を追加して実機データ化済み。
  *
  * 後方互換: `/?channel=X` でアクセスされた場合は `/chat?channel=X` にリダイレクトし、
  * 既存のチャンネル復元動線を維持する。
@@ -120,6 +112,10 @@ export default function InboxPage() {
       tab === 'mentions' || tab === 'all'
         ? api.messages.search('', { mentionedToMe: true, unreadOnly: true })
         : null,
+    [tab],
+  );
+  const threadsPromise = useMemo(
+    () => (tab === 'threads' ? api.threads.listSubscribed() : null),
     [tab],
   );
   const remindersPromise = useMemo(
@@ -179,8 +175,16 @@ export default function InboxPage() {
               <MentionsSection promise={mentionsPromise} />
             </Suspense>
           )}
-          {tab === 'threads' && (
-            <PlaceholderTab note="購読中スレッド一覧は Step 6c で実装予定です。" />
+          {tab === 'threads' && threadsPromise && (
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 2 }}>
+                  <CircularProgress size={20} />
+                </Box>
+              }
+            >
+              <ThreadsSection promise={threadsPromise} />
+            </Suspense>
           )}
           {tab === 'reminders' && remindersPromise && (
             <Suspense

--- a/packages/server/src/__tests__/integration/threadsSubscribed.test.ts
+++ b/packages/server/src/__tests__/integration/threadsSubscribed.test.ts
@@ -1,0 +1,281 @@
+/**
+ * 購読中スレッド一覧 API のテスト (Step 6c)
+ *
+ * テスト対象: GET /api/threads/subscribed
+ * 戦略:
+ *   - DB は pg-mem のインメモリ PostgreSQL 互換 DB を使用
+ *   - supertest で HTTP リクエストを発行し、ステータスコードとボディを検証する
+ *   - メッセージ・スレッド返信は DB に直接 INSERT して用意する
+ *
+ * 「購読中スレッド」の定義（Step 6c 確定スコープ）:
+ *   - 自分が返信投稿（parent_message_id IS NOT NULL かつ user_id = me）したスレッドの
+ *     ルートメッセージ一覧を返す
+ *   - リアクションのみの関与・メンションのみの関与は対象外（後続 Step で拡張）
+ *
+ * レスポンス: { threads: [{ rootMessage, channelName, replyCount, lastReplyAt, unreadCount }] }
+ *   - unreadCount は本 Step では 0 固定（thread_reads テーブルが未設計のため）
+ *   - ソートは lastReplyAt 降順
+ */
+
+import { createTestDatabase } from '../__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+
+jest.mock('../../db/database', () => testDb);
+
+import request from 'supertest';
+import { createApp } from '../../app';
+import { registerUser, createChannelReq, insertMessage } from '../__fixtures__/testHelpers';
+
+const app = createApp();
+
+/** スレッド返信（root_message_id / parent_message_id 付き）を直接 INSERT する */
+async function insertReply(
+  channelId: number,
+  userId: number,
+  content: string,
+  parentMessageId: number,
+  rootMessageId: number,
+): Promise<number> {
+  const result = await testDb.execute(
+    `INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id)
+     VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+    [channelId, userId, content, parentMessageId, rootMessageId],
+  );
+  return result.rows[0].id as number;
+}
+
+describe('GET /api/threads/subscribed', () => {
+  describe('正常系', () => {
+    it('自分が返信投稿したスレッドのルートメッセージが返される', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice1',
+        'th_alice1@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob1', 'th_bob1@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch1');
+
+      const rootId = await insertMessage(channelId, bobId, 'スレッドルート');
+      await insertReply(channelId, aliceId, '私の返信', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.threads)).toBe(true);
+      expect(res.body.threads).toHaveLength(1);
+      expect(res.body.threads[0].rootMessage.id).toBe(rootId);
+      expect(res.body.threads[0].rootMessage.content).toBe('スレッドルート');
+    });
+
+    it('自分が返信していないスレッドは返らない', async () => {
+      const { token: aliceToken } = await registerUser(app, 'th_alice2', 'th_alice2@example.com');
+      const { userId: bobId } = await registerUser(app, 'th_bob2', 'th_bob2@example.com');
+      const { userId: charlieId } = await registerUser(
+        app,
+        'th_charlie2',
+        'th_charlie2@example.com',
+      );
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch2');
+
+      const rootId = await insertMessage(channelId, bobId, 'alice 関与なし');
+      await insertReply(channelId, charlieId, 'charlie の返信', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.threads).toHaveLength(0);
+    });
+
+    it('複数のスレッドに返信していれば、それぞれ 1 件ずつまとめて返る', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice3',
+        'th_alice3@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob3', 'th_bob3@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch3');
+
+      const root1 = await insertMessage(channelId, bobId, 'ルート1');
+      const root2 = await insertMessage(channelId, bobId, 'ルート2');
+      // alice が root1 に 2 回・root2 に 1 回返信
+      await insertReply(channelId, aliceId, 'r1-1', root1, root1);
+      await insertReply(channelId, aliceId, 'r1-2', root1, root1);
+      await insertReply(channelId, aliceId, 'r2-1', root2, root2);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      const ids = (res.body.threads as { rootMessage: { id: number } }[]).map(
+        (t) => t.rootMessage.id,
+      );
+      expect(ids).toContain(root1);
+      expect(ids).toContain(root2);
+      expect(res.body.threads).toHaveLength(2);
+    });
+
+    it('レスポンスに channelName / replyCount / lastReplyAt が含まれる', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice4',
+        'th_alice4@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob4', 'th_bob4@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch4');
+
+      const rootId = await insertMessage(channelId, bobId, 'ルート');
+      await insertReply(channelId, aliceId, '返信1', rootId, rootId);
+      await insertReply(channelId, bobId, '返信2', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      const t = res.body.threads[0];
+      expect(t.channelName).toBe('th-ch4');
+      expect(t.replyCount).toBe(2);
+      expect(typeof t.lastReplyAt).toBe('string');
+      expect(new Date(t.lastReplyAt).toString()).not.toBe('Invalid Date');
+    });
+
+    it('lastReplyAt 降順でソートされる', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice5',
+        'th_alice5@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob5', 'th_bob5@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch5');
+
+      // ルートを 2 つ作って、片方は古い時刻、もう片方は新しい時刻に最終返信を持たせる
+      const rootOld = await insertMessage(channelId, bobId, '古いスレッド');
+      const rootNew = await insertMessage(channelId, bobId, '新しいスレッド');
+      // alice の返信を直接 INSERT して created_at を明示的に設定
+      await testDb.execute(
+        `INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [channelId, aliceId, 'old reply', rootOld, rootOld, '2024-01-01T00:00:00Z'],
+      );
+      await testDb.execute(
+        `INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [channelId, aliceId, 'new reply', rootNew, rootNew, '2025-12-31T00:00:00Z'],
+      );
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      const ids = (res.body.threads as { rootMessage: { id: number } }[]).map(
+        (t) => t.rootMessage.id,
+      );
+      // 新しいスレッドが先に来る
+      expect(ids[0]).toBe(rootNew);
+      expect(ids[1]).toBe(rootOld);
+    });
+
+    it('ルートメッセージが論理削除されているスレッドは結果から除外される', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice6',
+        'th_alice6@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob6', 'th_bob6@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch6');
+
+      const rootId = await insertMessage(channelId, bobId, '削除対象ルート');
+      await insertReply(channelId, aliceId, '返信', rootId, rootId);
+      await testDb.execute('UPDATE messages SET is_deleted = true WHERE id = $1', [rootId]);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.threads).toHaveLength(0);
+    });
+
+    it('複数チャンネルをまたいで購読中スレッドを集約できる', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice7',
+        'th_alice7@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob7', 'th_bob7@example.com');
+      const ch1 = await createChannelReq(app, aliceToken, 'th-ch7a');
+      const ch2 = await createChannelReq(app, aliceToken, 'th-ch7b');
+
+      const root1 = await insertMessage(ch1, bobId, 'ルートA');
+      const root2 = await insertMessage(ch2, bobId, 'ルートB');
+      await insertReply(ch1, aliceId, 'rA', root1, root1);
+      await insertReply(ch2, aliceId, 'rB', root2, root2);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.threads).toHaveLength(2);
+      const channelNames = (res.body.threads as { channelName: string }[]).map(
+        (t) => t.channelName,
+      );
+      expect(channelNames).toEqual(expect.arrayContaining(['th-ch7a', 'th-ch7b']));
+    });
+
+    it('unreadCount は本 Step では 0 固定で返る', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice8',
+        'th_alice8@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob8', 'th_bob8@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch8');
+
+      const rootId = await insertMessage(channelId, bobId, 'ルート');
+      await insertReply(channelId, aliceId, '返信', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.threads[0].unreadCount).toBe(0);
+    });
+  });
+
+  describe('認可・エラー系', () => {
+    it('未認証アクセスは 401 を返す', async () => {
+      const res = await request(app).get('/api/threads/subscribed');
+      expect(res.status).toBe(401);
+    });
+
+    it('他人が返信したスレッドは自分の購読リストには含まれない', async () => {
+      const { token: aliceToken } = await registerUser(app, 'th_alice9', 'th_alice9@example.com');
+      const { userId: bobId } = await registerUser(app, 'th_bob9', 'th_bob9@example.com');
+      const { userId: charlieId } = await registerUser(
+        app,
+        'th_charlie9',
+        'th_charlie9@example.com',
+      );
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch9');
+
+      const rootId = await insertMessage(channelId, bobId, 'ルート');
+      await insertReply(channelId, charlieId, 'charlie の返信', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.threads).toHaveLength(0);
+    });
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -23,6 +23,7 @@ import taskRoutes from './routes/tasks';
 import savedViewRoutes from './routes/savedViews';
 import guestLinksRouter, { channelGuestLinksRouter } from './routes/guestLinks';
 import calendarRoutes from './routes/calendar';
+import threadRoutes from './routes/threads';
 import { errorHandler } from './middleware/errorHandler';
 import { setupSwagger } from './swagger/setup';
 
@@ -66,6 +67,7 @@ export function createApp() {
   app.use('/api/channels/:id/guest-links', channelGuestLinksRouter);
   app.use('/api/guest-links', guestLinksRouter);
   app.use('/api/calendar', calendarRoutes);
+  app.use('/api/threads', threadRoutes);
 
   app.use(errorHandler);
 

--- a/packages/server/src/routes/threads.ts
+++ b/packages/server/src/routes/threads.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
+import * as threadService from '../services/threadService';
+
+const router = Router();
+
+/**
+ * Step 6c: GET /api/threads/subscribed
+ * 自分が返信したスレッドのサマリー一覧を返す（Inbox スレッドタブで使用）
+ */
+router.get('/subscribed', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  try {
+    const threads = await threadService.listSubscribedThreads(userId);
+    return res.json({ threads });
+  } catch {
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/packages/server/src/services/threadService.ts
+++ b/packages/server/src/services/threadService.ts
@@ -1,0 +1,64 @@
+import { query } from '../db/database';
+import type { ThreadSummary } from '@chat-app/shared';
+import * as messageService from './messageService';
+
+interface ThreadAggRow {
+  root_message_id: number;
+  channel_name: string;
+  reply_count: string;
+  last_reply_at: string;
+}
+
+/**
+ * Step 6c: 自分が返信投稿したスレッドの一覧を返す。
+ *
+ * 「購読中スレッド」の定義:
+ *   - parent_message_id IS NOT NULL かつ user_id = userId のメッセージ（= 自分の返信）
+ *   - そのルートメッセージ（root_message_id が指すメッセージ）を集約して返す
+ *   - ルートメッセージが論理削除済みの場合は除外する
+ *
+ * unreadCount は thread_reads テーブルが未設計のため Step 6c では 0 固定。
+ * Step 6d 以降で本実装予定。
+ *
+ * ソート: lastReplyAt 降順（自分の最後の返信時刻ではなくスレッド全体の最終返信時刻）
+ */
+export async function listSubscribedThreads(userId: number): Promise<ThreadSummary[]> {
+  const rows = await query<ThreadAggRow>(
+    `
+    SELECT
+      r.id AS root_message_id,
+      c.name AS channel_name,
+      COUNT(all_replies.id)::text AS reply_count,
+      MAX(all_replies.created_at) AS last_reply_at
+    FROM messages r
+    JOIN channels c ON c.id = r.channel_id
+    LEFT JOIN messages all_replies
+      ON all_replies.root_message_id = r.id AND all_replies.is_deleted = false
+    WHERE r.is_deleted = false
+      AND r.id IN (
+        SELECT my_reply.root_message_id
+        FROM messages my_reply
+        WHERE my_reply.parent_message_id IS NOT NULL
+          AND my_reply.user_id = $1
+          AND my_reply.is_deleted = false
+      )
+    GROUP BY r.id, c.name
+    ORDER BY MAX(all_replies.created_at) DESC
+    `,
+    [userId],
+  );
+
+  const summaries: ThreadSummary[] = [];
+  for (const row of rows) {
+    const rootMessage = await messageService.getMessageById(row.root_message_id);
+    if (!rootMessage) continue;
+    summaries.push({
+      rootMessage,
+      channelName: row.channel_name,
+      replyCount: Number(row.reply_count),
+      lastReplyAt: row.last_reply_at,
+      unreadCount: 0, // Step 6c では 0 固定
+    });
+  }
+  return summaries;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -21,3 +21,4 @@ export * from './types/savedView';
 export * from './types/guestLink';
 export * from './types/rateLimit';
 export * from './types/calendar';
+export * from './types/thread';

--- a/packages/shared/src/types/thread.ts
+++ b/packages/shared/src/types/thread.ts
@@ -1,0 +1,19 @@
+import type { Message } from './message';
+
+/**
+ * Step 6c: 購読中スレッドのサマリー
+ *
+ * Inbox 画面の「スレッド」タブで使用する集約レスポンス。
+ * 「購読中スレッド」 = 自分が返信投稿（parent_message_id IS NOT NULL かつ user_id = me）した
+ * スレッドのルートメッセージ。
+ *
+ * unreadCount は thread_reads テーブル未設計のため Step 6c では 0 固定。
+ * Step 6d 以降で本実装予定。
+ */
+export interface ThreadSummary {
+  rootMessage: Message;
+  channelName: string;
+  replyCount: number;
+  lastReplyAt: string;
+  unreadCount: number;
+}


### PR DESCRIPTION
## 概要

Inbox の「スレッド」タブを準備中プレースホルダから実機データ化する Step 6c。サーバー側に `GET /api/threads/subscribed` を新設し、自分が返信投稿したスレッドのルートメッセージを集約して返す。

## 変更内容

### サーバー
- `packages/shared/src/types/thread.ts` 新設（`ThreadSummary`: rootMessage / channelName / replyCount / lastReplyAt / unreadCount）
- `packages/server/src/services/threadService.ts` 新設（`listSubscribedThreads(userId)`)
- `packages/server/src/routes/threads.ts` 新設（`GET /api/threads/subscribed`）
- `packages/server/src/app.ts` にルート登録

### フロント
- `packages/client/src/api/client.ts` に `api.threads.listSubscribed()` を追加
- `packages/client/src/components/Inbox/ThreadsList.tsx` 新設（純粋コンポーネント／カードでチャンネル名・本文・返信件数・最終返信時刻を表示）
- `packages/client/src/pages/InboxPage.tsx` のスレッドタブを Suspense + `use(promise)` で実機データ化、`PlaceholderTab` 関数を撤去

### 「購読中スレッド」の定義（Step 6c 確定スコープ）
- `parent_message_id IS NOT NULL` かつ `user_id = me` の返信メッセージが存在するスレッドのルート
- 結果ソート: `lastReplyAt` 降順
- ルートメッセージが論理削除済みの場合は除外
- `unreadCount` は `thread_reads` テーブル未設計のため **0 固定**（Step 6d 以降で本実装予定）

## 影響範囲
- フロント: Inbox 画面のスレッドタブのみ。チャットページや他タブの動作は不変
- サーバー: 新規エンドポイント追加のみ。既存 API は不変。`messageService` の既存 `getMessageById` をそのまま再利用

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1377 件 + 5 skip）
- [x] バックエンドユニットテストがすべてパスする（1373 件、Step 6c 統合テスト 10 件追加）
- [x] ビルドが正常に完了すること（shared / server / client）
- [ ] (手動確認) スレッドに返信した状態で `/?tab=threads` にアクセスしてスレッドカードが表示されること

## 関連Issue
Fixes #N/A (UI/UX ブラッシュアップ Step 6c — `doc/brushup-uiux-plan/PROGRESS.md` 参照)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（PROGRESS.md）の更新はマージ後に実施
- [x] `it.todo` / 空ボディの `it` が残っていない

## 既存テストの変更
| ファイル | 変更箇所 | 理由 |
|---|---|---|
| `packages/client/src/__tests__/InboxPage.test.tsx` | 「スレッドタブで「準備中」プレースホルダが表示される」を削除し「スレッドタブを開くと api.threads.listSubscribed が呼ばれる」に置換 | 仕様変更（Step 6c で実機データ化したためプレースホルダ自体が存在しない） |

## 実装メモ
- pg-mem は相関サブクエリ（FROM 外のエイリアスを参照）を実行できないため、集計クエリは `LEFT JOIN + GROUP BY` で組み直した
- ThreadsList は MentionsList と同じ純粋コンポーネント + Suspense ラッパーパターン（jsdom 互換性のため）