### PR TITLE
fix(inbox): メッセージ本文の生 JSON 表示を修正 + extractMessageText util 共通化

### DIFF
--- a/packages/client/src/components/Chat/SearchResults.tsx
+++ b/packages/client/src/components/Chat/SearchResults.tsx
@@ -3,24 +3,11 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type { MessageSearchResult } from '@chat-app/shared';
 import TagChip from './TagChip';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   results: MessageSearchResult[];
   onNavigate: (channelId: number, messageId: number) => void;
-}
-
-function extractText(content: string): string {
-  try {
-    const delta = JSON.parse(content) as { ops?: { insert?: unknown }[] };
-    return (
-      delta.ops
-        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-        .join('')
-        .trim() ?? content
-    );
-  } catch {
-    return content;
-  }
 }
 
 function formatDate(iso: string): string {
@@ -89,11 +76,11 @@ export default function SearchResults({ results, onNavigate }: Props) {
                   wordBreak: 'break-word',
                 }}
               >
-                {extractText(result.rootMessageContent)}
+                {extractMessageText(result.rootMessageContent)}
               </Typography>
             )}
             <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-              {extractText(result.content)}
+              {extractMessageText(result.content)}
             </Typography>
             {result.tags && result.tags.length > 0 && (
               <Box

--- a/packages/client/src/components/Chat/ThreadPanel.tsx
+++ b/packages/client/src/components/Chat/ThreadPanel.tsx
@@ -6,6 +6,7 @@ import type { Message, User } from '@chat-app/shared';
 import { useSocket } from '../../contexts/SocketContext';
 import RichEditor from './RichEditor';
 import { getAvatarColor } from '../../utils/avatarColor';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 const THREAD_PANEL_WIDTH = 360;
 const MAX_INDENT_DEPTH = 2;
@@ -21,24 +22,6 @@ interface Props {
 
 function formatTime(dateStr: string): string {
   return new Date(dateStr).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-}
-
-interface DeltaOp {
-  insert?: string | { mention?: { value: string } };
-}
-
-function extractText(content: string): string {
-  try {
-    const delta = JSON.parse(content) as { ops?: DeltaOp[] };
-    return (
-      delta.ops
-        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-        .join('')
-        .trim() ?? content
-    );
-  } catch {
-    return content;
-  }
 }
 
 interface ReplyItemProps {
@@ -88,7 +71,7 @@ function ReplyItem({ message, depth, users, onReply }: ReplyItemProps) {
           </Typography>
         </Box>
         <Typography variant="body2" sx={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
-          {extractText(message.content)}
+          {extractMessageText(message.content)}
         </Typography>
       </Box>
       <Tooltip title="返信">
@@ -209,7 +192,7 @@ export default function ThreadPanel({
               </Typography>
             </Box>
             <Typography variant="body2" sx={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
-              {extractText(rootMessage.content)}
+              {extractMessageText(rootMessage.content)}
             </Typography>
           </Box>
         </Box>

--- a/packages/client/src/components/Inbox/DraftsList.tsx
+++ b/packages/client/src/components/Inbox/DraftsList.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import type { Draft } from '@chat-app/shared';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 /** Step 6d: 「再開」アクションの宛先種別 */
 export type DraftResumeTarget =
@@ -13,20 +14,6 @@ interface Props {
    * チャンネル下書き / DM 下書きのいずれかを判別して通知する。
    */
   onResume?: (target: DraftResumeTarget) => void;
-}
-
-function parseMessageContent(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
-    return (
-      parsed.ops
-        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-        .join('')
-        .trim() ?? raw
-    );
-  } catch {
-    return raw;
-  }
 }
 
 function formatDateTime(iso: string): string {
@@ -76,7 +63,7 @@ export default function DraftsList({ drafts, onResume }: Props) {
               <Typography variant="caption" color="text.secondary">
                 📝 {formatDateTime(d.updatedAt)}
               </Typography>
-              <Typography variant="body2">{parseMessageContent(d.content)}</Typography>
+              <Typography variant="body2">{extractMessageText(d.content)}</Typography>
             </CardContent>
             {target && (
               <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>

--- a/packages/client/src/components/Inbox/MentionsList.tsx
+++ b/packages/client/src/components/Inbox/MentionsList.tsx
@@ -1,22 +1,9 @@
 import { Box, Card, CardContent, Typography } from '@mui/material';
 import type { MessageSearchResult } from '@chat-app/shared';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   messages: MessageSearchResult[];
-}
-
-function parseMessageContent(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
-    return (
-      parsed.ops
-        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-        .join('')
-        .trim() ?? raw
-    );
-  } catch {
-    return raw;
-  }
 }
 
 function formatDateTime(iso: string): string {
@@ -53,7 +40,7 @@ export default function MentionsList({ messages }: Props) {
             <Typography variant="caption" color="text.secondary">
               📨 #{m.channelName} · {m.username} · {formatDateTime(m.createdAt)}
             </Typography>
-            <Typography variant="body2">{parseMessageContent(m.content)}</Typography>
+            <Typography variant="body2">{extractMessageText(m.content)}</Typography>
           </CardContent>
         </Card>
       ))}

--- a/packages/client/src/components/Inbox/RemindersList.tsx
+++ b/packages/client/src/components/Inbox/RemindersList.tsx
@@ -1,24 +1,11 @@
 import { Box, Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import type { Reminder } from '@chat-app/shared';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   reminders: Reminder[];
   /** Step 6d: 「完了」ボタンが押されたとき、対象リマインダー id で呼ばれる */
   onComplete?: (id: number) => void;
-}
-
-function parseMessageContent(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
-    return (
-      parsed.ops
-        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-        .join('')
-        .trim() ?? raw
-    );
-  } catch {
-    return raw;
-  }
 }
 
 function formatDateTime(iso: string): string {
@@ -56,7 +43,7 @@ export default function RemindersList({ reminders, onComplete }: Props) {
               ⏰ {formatDateTime(r.remindAt)}
             </Typography>
             <Typography variant="body2">
-              {r.message ? parseMessageContent(r.message.content) : '(メッセージが見つかりません)'}
+              {r.message ? extractMessageText(r.message.content) : '(メッセージが見つかりません)'}
             </Typography>
           </CardContent>
           <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>

--- a/packages/client/src/components/Inbox/ThreadsList.tsx
+++ b/packages/client/src/components/Inbox/ThreadsList.tsx
@@ -1,22 +1,9 @@
 import { Box, Card, CardContent, Typography } from '@mui/material';
 import type { ThreadSummary } from '@chat-app/shared';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   threads: ThreadSummary[];
-}
-
-function parseMessageContent(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw) as { ops?: { insert?: string | object }[] };
-    return (
-      parsed.ops
-        ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-        .join('')
-        .trim() ?? raw
-    );
-  } catch {
-    return raw;
-  }
 }
 
 function formatDateTime(iso: string): string {
@@ -53,7 +40,7 @@ export default function ThreadsList({ threads }: Props) {
               🧵 #{t.channelName} · {t.rootMessage.username} · 返信 {t.replyCount} 件 ·{' '}
               {formatDateTime(t.lastReplyAt)}
             </Typography>
-            <Typography variant="body2">{parseMessageContent(t.rootMessage.content)}</Typography>
+            <Typography variant="body2">{extractMessageText(t.rootMessage.content)}</Typography>
           </CardContent>
         </Card>
       ))}

--- a/packages/client/src/utils/__tests__/extractMessageText.test.ts
+++ b/packages/client/src/utils/__tests__/extractMessageText.test.ts
@@ -1,0 +1,105 @@
+/**
+ * テスト対象: utils/extractMessageText.ts
+ *
+ * Inbox / Thread / Search で使うメッセージ本文のテキスト抽出関数。
+ * Quill Delta JSON / TipTap JSON / プレーンテキストの 3 形式を判別して
+ * 純粋テキストを返す。判別不能なときは空文字を返す（生 JSON を透けさせない）。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractMessageText } from '../extractMessageText';
+
+describe('extractMessageText', () => {
+  describe('Quill Delta 形式', () => {
+    it('{ ops: [{ insert: "hello" }] } から "hello" を返す', () => {
+      const raw = JSON.stringify({ ops: [{ insert: 'hello' }] });
+      expect(extractMessageText(raw)).toBe('hello');
+    });
+
+    it('複数の insert を結合して返す', () => {
+      const raw = JSON.stringify({
+        ops: [{ insert: 'foo ' }, { insert: 'bar' }, { insert: ' baz' }],
+      });
+      expect(extractMessageText(raw)).toBe('foo bar baz');
+    });
+
+    it('object insert (mention / image 等) は無視して文字列 insert のみ抽出する', () => {
+      const raw = JSON.stringify({
+        ops: [
+          { insert: 'こんにちは ' },
+          { insert: { mention: { value: 'alice' } } },
+          { insert: ' さん' },
+        ],
+      });
+      expect(extractMessageText(raw)).toBe('こんにちは  さん');
+    });
+
+    it('末尾の連続改行を trim して返す', () => {
+      const raw = JSON.stringify({ ops: [{ insert: 'message\n\n\n' }] });
+      expect(extractMessageText(raw)).toBe('message');
+    });
+  });
+
+  describe('TipTap JSON 形式', () => {
+    it('{ type: "doc", content: [...] } を再帰的にたどって text を結合する', () => {
+      const raw = JSON.stringify({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'hello tiptap' }],
+          },
+        ],
+      });
+      expect(extractMessageText(raw)).toBe('hello tiptap');
+    });
+
+    it('複数の paragraph を改行ではなく単純結合（または空白挟み）で連結する', () => {
+      const raw = JSON.stringify({
+        type: 'doc',
+        content: [
+          { type: 'paragraph', content: [{ type: 'text', text: '一段目' }] },
+          { type: 'paragraph', content: [{ type: 'text', text: '二段目' }] },
+        ],
+      });
+      expect(extractMessageText(raw)).toBe('一段目二段目');
+    });
+
+    it('text プロパティを持たないノードは無視する', () => {
+      const raw = JSON.stringify({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              { type: 'text', text: 'before' },
+              { type: 'image', src: 'http://example.com/x.png' },
+              { type: 'text', text: 'after' },
+            ],
+          },
+        ],
+      });
+      expect(extractMessageText(raw)).toBe('beforeafter');
+    });
+  });
+
+  describe('プレーンテキスト / フォールバック', () => {
+    it('JSON でない文字列はそのまま返す（trim 済み）', () => {
+      expect(extractMessageText('  普通の文字列  ')).toBe('普通の文字列');
+    });
+
+    it('空文字列は空文字を返す', () => {
+      expect(extractMessageText('')).toBe('');
+    });
+
+    it('null / undefined は空文字を返す', () => {
+      expect(extractMessageText(null)).toBe('');
+      expect(extractMessageText(undefined)).toBe('');
+    });
+
+    it('構造不明な JSON ({ foo: "bar" } 等) は空文字を返す（生 JSON を透けさせない）', () => {
+      expect(extractMessageText(JSON.stringify({ foo: 'bar' }))).toBe('');
+      expect(extractMessageText(JSON.stringify([1, 2, 3]))).toBe('');
+    });
+  });
+});

--- a/packages/client/src/utils/extractMessageText.ts
+++ b/packages/client/src/utils/extractMessageText.ts
@@ -1,0 +1,69 @@
+/**
+ * メッセージ本文 (Message.content) からプレーンテキストを抽出する。
+ *
+ * 想定フォーマット:
+ *   1. Quill Delta JSON  — RichEditor が `JSON.stringify(quill.getContents())` で保存する形式。
+ *      `{ ops: [{ insert: "..." | { mention: { value: "..." } } }, ...] }`
+ *   2. TipTap JSON       — 旧データ・将来の互換用。`{ type: "doc", content: [{ type, text, content }, ...] }`
+ *   3. プレーンテキスト   — JSON で parse できない場合（古いデータや単純な文字列）。
+ *
+ * 重要な振る舞い:
+ *   - 判別不能な JSON（構造不明 / 想定外フォーマット）のときは **空文字を返す**。
+ *     これにより、生 JSON 文字列が UI に透けて表示される事故を防ぐ。
+ *   - null / undefined / 空文字は空文字を返す。
+ */
+
+interface QuillDelta {
+  ops?: Array<{ insert?: unknown }>;
+}
+
+interface TipTapNode {
+  type?: string;
+  text?: string;
+  content?: TipTapNode[];
+}
+
+function isQuillDelta(value: unknown): value is QuillDelta {
+  return typeof value === 'object' && value !== null && Array.isArray((value as QuillDelta).ops);
+}
+
+function isTipTapDoc(value: unknown): value is TipTapNode {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as TipTapNode;
+  return v.type === 'doc' && Array.isArray(v.content);
+}
+
+function extractFromQuill(delta: QuillDelta): string {
+  return (
+    delta.ops
+      ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
+      .join('')
+      .replace(/\n+$/, '') ?? ''
+  );
+}
+
+function extractFromTipTap(node: TipTapNode): string {
+  if (typeof node.text === 'string') return node.text;
+  if (Array.isArray(node.content)) {
+    return node.content.map(extractFromTipTap).join('');
+  }
+  return '';
+}
+
+export function extractMessageText(raw: string | null | undefined): string {
+  if (!raw) return '';
+  const trimmed = raw.trim();
+  if (trimmed === '') return '';
+
+  // JSON parse に成功した場合のみフォーマット判別を試みる
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (isQuillDelta(parsed)) return extractFromQuill(parsed);
+    if (isTipTapDoc(parsed)) return extractFromTipTap(parsed).trim();
+    // 構造不明な JSON は空文字 (生 JSON を表示しない)
+    return '';
+  } catch {
+    // JSON でない場合はプレーンテキストとしてそのまま返す
+    return trimmed;
+  }
+}

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -31,7 +31,12 @@ export interface Message {
   userId: number | null;
   username: string;
   avatarUrl: string | null;
-  content: string; // TipTap JSON string
+  /**
+   * Quill Delta JSON string (RichEditor が JSON.stringify(quill.getContents()) で保存する形式)。
+   * 旧データ互換のため TipTap JSON / プレーンテキストが混在する場合は
+   * `utils/extractMessageText.ts` で吸収する。
+   */
+  content: string;
   isEdited: boolean;
   isDeleted: boolean;
   createdAt: string;


### PR DESCRIPTION
## 概要

Inbox の **メンション / すべて** タブで、メッセージ本文が `{\"ops\":[{\"insert\":\"...\"}]}` のような JSON 文字列のまま表示される事象を修正する。同時に Inbox / ThreadPanel / SearchResults で重複していた 6 箇所の独自パース関数を `utils/extractMessageText.ts` に集約する。

## 変更内容

### 原因
Inbox 4 コンポーネント (`MentionsList` / `ThreadsList` / `RemindersList` / `DraftsList`) と `ThreadPanel.tsx` / `SearchResults.tsx` の合計 6 箇所で、それぞれが独自の `parseMessageContent` / `extractText` を持っており、いずれも以下のフォールバックロジックがあった：

\`\`\`ts
return parsed.ops?.map(...).join('').trim() ?? raw;  // ← parsed.ops が無いと raw を返す
\`\`\`

`parsed.ops` が `undefined` のとき（TipTap JSON や非標準フォーマット）に **生 JSON 文字列が UI に透ける** バグだった。

### 修正
- 新規: `packages/client/src/utils/extractMessageText.ts`
  - Quill Delta JSON / TipTap JSON / プレーンテキストの 3 形式を判別
  - 構造不明な JSON は **空文字を返す**（生 JSON を絶対に表示しない）
  - 末尾改行 trim、object insert (mention/image) は無視
- 新規: `packages/client/src/utils/__tests__/extractMessageText.test.ts` — 11 件
- 修正: 上記 6 ファイルの重複ロジックを撤去 → `extractMessageText` に集約
- 修正: `packages/shared/src/types/message.ts` の `Message.content` コメントを「TipTap JSON string」→「Quill Delta JSON string ...」に訂正

### 共通化対象ファイル
| ファイル | Before | After |
|---|---|---|
| `MentionsList.tsx` | 独自 `parseMessageContent` | `extractMessageText` |
| `ThreadsList.tsx` | 独自 `parseMessageContent` | `extractMessageText` |
| `RemindersList.tsx` | 独自 `parseMessageContent` | `extractMessageText` |
| `DraftsList.tsx` | 独自 `parseMessageContent` | `extractMessageText` |
| `ThreadPanel.tsx` | 独自 `extractText` | `extractMessageText` |
| `SearchResults.tsx` | 独自 `extractText` | `extractMessageText` |

## 影響範囲
- フロントのみ。サーバー / DB 変更なし
- 表示テキストの仕様: 構造不明な JSON は **空文字** 表示に変わる（従来は生 JSON が透けていた）。Inbox / 検索結果 / スレッドペインの全エリアに影響

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1403 件 + 5 skip）
- [x] バックエンドユニットテストがすべてパスする（1373 件、追加なし）
- [x] ビルドが正常に完了すること
- [ ] (手動確認) Inbox のメンション/すべて タブで JSON 文字列が表示されないこと

## 関連Issue
Fixes #N/A (運用中に発覚した表示バグの修正)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (shared types のコメント) を実装と整合する形に修正した
- [x] `it.todo` / 空ボディの `it` が残っていない

## 既存テストの変更
変更なし。