### PR TITLE
feat(inbox/rail): メンション数バッジ + Inbox クイックアクション + ChannelList バッジ色調整 (Step 6d)

### DIFF
--- a/packages/client/src/__tests__/DraftsList.test.tsx
+++ b/packages/client/src/__tests__/DraftsList.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
 import DraftsList from '../components/Inbox/DraftsList';
 import type { Draft } from '@chat-app/shared';
 
@@ -40,5 +41,35 @@ describe('DraftsList (Step 6a)', () => {
     ];
     render(<DraftsList drafts={drafts} />);
     expect(screen.getAllByTestId('draft-card')).toHaveLength(2);
+  });
+
+  describe('クイックアクション (Step 6d)', () => {
+    it('チャンネル下書きのカードに「再開」ボタンが表示される', () => {
+      render(<DraftsList drafts={[makeDraft({ channelId: 7 })]} />);
+      expect(screen.getByRole('button', { name: '再開' })).toBeInTheDocument();
+    });
+
+    it('「再開」ボタンを押すと onResume props が該当の channelId で呼ばれる', async () => {
+      const onResume = vi.fn();
+      render(<DraftsList drafts={[makeDraft({ channelId: 7 })]} onResume={onResume} />);
+      await userEvent.click(screen.getByRole('button', { name: '再開' }));
+      expect(onResume).toHaveBeenCalledWith({ kind: 'channel', channelId: 7 });
+    });
+
+    it('DM 下書き (channelId = null, dmConversationId 有) の「再開」は dmConversationId で onResume を呼ぶ', async () => {
+      const onResume = vi.fn();
+      render(
+        <DraftsList
+          drafts={[makeDraft({ channelId: null, dmConversationId: 99 })]}
+          onResume={onResume}
+        />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: '再開' }));
+      expect(onResume).toHaveBeenCalledWith({ kind: 'dm', dmConversationId: 99 });
+    });
+
+    it('onResume が未指定でも描画はクラッシュしない', () => {
+      expect(() => render(<DraftsList drafts={[makeDraft()]} />)).not.toThrow();
+    });
   });
 });

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -22,6 +22,11 @@ vi.mock('../hooks/useDmUnreadCount', () => ({
   useDmUnreadCount: () => mockDmUnreadCount,
 }));
 
+let mockMentionUnreadCount = 0;
+vi.mock('../hooks/useMentionUnreadCount', () => ({
+  useMentionUnreadCount: () => mockMentionUnreadCount,
+}));
+
 const mockUser = {
   id: 1,
   username: 'alice',
@@ -36,6 +41,7 @@ const mockUser = {
 beforeEach(() => {
   mockUser.role = 'user';
   mockDmUnreadCount = 0;
+  mockMentionUnreadCount = 0;
 });
 
 function renderRail(initialPath = '/', role: 'user' | 'admin' = 'user') {
@@ -190,6 +196,37 @@ describe('Rail', () => {
     it('現在のパスが / のとき、ホームアイコンに aria-current="page" が付与される', () => {
       renderRail('/');
       expect(screen.getByRole('link', { name: 'ホーム' })).toHaveAttribute('aria-current', 'page');
+    });
+  });
+
+  describe('メンション未読バッジ (Step 6d / 保留 TODO #5 解消)', () => {
+    it('useMentionUnreadCount が 0 のとき、ホームアイコンにメンション数バッジは表示されない', () => {
+      mockMentionUnreadCount = 0;
+      // ホームアイコン外の他リンクのバッジ "3" 等の干渉を避けるため、現在パスは /chat
+      renderRail('/chat');
+      const homeLink = screen.getByRole('link', { name: 'ホーム' });
+      // バッジが「不可視（0）」状態であること（DOM 上に MuiBadge-invisible が付く）
+      expect(homeLink.querySelector('.MuiBadge-invisible')).not.toBeNull();
+    });
+
+    it('useMentionUnreadCount が 3 のとき、ホームアイコンに "3" のバッジが表示される', () => {
+      mockMentionUnreadCount = 3;
+      renderRail('/chat');
+      // DM 未読は 0 のため、画面上の "3" はホームアイコンのバッジ由来
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('useMentionUnreadCount が 12 のとき、ホームアイコンに "9+" のバッジが表示される (max=9)', () => {
+      mockMentionUnreadCount = 12;
+      renderRail('/chat');
+      expect(screen.getByText('9+')).toBeInTheDocument();
+    });
+
+    it('未読メンションがあるとき、ホームアイコンの aria-label に未読数の情報が含まれる', () => {
+      mockMentionUnreadCount = 4;
+      renderRail('/chat');
+      const homeLink = screen.getByRole('link', { name: /ホーム.*4.*未読/ });
+      expect(homeLink).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/RemindersList.test.tsx
+++ b/packages/client/src/__tests__/RemindersList.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
 import RemindersList from '../components/Inbox/RemindersList';
 import type { Reminder } from '@chat-app/shared';
 
@@ -65,5 +66,24 @@ describe('RemindersList (Step 6a)', () => {
     ];
     render(<RemindersList reminders={reminders} />);
     expect(screen.getAllByTestId('reminder-card')).toHaveLength(2);
+  });
+
+  describe('クイックアクション (Step 6d)', () => {
+    it('各カードに「完了」ボタンが表示される', () => {
+      render(<RemindersList reminders={[makeReminder(), makeReminder({ id: 2 })]} />);
+      const buttons = screen.getAllByRole('button', { name: '完了' });
+      expect(buttons).toHaveLength(2);
+    });
+
+    it('「完了」ボタンを押すと onComplete props が該当 id で呼ばれる', async () => {
+      const onComplete = vi.fn();
+      render(<RemindersList reminders={[makeReminder({ id: 42 })]} onComplete={onComplete} />);
+      await userEvent.click(screen.getByRole('button', { name: '完了' }));
+      expect(onComplete).toHaveBeenCalledWith(42);
+    });
+
+    it('onComplete が未指定でも描画はクラッシュしない', () => {
+      expect(() => render(<RemindersList reminders={[makeReminder()]} />)).not.toThrow();
+    });
   });
 });

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -73,6 +73,10 @@ vi.mock('../api/client', () => ({
     dm: {
       listConversations: () => Promise.resolve({ conversations: [] }),
     },
+    // Step 6d: Rail 内 useMentionUnreadCount が api.messages.search を呼ぶため
+    messages: {
+      search: () => Promise.resolve({ messages: [] }),
+    },
   },
 }));
 

--- a/packages/client/src/components/Channel/ChannelItem.tsx
+++ b/packages/client/src/components/Channel/ChannelItem.tsx
@@ -248,8 +248,14 @@ export default function ChannelItem({
             {(channel.mentionCount ?? 0) > 0 && !isMuted && (
               <Badge
                 badgeContent={(channel.mentionCount ?? 0) > 9 ? '9+' : channel.mentionCount}
-                color="error"
-                sx={{ ml: 1, mr: isHovered ? '36px' : 0 }}
+                sx={{
+                  ml: 1,
+                  mr: isHovered ? '36px' : 0,
+                  '& .MuiBadge-badge': {
+                    bgcolor: 'var(--accent)',
+                    color: 'var(--accent-fg)',
+                  },
+                }}
               >
                 <Box component="span" sx={{ display: 'inline-block', width: 8, height: 8 }} />
               </Badge>
@@ -257,9 +263,15 @@ export default function ChannelItem({
             {channel.unreadCount > 0 && (channel.mentionCount ?? 0) === 0 && !isMuted && (
               <Badge
                 badgeContent={channel.unreadCount}
-                color="primary"
                 max={9}
-                sx={{ ml: 1, mr: isHovered ? '36px' : 0 }}
+                sx={{
+                  ml: 1,
+                  mr: isHovered ? '36px' : 0,
+                  '& .MuiBadge-badge': {
+                    bgcolor: 'var(--text-muted)',
+                    color: 'var(--bg)',
+                  },
+                }}
               >
                 <Box component="span" sx={{ display: 'inline-block', width: 8, height: 8 }} />
               </Badge>

--- a/packages/client/src/components/Inbox/DraftsList.tsx
+++ b/packages/client/src/components/Inbox/DraftsList.tsx
@@ -1,8 +1,18 @@
-import { Box, Card, CardContent, Typography } from '@mui/material';
+import { Box, Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import type { Draft } from '@chat-app/shared';
+
+/** Step 6d: 「再開」アクションの宛先種別 */
+export type DraftResumeTarget =
+  | { kind: 'channel'; channelId: number }
+  | { kind: 'dm'; dmConversationId: number };
 
 interface Props {
   drafts: Draft[];
+  /**
+   * Step 6d: 「再開」ボタンが押されたとき呼ばれる。
+   * チャンネル下書き / DM 下書きのいずれかを判別して通知する。
+   */
+  onResume?: (target: DraftResumeTarget) => void;
 }
 
 function parseMessageContent(raw: string): string {
@@ -30,11 +40,25 @@ function formatDateTime(iso: string): string {
   });
 }
 
+function resolveTarget(d: Draft): DraftResumeTarget | null {
+  if (d.channelId !== null && d.channelId !== undefined) {
+    return { kind: 'channel', channelId: d.channelId };
+  }
+  if (d.dmConversationId !== null && d.dmConversationId !== undefined) {
+    return { kind: 'dm', dmConversationId: d.dmConversationId };
+  }
+  return null;
+}
+
 /**
  * Step 6a: Inbox の「下書き」タブ表示用の純粋コンポーネント。
  * Promise の解決は親 (InboxPage) の Suspense で行い、ここには配列を受け取って描画するだけにする。
+ *
+ * Step 6d: 各カードに「再開」クイックアクションを追加。
+ * 押下で onResume?.(target) を呼ぶ。target は channelId か dmConversationId のいずれか。
+ * 実際の navigation は親 (InboxPage) に委譲。
  */
-export default function DraftsList({ drafts }: Props) {
+export default function DraftsList({ drafts, onResume }: Props) {
   if (drafts.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
@@ -44,16 +68,26 @@ export default function DraftsList({ drafts }: Props) {
   }
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {drafts.map((d) => (
-        <Card key={d.id} variant="outlined" data-testid="draft-card">
-          <CardContent>
-            <Typography variant="caption" color="text.secondary">
-              📝 {formatDateTime(d.updatedAt)}
-            </Typography>
-            <Typography variant="body2">{parseMessageContent(d.content)}</Typography>
-          </CardContent>
-        </Card>
-      ))}
+      {drafts.map((d) => {
+        const target = resolveTarget(d);
+        return (
+          <Card key={d.id} variant="outlined" data-testid="draft-card">
+            <CardContent>
+              <Typography variant="caption" color="text.secondary">
+                📝 {formatDateTime(d.updatedAt)}
+              </Typography>
+              <Typography variant="body2">{parseMessageContent(d.content)}</Typography>
+            </CardContent>
+            {target && (
+              <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>
+                <Button size="small" onClick={() => onResume?.(target)}>
+                  再開
+                </Button>
+              </CardActions>
+            )}
+          </Card>
+        );
+      })}
     </Box>
   );
 }

--- a/packages/client/src/components/Inbox/RemindersList.tsx
+++ b/packages/client/src/components/Inbox/RemindersList.tsx
@@ -1,8 +1,10 @@
-import { Box, Card, CardContent, Typography } from '@mui/material';
+import { Box, Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import type { Reminder } from '@chat-app/shared';
 
 interface Props {
   reminders: Reminder[];
+  /** Step 6d: 「完了」ボタンが押されたとき、対象リマインダー id で呼ばれる */
+  onComplete?: (id: number) => void;
 }
 
 function parseMessageContent(raw: string): string {
@@ -33,8 +35,11 @@ function formatDateTime(iso: string): string {
 /**
  * Step 6a: Inbox の「リマインダー」タブ表示用の純粋コンポーネント。
  * Promise の解決は親 (InboxPage) の Suspense で行い、ここには配列を受け取って描画するだけにする。
+ *
+ * Step 6d: 各カードに「完了」クイックアクションを追加。
+ * 押下で onComplete?.(id) を呼ぶ。実際の API 呼び出し (api.reminders.delete) は親に委譲。
  */
-export default function RemindersList({ reminders }: Props) {
+export default function RemindersList({ reminders, onComplete }: Props) {
   if (reminders.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
@@ -54,6 +59,11 @@ export default function RemindersList({ reminders }: Props) {
               {r.message ? parseMessageContent(r.message.content) : '(メッセージが見つかりません)'}
             </Typography>
           </CardContent>
+          <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>
+            <Button size="small" onClick={() => onComplete?.(r.id)}>
+              完了
+            </Button>
+          </CardActions>
         </Card>
       ))}
     </Box>

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -11,6 +11,7 @@ import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useDmUnreadCount } from '../../hooks/useDmUnreadCount';
+import { useMentionUnreadCount } from '../../hooks/useMentionUnreadCount';
 
 interface NavItem {
   label: string;
@@ -81,6 +82,7 @@ export default function Rail() {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
   const dmUnreadCount = useDmUnreadCount();
+  const mentionUnreadCount = useMentionUnreadCount();
 
   return (
     <Box
@@ -124,9 +126,12 @@ export default function Rail() {
       </Box>
 
       <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
-        {TOP_ITEMS.map((item) => (
-          <RailLink key={item.to} item={item} badgeCount={item.to === '/dm' ? dmUnreadCount : 0} />
-        ))}
+        {TOP_ITEMS.map((item) => {
+          let badgeCount = 0;
+          if (item.to === '/dm') badgeCount = dmUnreadCount;
+          else if (item.to === '/') badgeCount = mentionUnreadCount;
+          return <RailLink key={item.to} item={item} badgeCount={badgeCount} />;
+        })}
 
         {/* 検索アイコン (Step 2b で配置だけ追加、Step 7 で検索ページ新設時に有効化)
             動線未完成として PROGRESS.md 保留 TODO #1 に登録済み */}

--- a/packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx
+++ b/packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * テスト対象: hooks/useMentionUnreadCount.ts (Step 6d / 保留 TODO #5)
+ *
+ * Rail のホームアイコン (Inbox) に出すメンション未読数バッジ用集計フック。
+ * Step 6b で追加した `api.messages.search('', { mentionedToMe: true, unreadOnly: true })`
+ * を再利用して count を取得する。
+ *
+ * 戦略:
+ *   - api.messages.search をモックして件数を制御する
+ *   - 現在パスが Inbox (ホーム `/`) のときは count を 0 に潰す（自分が見ている画面に
+ *     バッジを出すと冗長になるため）
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+import { useMentionUnreadCount } from '../useMentionUnreadCount';
+
+const mockSearch = vi.fn();
+
+vi.mock('../../api/client', () => ({
+  api: {
+    messages: {
+      search: (q: string, filters: unknown) => mockSearch(q, filters),
+    },
+  },
+}));
+
+function wrapperFactory(initialPath: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>;
+  };
+}
+
+beforeEach(() => {
+  mockSearch.mockReset();
+});
+
+describe('useMentionUnreadCount (Step 6d)', () => {
+  it('初回マウント時に api.messages.search を mentionedToMe / unreadOnly フィルタで呼ぶ', async () => {
+    mockSearch.mockResolvedValue({ messages: [] });
+    renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith('', { mentionedToMe: true, unreadOnly: true });
+    });
+  });
+
+  it('レスポンスの messages.length をカウントとして返す', async () => {
+    mockSearch.mockResolvedValue({
+      messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+    });
+    const { result } = renderHook(() => useMentionUnreadCount(), {
+      wrapper: wrapperFactory('/chat'),
+    });
+    await waitFor(() => {
+      expect(result.current).toBe(3);
+    });
+  });
+
+  it('現在パスが / (Inbox) のときは 0 を返す（内部 state は保持）', async () => {
+    mockSearch.mockResolvedValue({ messages: [{ id: 1 }, { id: 2 }] });
+    const { result } = renderHook(() => useMentionUnreadCount(), {
+      wrapper: wrapperFactory('/'),
+    });
+    // API は呼ばれるが、location が '/' のため count は 0
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalled();
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it('API が失敗した場合は 0 を返す（throw しない）', async () => {
+    mockSearch.mockRejectedValue(new Error('boom'));
+    const { result } = renderHook(() => useMentionUnreadCount(), {
+      wrapper: wrapperFactory('/chat'),
+    });
+    // 失敗後も throw せず 0 のまま
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalled();
+    });
+    expect(result.current).toBe(0);
+  });
+});

--- a/packages/client/src/hooks/useMentionUnreadCount.ts
+++ b/packages/client/src/hooks/useMentionUnreadCount.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { api } from '../api/client';
+
+/**
+ * Step 6d: Rail のホームアイコン (Inbox) に出すメンション未読バッジ用集計フック。
+ *
+ * - Step 6b の `api.messages.search('', { mentionedToMe: true, unreadOnly: true })`
+ *   を再利用して未読メンション件数を取得する
+ * - 現在パスが Inbox (`/`) のときは 0 を返す（自分が見ている画面に
+ *   バッジを出すと冗長になるため。state は保持）
+ * - API 失敗時は 0 を返す（throw しない）
+ */
+export function useMentionUnreadCount(): number {
+  const [count, setCount] = useState(0);
+  const location = useLocation();
+
+  useEffect(() => {
+    let cancelled = false;
+    api.messages
+      .search('', { mentionedToMe: true, unreadOnly: true })
+      .then(({ messages }) => {
+        if (cancelled) return;
+        setCount(messages.length);
+      })
+      .catch(() => {
+        // 取得失敗時は 0 のまま
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (location.pathname === '/') return 0;
+  return count;
+}

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -7,6 +7,7 @@ import RemindersList from '../components/Inbox/RemindersList';
 import DraftsList from '../components/Inbox/DraftsList';
 import MentionsList from '../components/Inbox/MentionsList';
 import ThreadsList from '../components/Inbox/ThreadsList';
+import type { DraftResumeTarget } from '../components/Inbox/DraftsList';
 import { api } from '../api/client';
 import { useAuth } from '../contexts/AuthContext';
 import type { Draft, MessageSearchResult, Reminder, ThreadSummary } from '@chat-app/shared';
@@ -24,14 +25,26 @@ function SummarySection({ promise }: { promise: Promise<SummaryData> }) {
   return <SummaryCards data={data} />;
 }
 
-function RemindersSection({ promise }: { promise: Promise<{ reminders: Reminder[] }> }) {
+function RemindersSection({
+  promise,
+  onComplete,
+}: {
+  promise: Promise<{ reminders: Reminder[] }>;
+  onComplete?: (id: number) => void;
+}) {
   const { reminders } = use(promise);
-  return <RemindersList reminders={reminders} />;
+  return <RemindersList reminders={reminders} onComplete={onComplete} />;
 }
 
-function DraftsSection({ promise }: { promise: Promise<{ drafts: Draft[] }> }) {
+function DraftsSection({
+  promise,
+  onResume,
+}: {
+  promise: Promise<{ drafts: Draft[] }>;
+  onResume?: (target: DraftResumeTarget) => void;
+}) {
   const { drafts } = use(promise);
-  return <DraftsList drafts={drafts} />;
+  return <DraftsList drafts={drafts} onResume={onResume} />;
 }
 
 function MentionsSection({ promise }: { promise: Promise<{ messages: MessageSearchResult[] }> }) {
@@ -118,9 +131,12 @@ export default function InboxPage() {
     () => (tab === 'threads' ? api.threads.listSubscribed() : null),
     [tab],
   );
+  // Step 6d: 「完了」ボタン押下後に再フェッチするためのキー。インクリメントで promise 再生成。
+  const [remindersKey, setRemindersKey] = useState(0);
   const remindersPromise = useMemo(
     () => (tab === 'reminders' || tab === 'all' ? api.reminders.list() : null),
-    [tab],
+    // remindersKey も deps に含めて再フェッチをトリガー
+    [tab, remindersKey],
   );
   const draftsPromise = useMemo(
     () => (tab === 'drafts' || tab === 'all' ? api.drafts.getAll() : null),
@@ -132,6 +148,23 @@ export default function InboxPage() {
 
   const handleTabChange = (_: React.SyntheticEvent, newTab: TabKey) => {
     setSearchParams({ tab: newTab });
+  };
+
+  // Step 6d: クイックアクション
+  const handleReminderComplete = async (id: number) => {
+    try {
+      await api.reminders.delete(id);
+      setRemindersKey((k) => k + 1);
+    } catch {
+      // 失敗時は state を変えない（次回タブ切替で再取得される）
+    }
+  };
+  const handleDraftResume = (target: DraftResumeTarget) => {
+    if (target.kind === 'channel') {
+      navigate(`/chat?channel=${target.channelId}`);
+    } else {
+      navigate(`/dm?conversation=${target.dmConversationId}`);
+    }
   };
 
   return (
@@ -194,7 +227,7 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <RemindersSection promise={remindersPromise} />
+              <RemindersSection promise={remindersPromise} onComplete={handleReminderComplete} />
             </Suspense>
           )}
           {tab === 'drafts' && draftsPromise && (
@@ -205,7 +238,7 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <DraftsSection promise={draftsPromise} />
+              <DraftsSection promise={draftsPromise} onResume={handleDraftResume} />
             </Suspense>
           )}
           {tab === 'all' && mentionsPromise && remindersPromise && draftsPromise && (


### PR DESCRIPTION
## 概要

Inbox 系仕上げ Step。Rail のメンション数バッジ追加 / ChannelList のバッジ色調整 / Inbox リマインダー・下書きタブにクイックアクションを追加。保留 TODO #5（Rail メンションバッジ）と #7（ChannelList 未読バッジ色分け）を解消する。

## 変更内容

### 新規
- `packages/client/src/hooks/useMentionUnreadCount.ts` — Step 6b の `api.messages.search('', { mentionedToMe: true, unreadOnly: true })` を再利用してメンション未読数を集計するフック。`useDmUnreadCount` と同じパターンで実装
- `packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx` — 4 件
- ホームパス `/` のときは 0 を返す（自分が見ている画面に冗長表示しないため）

### Rail メンションバッジ（保留 TODO #5 解消）
- `Rail.tsx` でホームアイコンに `useMentionUnreadCount` を渡してバッジ表示。`max=9`、aria-label に未読数情報を含める

### ChannelList バッジ色調整（保留 TODO #7 解消）
- `ChannelItem.tsx` のメンション数バッジ → `var(--accent)` / `var(--accent-fg)`
- 通常未読数バッジ → `var(--text-muted)` / `var(--bg)`
- MUI の標準 `color=\"error\"` / `color=\"primary\"` をやめ、CSS 変数で統一

### Inbox クイックアクション
- `RemindersList.tsx` に **「完了」ボタン** + `onComplete` props
- `DraftsList.tsx` に **「再開」ボタン** + `onResume` props（チャンネル / DM の対象を判別して通知）
- `InboxPage.tsx`:
  - リマインダー完了: `api.reminders.delete(id)` + `remindersKey` インクリメントで再フェッチ
  - 下書き再開: チャンネルなら `/chat?channel=X`、DM なら `/dm?conversation=Y` に navigate
  - `DraftResumeTarget` 型を `DraftsList.tsx` から re-export して受け取り

### スコープ外（後続 Step）
- メンション/スレッドタブのクイックアクション（メンション既読化 API / スレッド既読化 API の新設が必要）
- スレッド `unreadCount` の本実装（thread_reads テーブル新設が必要）

## 影響範囲
- フロントのみ。サーバー / DB 変更なし
- AppLayout 経由で `useMentionUnreadCount` が動くため、`TaskBoardPage.test.tsx` の api モックに `messages.search` を追加（既存テスト 1 件改修）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1392 件 + 5 skip）
- [x] バックエンドユニットテストがすべてパスする（1373 件、追加なし）
- [x] ビルドが正常に完了すること
- [ ] (手動確認) Rail のホームアイコンにメンション未読数バッジが表示されること、リマインダー「完了」/ 下書き「再開」が動作すること

## 関連Issue
Fixes #N/A (UI/UX ブラッシュアップ Step 6d、保留 TODO #5 / #7 解消)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（PROGRESS.md）の更新はマージ後に実施
- [x] `it.todo` / 空ボディの `it` が残っていない

## 既存テストの変更
| ファイル | 変更箇所 | 理由 |
|---|---|---|
| `packages/client/src/__tests__/TaskBoardPage.test.tsx` | api モックに `messages.search` を追加 | 仕様変更（Rail に `useMentionUnreadCount` が組み込まれ、AppLayout 経由のページからも `api.messages.search` が呼ばれるようになった依存追加への追従） |

## 実装メモ
- 「画面で見えるだけ」のバッジ色のテストは追加していない（CSS 変数 `var(--accent)` は jsdom で `toHaveStyle` 検証できないため。過去のハマりどころに準拠）
- リマインダー完了後の再フェッチは `useState<number>` のキー更新でシンプルに実装。Suspense 互換のため `useMemo` の deps に key を追加する形