### PR TITLE
feat(search): 検索ページ新設 + Rail アイコン有効化 + ChatPage dead code 撤去 (Step 7a)

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -26,6 +26,7 @@ import InviteRedeemPage from './pages/InviteRedeemPage';
 import GuestChannelPage from './pages/GuestChannelPage';
 import TaskBoardPage from './pages/TaskBoardPage';
 import CalendarPage from './pages/CalendarPage';
+import SearchPage from './pages/SearchPage';
 import { api, setRateLimitErrorHandler } from './api/client';
 import { useSnackbar } from './contexts/SnackbarContext';
 import type { User } from '@chat-app/shared';
@@ -217,6 +218,16 @@ function AppRoutes() {
           element={
             <RequireAuth>
               <CalendarPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/search"
+          element={
+            <RequireAuth>
+              <SocketProvider>
+                <SearchPage />
+              </SocketProvider>
             </RequireAuth>
           }
         />

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -13,7 +13,7 @@
  *   - SearchFilterPanel スタブは onFilterChange を露出してフィルター変更をシミュレートする
  */
 
-import { render, waitFor, act, screen, fireEvent } from '@testing-library/react';
+import { render, waitFor, act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ChatPage from '../pages/ChatPage';
@@ -28,7 +28,7 @@ vi.mock('../components/Channel/ChannelList', () => ({ default: MockChannelList }
 // SidebarDmList 自体の挙動は SidebarDmList.test.tsx で検証する。
 vi.mock('../components/Layout/SidebarDmList', () => ({ default: () => null }));
 
-// AppLayout スタブ — searchQuery/onSearchChange/onSearchFocus に加え rightPane (Step 5a) も露出する
+// AppLayout スタブ — Step 7a で検索 props は撤去されたため sidebar / children / rightPane のみ
 vi.mock('../components/Layout/AppLayout', async () => {
   const React = (await import('react')) as typeof import('react');
   return {
@@ -36,33 +36,11 @@ vi.mock('../components/Layout/AppLayout', async () => {
       sidebar,
       children,
       rightPane,
-      searchQuery,
-      onSearchChange,
-      onSearchFocus,
-      onSearchBlur,
     }: {
       sidebar: React.ReactNode;
       children: React.ReactNode;
       rightPane?: React.ReactNode;
-      searchQuery?: string;
-      onSearchChange?: (q: string) => void;
-      onSearchFocus?: () => void;
-      onSearchBlur?: () => void;
-    }) =>
-      React.createElement(
-        React.Fragment,
-        null,
-        sidebar,
-        React.createElement('input', {
-          'data-testid': 'mock-search-input',
-          value: searchQuery ?? '',
-          onChange: (e: React.ChangeEvent<HTMLInputElement>) => onSearchChange?.(e.target.value),
-          onFocus: () => onSearchFocus?.(),
-          onBlur: () => onSearchBlur?.(),
-        }),
-        children,
-        rightPane,
-      ),
+    }) => React.createElement(React.Fragment, null, sidebar, children, rightPane),
   };
 });
 
@@ -76,20 +54,7 @@ vi.mock('../components/Chat/MessageList', () => ({ default: () => null }));
 const MockRichEditor = vi.hoisted(() => vi.fn(() => null));
 vi.mock('../components/Chat/RichEditor', () => ({ default: MockRichEditor }));
 
-// SearchFilterPanel スタブ: onFilterChange を呼び出せるボタンを公開
-vi.mock('../components/Chat/SearchFilterPanel', () => ({
-  default: ({ onFilterChange }: { onFilterChange: (filters: { tagIds?: number[] }) => void }) => (
-    <div data-testid="mock-search-filter-panel">
-      <button data-testid="set-tag-filter" onClick={() => onFilterChange({ tagIds: [42] })}>
-        set-tag-filter
-      </button>
-      <button data-testid="clear-tag-filter" onClick={() => onFilterChange({})}>
-        clear-filter
-      </button>
-    </div>
-  ),
-}));
-vi.mock('../components/Chat/SearchResults', () => ({ default: () => null }));
+// Step 7a: 検索 UI は SearchPage に分離したため SearchFilterPanel / SearchResults のスタブは不要
 vi.mock('../components/Chat/ThreadPanel', () => ({ default: () => null }));
 vi.mock('../components/Channel/ChannelTopicBar', () => ({ default: () => null }));
 // Step 5b: PinnedMessages の Main 上部バー撤去確認のため呼び出しを track できるよう vi.fn にする
@@ -212,103 +177,9 @@ describe('ChatPage', () => {
     });
   });
 
-  // #115 — クエリ無しでもフィルター指定で検索が走るようにする
-  // Step 2b で AppLayout から検索 box を撤去したため、これらのテストは一時的に skip。
-  // 復活予定: Step 7 (検索ページ新設) — PROGRESS.md 保留 TODO #2 を参照。
-  describe.skip('検索モードの切り替え (#115) [Step 2b で skip / Step 7 で復活]', () => {
-    it('検索クエリが空でもフィルター（tagIds など）が指定されれば検索 API が呼ばれる', async () => {
-      render(<ChatPage users={[]} />);
+  // Step 7a: 検索 UI は SearchPage に分離。検索系テストは SearchPage.test.tsx に移譲。
 
-      // 検索ボックスにフォーカス → 検索モード ON、フィルターパネルが現れる
-      const searchInput = screen.getByTestId('mock-search-input');
-      await act(async () => {
-        fireEvent.focus(searchInput);
-      });
-
-      // フィルターパネルが表示されることを確認
-      const setTagBtn = await screen.findByTestId('set-tag-filter');
-      await userEvent.click(setTagBtn);
-
-      // debounce 300ms を待ってから search が呼ばれる
-      await waitFor(
-        () => {
-          expect(mockSearch).toHaveBeenCalled();
-        },
-        { timeout: 1000 },
-      );
-
-      // q='' で tagIds=[42] が渡される
-      const lastCall = mockSearch.mock.calls[mockSearch.mock.calls.length - 1];
-      expect(lastCall[0]).toBe('');
-      expect(lastCall[1]).toEqual(expect.objectContaining({ tagIds: [42] }));
-    });
-
-    it('検索クエリ・フィルター共に空のときは検索 API は呼ばれない', async () => {
-      render(<ChatPage users={[]} />);
-
-      // 何もせずに 400ms 待っても呼ばれないこと
-      await new Promise((r) => setTimeout(r, 400));
-      expect(mockSearch).not.toHaveBeenCalled();
-    });
-
-    it('検索クエリが空でも検索ボックスにフォーカスすると検索モードに入りフィルターパネルが表示される', async () => {
-      render(<ChatPage users={[]} />);
-
-      // フォーカス前: フィルターパネルは表示されない
-      expect(screen.queryByTestId('mock-search-filter-panel')).toBeNull();
-
-      const searchInput = screen.getByTestId('mock-search-input');
-      await act(async () => {
-        fireEvent.focus(searchInput);
-      });
-
-      // フォーカス後: フィルターパネルが表示される
-      expect(screen.getByTestId('mock-search-filter-panel')).toBeInTheDocument();
-    });
-
-    // バグ1: 検索ボックスから blur してもパネルが消えないこと
-    it('検索ボックスから blur してもフィルターパネルは表示されたまま維持される', async () => {
-      render(<ChatPage users={[]} />);
-
-      const searchInput = screen.getByTestId('mock-search-input');
-      await act(async () => {
-        fireEvent.focus(searchInput);
-      });
-      expect(screen.getByTestId('mock-search-filter-panel')).toBeInTheDocument();
-
-      // タグ Autocomplete などにクリックすることをシミュレート: blur が発火する
-      await act(async () => {
-        fireEvent.blur(searchInput);
-      });
-
-      // blur 後もフィルターパネルが残ること
-      expect(screen.getByTestId('mock-search-filter-panel')).toBeInTheDocument();
-    });
-
-    it('チャンネル切り替えで検索モードが解除されフィルターパネルが閉じる', async () => {
-      render(<ChatPage users={[]} />);
-
-      const searchInput = screen.getByTestId('mock-search-input');
-      await act(async () => {
-        fireEvent.focus(searchInput);
-      });
-      expect(screen.getByTestId('mock-search-filter-panel')).toBeInTheDocument();
-
-      // ChannelList の onSelect を呼び出してチャンネル切替をシミュレート
-      const calls = MockChannelList.mock.calls as unknown as Array<
-        [{ onSelect: (id: number, name: string) => void }]
-      >;
-      const props = calls[calls.length - 1][0];
-      await act(async () => {
-        props.onSelect(99, 'random');
-      });
-
-      // 検索モード解除でパネルが消える
-      expect(screen.queryByTestId('mock-search-filter-panel')).toBeNull();
-    });
-  });
-
-  // #113 投稿権限制御チャンネル — RichEditor の disabled 計算
+  // #113 投稿権限制御チャンネル — RichEditor の disaled 計算
   describe('投稿権限による RichEditor 無効化 (#113)', () => {
     /**
      * activeChannel を任意の postingPermission で設定するヘルパー

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -55,13 +55,14 @@ function renderRail(initialPath = '/', role: 'user' | 'admin' = 'user') {
 
 describe('Rail', () => {
   describe('ナビゲーション項目の表示', () => {
-    it('上部にホーム / DM / カレンダー / タスク / ブックマークの 5 つのアイコンが表示される', () => {
+    it('上部にホーム / DM / カレンダー / タスク / ブックマーク / 検索の 6 つのアイコンが表示される', () => {
       renderRail();
       expect(screen.getByRole('link', { name: 'ホーム' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'DM' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'カレンダー' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'タスク' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'ブックマーク' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: '検索' })).toBeInTheDocument();
     });
 
     it('区切り線の下にテンプレートのアイコンが表示される', () => {
@@ -123,7 +124,7 @@ describe('Rail', () => {
     });
   });
 
-  describe('ロゴと検索アイコン (Step 2b で追加)', () => {
+  describe('ロゴと検索アイコン (Step 2b で追加 / Step 7a で有効化)', () => {
     it('最上部に Chat App ロゴ要素が表示される', () => {
       renderRail();
       expect(screen.getByRole('img', { name: 'Chat App ロゴ' })).toBeInTheDocument();
@@ -131,13 +132,12 @@ describe('Rail', () => {
 
     it('上部ナビに検索アイコン (aria-label="検索") が表示される', () => {
       renderRail();
-      expect(screen.getByRole('button', { name: '検索' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: '検索' })).toBeInTheDocument();
     });
 
-    it('検索アイコンは無効状態である (Step 7 で有効化予定)', () => {
+    it('検索アイコンは /search にリンクする (Step 7a で disabled 解除)', () => {
       renderRail();
-      const searchButton = screen.getByRole('button', { name: '検索' });
-      expect(searchButton).toBeDisabled();
+      expect(screen.getByRole('link', { name: '検索' })).toHaveAttribute('href', '/search');
     });
   });
 

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * pages/SearchPage.tsx のユニットテスト (Step 7a)
+ *
+ * テスト対象:
+ *   - 検索ページの描画 (検索クエリ入力 / SearchFilterPanel / SearchResults)
+ *   - クエリ入力の debounce 後に api.messages.search が呼ばれる
+ *   - 結果クリックで /chat?channel=X#message-Y に navigate する
+ *   - 「保存」ボタン押下で api.savedViews.create が呼ばれる
+ *
+ * 戦略:
+ *   - SearchFilterPanel / SearchResults は最小スタブ
+ *   - api.messages.search / api.savedViews.create を vi.hoisted で操作
+ *   - react-router-dom は importActual + MemoryRouter で初期 URL を制御
+ */
+
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import SearchPage from '../pages/SearchPage';
+
+// AppLayout は最小スタブ
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
+
+// ChannelList / SidebarDmList も最小スタブ（api 依存を避ける）
+vi.mock('../components/Channel/ChannelList', () => ({ default: () => null }));
+vi.mock('../components/Layout/SidebarDmList', () => ({ default: () => null }));
+
+// SearchFilterPanel スタブ: onFilterChange / onSaveView を呼び出せるボタンを公開
+vi.mock('../components/Chat/SearchFilterPanel', () => ({
+  default: ({
+    onFilterChange,
+    onSaveView,
+  }: {
+    onFilterChange: (filters: { tagIds?: number[] }) => void;
+    onSaveView?: (params: { name: string; filters: { tagIds?: number[] } }) => void;
+  }) => (
+    <div data-testid="mock-search-filter-panel">
+      <button data-testid="set-tag-filter" onClick={() => onFilterChange({ tagIds: [42] })}>
+        set-tag-filter
+      </button>
+      <button
+        data-testid="save-view-btn"
+        onClick={() => onSaveView?.({ name: 'view1', filters: { tagIds: [42] } })}
+      >
+        save-view
+      </button>
+    </div>
+  ),
+}));
+
+// SearchResults スタブ: onNavigate を呼び出せるボタンを公開
+vi.mock('../components/Chat/SearchResults', () => ({
+  default: ({ onNavigate }: { onNavigate: (channelId: number, messageId: number) => void }) => (
+    <div data-testid="mock-search-results">
+      <button data-testid="navigate-btn" onClick={() => onNavigate(7, 42)}>
+        navigate
+      </button>
+    </div>
+  ),
+}));
+
+// Snackbar
+const mockSnackbar = vi.hoisted(() => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  showInfo: vi.fn(),
+}));
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => mockSnackbar,
+}));
+
+// API モック
+const mockSearch = vi.hoisted(() => vi.fn());
+const mockSavedViewsCreate = vi.hoisted(() => vi.fn());
+vi.mock('../api/client', () => ({
+  api: {
+    messages: { search: (...args: unknown[]) => mockSearch(...args) },
+    savedViews: { create: (...args: unknown[]) => mockSavedViewsCreate(...args) },
+  },
+}));
+
+// useNavigate は importActual + spy で記録
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+beforeEach(() => {
+  mockSearch.mockReset();
+  mockSearch.mockResolvedValue({ messages: [] });
+  mockSavedViewsCreate.mockReset();
+  mockSavedViewsCreate.mockResolvedValue({ savedView: { id: 1, name: 'view1' } });
+  mockNavigate.mockReset();
+  mockSnackbar.showSuccess.mockReset();
+  mockSnackbar.showError.mockReset();
+});
+
+function renderSearch() {
+  return render(
+    <MemoryRouter initialEntries={['/search']}>
+      <SearchPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('SearchPage (Step 7a)', () => {
+  describe('描画', () => {
+    it('検索クエリ入力欄が表示される', () => {
+      renderSearch();
+      expect(screen.getByLabelText('メッセージ検索')).toBeInTheDocument();
+    });
+
+    it('SearchFilterPanel が表示される', () => {
+      renderSearch();
+      expect(screen.getByTestId('mock-search-filter-panel')).toBeInTheDocument();
+    });
+
+    it('SearchResults が表示される', () => {
+      renderSearch();
+      expect(screen.getByTestId('mock-search-results')).toBeInTheDocument();
+    });
+  });
+
+  describe('検索動作', () => {
+    it('クエリ入力後 debounce で api.messages.search が呼ばれる', async () => {
+      renderSearch();
+      const input = screen.getByLabelText('メッセージ検索');
+      await userEvent.type(input, 'hello');
+      await waitFor(
+        () => {
+          expect(mockSearch).toHaveBeenCalled();
+        },
+        { timeout: 1000 },
+      );
+      const lastCall = mockSearch.mock.calls[mockSearch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe('hello');
+    });
+
+    it('クエリ・フィルタ共に空のときは api.messages.search は呼ばれない', async () => {
+      renderSearch();
+      // debounce 期間 (300ms) より長く待っても呼ばれないこと
+      await new Promise((r) => setTimeout(r, 400));
+      expect(mockSearch).not.toHaveBeenCalled();
+    });
+
+    it('SearchFilterPanel から onFilterChange が呼ばれた後、フィルタ込みで search が呼ばれる', async () => {
+      renderSearch();
+      await act(async () => {
+        await userEvent.click(screen.getByTestId('set-tag-filter'));
+      });
+      await waitFor(
+        () => {
+          expect(mockSearch).toHaveBeenCalled();
+        },
+        { timeout: 1000 },
+      );
+      const lastCall = mockSearch.mock.calls[mockSearch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe('');
+      expect(lastCall[1]).toEqual(expect.objectContaining({ tagIds: [42] }));
+    });
+  });
+
+  describe('ナビゲーション', () => {
+    it('SearchResults の onNavigate が発火すると /chat?channel=X#message-Y へ遷移する', async () => {
+      renderSearch();
+      await userEvent.click(screen.getByTestId('navigate-btn'));
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7#message-42');
+    });
+  });
+
+  describe('保存ビュー作成', () => {
+    it('SearchFilterPanel の onSaveView が発火すると api.savedViews.create が呼ばれる', async () => {
+      renderSearch();
+      await userEvent.click(screen.getByTestId('save-view-btn'));
+      await waitFor(() => {
+        expect(mockSavedViewsCreate).toHaveBeenCalled();
+      });
+      const callArg = mockSavedViewsCreate.mock.calls[0][0];
+      expect(callArg.name).toBe('view1');
+      expect(callArg.query.tagIds).toEqual([42]);
+    });
+  });
+});

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Badge, Box, IconButton, Tooltip, Divider } from '@mui/material';
+import { Badge, Box, Tooltip, Divider } from '@mui/material';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
@@ -27,6 +27,8 @@ const TOP_ITEMS: NavItem[] = [
   { label: 'カレンダー', to: '/calendar', icon: <CalendarMonthOutlinedIcon /> },
   { label: 'タスク', to: '/tasks', icon: <AssignmentOutlinedIcon /> },
   { label: 'ブックマーク', to: '/bookmarks', icon: <BookmarkBorderOutlinedIcon /> },
+  // Step 7a: 検索ページに遷移するアイコン (保留 TODO #1 解消)
+  { label: '検索', to: '/search', icon: <SearchOutlinedIcon /> },
 ];
 
 const BOTTOM_ITEMS: NavItem[] = [
@@ -132,25 +134,6 @@ export default function Rail() {
           else if (item.to === '/') badgeCount = mentionUnreadCount;
           return <RailLink key={item.to} item={item} badgeCount={badgeCount} />;
         })}
-
-        {/* 検索アイコン (Step 2b で配置だけ追加、Step 7 で検索ページ新設時に有効化)
-            動線未完成として PROGRESS.md 保留 TODO #1 に登録済み */}
-        <Tooltip title="検索 (Step 7 で実装予定)" placement="right">
-          <span style={{ display: 'flex', justifyContent: 'center' }}>
-            <IconButton
-              aria-label="検索"
-              disabled
-              sx={{
-                width: 40,
-                height: 40,
-                my: 0.5,
-                borderRadius: 'var(--radius-md)',
-              }}
-            >
-              <SearchOutlinedIcon />
-            </IconButton>
-          </span>
-        </Tooltip>
       </Box>
       <Divider sx={{ width: 32, mx: 'auto', my: 1, borderColor: 'var(--border)' }} />
       <Box sx={{ display: 'flex', flexDirection: 'column' }}>

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -11,8 +11,6 @@ import ChannelTopicBar from '../components/Channel/ChannelTopicBar';
 import ContextRail from '../components/Channel/ContextRail';
 import MessageList from '../components/Chat/MessageList';
 import RichEditor, { type QuotedMessagePreview } from '../components/Chat/RichEditor';
-import SearchResults from '../components/Chat/SearchResults';
-import SearchFilterPanel, { type SearchFilters } from '../components/Chat/SearchFilterPanel';
 import ThreadPanel from '../components/Chat/ThreadPanel';
 import ScheduledMessagesDialog from '../components/Chat/ScheduledMessagesDialog';
 import CreateEventDialog from '../components/Chat/CreateEventDialog';
@@ -20,13 +18,7 @@ import { useMessages } from '../hooks/useMessages';
 import { useScheduledMessages } from '../hooks/useScheduledMessages';
 import { useSocket } from '../contexts/SocketContext';
 import { api } from '../api/client';
-import type {
-  User,
-  Message,
-  MessageSearchResult,
-  Channel,
-  RateLimitSocketError,
-} from '@chat-app/shared';
+import type { User, Message, Channel, RateLimitSocketError } from '@chat-app/shared';
 import ArchivedBanner from '../components/Channel/ArchivedBanner';
 import { useAuth } from '../contexts/AuthContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
@@ -64,15 +56,6 @@ export default function ChatPage({ users }: Props) {
   const [bookmarkedMessageIds, setBookmarkedMessageIds] = useState<Set<number>>(new Set());
   const { messages, loading, loadMore, refetch } = useMessages(activeChannelId);
   const socket = useSocket();
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchFilters, setSearchFilters] = useState<SearchFilters>({});
-  const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
-  const [searching, setSearching] = useState(false);
-  // 検索モードの「明示的な開始/終了」フラグ。
-  // - true にする: 検索ボックスへの focus（onSearchFocus）
-  // - false に戻す: チャンネル切替 / 検索結果からの遷移（handleNavigate）
-  // blur では false にしない（フィルターパネル内のクリックでパネルが消えるバグの回避）
-  const [searchActive, setSearchActive] = useState(false);
   const [threadRootId, setThreadRootId] = useState<number | null>(null);
   const [threadReplies, setThreadReplies] = useState<Message[]>([]);
   const [quotedMessage, setQuotedMessage] = useState<QuotedMessagePreview | undefined>(undefined);
@@ -150,34 +133,6 @@ export default function ChatPage({ users }: Props) {
     });
   }, []);
 
-  // フィルター（tagIds/dateFrom/dateTo/userId/hasAttachment）が 1 つでも指定されているか
-  const hasAnyFilter =
-    (searchFilters.tagIds?.length ?? 0) > 0 ||
-    !!searchFilters.dateFrom ||
-    !!searchFilters.dateTo ||
-    searchFilters.userId !== undefined ||
-    searchFilters.hasAttachment !== undefined;
-
-  // 検索クエリ or フィルタが変わったら API を呼ぶ（300ms debounce）
-  // クエリ・フィルタ両方が空なら API 呼び出しスキップ
-  useEffect(() => {
-    const trimmedQuery = searchQuery.trim();
-    if (!trimmedQuery && !hasAnyFilter) {
-      setSearchResults([]);
-      setSearching(false);
-      return;
-    }
-    const timer = setTimeout(() => {
-      setSearching(true);
-      api.messages
-        .search(trimmedQuery, searchFilters)
-        .then(({ messages }) => setSearchResults(messages))
-        .catch(console.error)
-        .finally(() => setSearching(false));
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchQuery, searchFilters, hasAnyFilter]);
-
   // ピン留め状態の変化時にリフレッシュ
   useEffect(() => {
     if (!socket || !activeChannelId) return;
@@ -192,7 +147,7 @@ export default function ChatPage({ users }: Props) {
   }, [socket, activeChannelId]);
 
   // #117 NG ワード関連: 送信エラー / 警告を Socket 経由で受信
-  const { showError, showInfo, showSuccess } = useSnackbar();
+  const { showError, showInfo } = useSnackbar();
   useEffect(() => {
     if (!socket) return;
     const handleError = (msg: string | RateLimitSocketError) => {
@@ -279,21 +234,6 @@ export default function ChatPage({ users }: Props) {
     setQuotedMessage(undefined);
   };
 
-  // 検索結果から投稿へ移動
-  const handleNavigate = useCallback((channelId: number, messageId: number) => {
-    setSearchQuery('');
-    setSearchFilters({});
-    setSearchActive(false);
-    setActiveChannelId(channelId);
-    setTimeout(() => {
-      window.location.hash = `#message-${messageId}`;
-    }, 100);
-  }, []);
-
-  // 検索モード: クエリがある or フィルター指定済み or 検索が明示的にアクティブ
-  // searchActive は onFocus で true、明示的な閉じる動作（チャンネル切替・結果遷移）で false
-  const isSearchMode = searchQuery.trim().length > 0 || hasAnyFilter || searchActive;
-
   return (
     <AppLayout
       sidebar={
@@ -306,10 +246,6 @@ export default function ChatPage({ users }: Props) {
                 setActiveChannelName(name);
                 setActiveChannel(channel ?? null);
                 setActiveTab('messages');
-                // チャンネル切替は「検索を閉じる」アクションとして扱う
-                setSearchActive(false);
-                setSearchQuery('');
-                setSearchFilters({});
               }}
               draftMap={draftMap}
             />
@@ -422,99 +358,49 @@ export default function ChatPage({ users }: Props) {
             </Suspense>
           )}
 
-          {/* メッセージタブ */}
+          {/* メッセージタブ (Step 7a: 検索 UI は SearchPage に分離。dead code 撤去) */}
           {activeTab === 'messages' && (
             <>
-              {isSearchMode ? (
-                <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
-                  <Box
-                    sx={{
-                      width: 240,
-                      flexShrink: 0,
-                      borderRight: 1,
-                      borderColor: 'divider',
-                      overflowY: 'auto',
-                    }}
-                  >
-                    <Suspense fallback={null}>
-                      <SearchFilterPanel
-                        key={JSON.stringify(searchFilters)}
-                        filters={searchFilters}
-                        onFilterChange={setSearchFilters}
-                        searchResults={searchResults}
-                        onSaveView={async ({ name, filters }) => {
-                          try {
-                            await api.savedViews.create({
-                              name,
-                              query: {
-                                keyword: searchQuery || undefined,
-                                dateFrom: filters.dateFrom,
-                                dateTo: filters.dateTo,
-                                userId: filters.userId,
-                                hasAttachment: filters.hasAttachment,
-                                tagIds: filters.tagIds,
-                              },
-                            });
-                            showSuccess(`保存ビュー「${name}」を保存しました`);
-                          } catch (err) {
-                            showError(
-                              err instanceof Error ? err.message : '保存ビューの作成に失敗しました',
-                            );
-                          }
-                        }}
-                      />
-                    </Suspense>
-                  </Box>
-                  <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
-                    {!searching && (
-                      <SearchResults results={searchResults} onNavigate={handleNavigate} />
-                    )}
-                  </Box>
-                </Box>
-              ) : (
-                <>
-                  {/* Step 5b: Main 上部の PinnedMessages バーは ContextRail のピン留めタブに集約したため撤去 */}
-                  {activeChannel?.isArchived && <ArchivedBanner />}
-                  <MessageList
-                    messages={messages}
-                    loading={loading}
-                    onLoadMore={loadMore}
-                    currentUserId={null}
-                    users={users}
-                    onOpenThread={handleOpenThread}
-                    onPinMessage={handlePinMessage}
-                    bookmarkedMessageIds={bookmarkedMessageIds}
-                    onBookmarkChange={handleBookmarkChange}
-                    onQuoteReply={handleQuoteReply}
-                  />
-                  <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}>
-                    <RichEditor
-                      users={users}
-                      onSend={handleSend}
-                      disabled={
-                        !activeChannelId ||
-                        activeChannel?.isArchived === true ||
-                        !canPostToActiveChannel
-                      }
-                      quotedMessage={quotedMessage}
-                      onClearQuote={() => setQuotedMessage(undefined)}
-                      channelId={activeChannelId ?? undefined}
-                      initialContent={
-                        activeChannelId !== null ? draftMap.get(activeChannelId) : undefined
-                      }
-                      onDraftSaved={handleDraftSaved}
-                      onDraftDeleted={handleDraftDeleted}
-                      onSlashEvent={() => {
-                        if (activeChannelId) {
-                          setEventDialogOpen(true);
-                        } else {
-                          showError('チャンネルを選択してからイベントを作成してください');
-                        }
-                      }}
-                    />
-                  </Box>
-                </>
-              )}
+              {/* Step 5b: Main 上部の PinnedMessages バーは ContextRail のピン留めタブに集約したため撤去 */}
+              {activeChannel?.isArchived && <ArchivedBanner />}
+              <MessageList
+                messages={messages}
+                loading={loading}
+                onLoadMore={loadMore}
+                currentUserId={null}
+                users={users}
+                onOpenThread={handleOpenThread}
+                onPinMessage={handlePinMessage}
+                bookmarkedMessageIds={bookmarkedMessageIds}
+                onBookmarkChange={handleBookmarkChange}
+                onQuoteReply={handleQuoteReply}
+              />
+              <Box sx={{ p: 2, borderTop: 1, borderColor: 'divider' }}>
+                <RichEditor
+                  users={users}
+                  onSend={handleSend}
+                  disabled={
+                    !activeChannelId ||
+                    activeChannel?.isArchived === true ||
+                    !canPostToActiveChannel
+                  }
+                  quotedMessage={quotedMessage}
+                  onClearQuote={() => setQuotedMessage(undefined)}
+                  channelId={activeChannelId ?? undefined}
+                  initialContent={
+                    activeChannelId !== null ? draftMap.get(activeChannelId) : undefined
+                  }
+                  onDraftSaved={handleDraftSaved}
+                  onDraftDeleted={handleDraftDeleted}
+                  onSlashEvent={() => {
+                    if (activeChannelId) {
+                      setEventDialogOpen(true);
+                    } else {
+                      showError('チャンネルを選択してからイベントを作成してください');
+                    }
+                  }}
+                />
+              </Box>
             </>
           )}
         </Box>

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -1,0 +1,151 @@
+import { useState, useEffect, useCallback, Suspense } from 'react';
+import { Box, TextField, CircularProgress } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+import AppLayout from '../components/Layout/AppLayout';
+import ChannelList from '../components/Channel/ChannelList';
+import SidebarDmList from '../components/Layout/SidebarDmList';
+import SearchResults from '../components/Chat/SearchResults';
+import SearchFilterPanel, { type SearchFilters } from '../components/Chat/SearchFilterPanel';
+import { api } from '../api/client';
+import type { MessageSearchResult } from '@chat-app/shared';
+import { useSnackbar } from '../contexts/SnackbarContext';
+
+/**
+ * Step 7a: 検索ページ。
+ * これまで ChatPage 内で `isSearchMode` 切替表示していた検索 UI を独立ページに分離する。
+ * Rail の検索アイコン (Step 7a で disabled 解除) からも本ページへ遷移する。
+ *
+ * スコープ:
+ *   - 既存 SearchFilterPanel / SearchResults を流用
+ *   - クエリ入力 (TextField) + フィルタの両方が空のときは API を呼ばない
+ *   - 結果クリックで /chat?channel=X#message-Y へ navigate
+ *   - 「保存」ボタン押下で api.savedViews.create を呼ぶ
+ *
+ * Step 7a スコープ外 (後続):
+ *   - 保存ビューのピル一覧 → Step 7b
+ *   - チップ式フィルタ入力 (`from:` `in:` 等) + スニペットハイライト → Step 7c
+ */
+export default function SearchPage() {
+  const navigate = useNavigate();
+  const { showSuccess, showError } = useSnackbar();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchFilters, setSearchFilters] = useState<SearchFilters>({});
+  const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  const hasAnyFilter =
+    (searchFilters.tagIds?.length ?? 0) > 0 ||
+    !!searchFilters.dateFrom ||
+    !!searchFilters.dateTo ||
+    searchFilters.userId !== undefined ||
+    searchFilters.hasAttachment !== undefined;
+
+  // 検索クエリ or フィルタが変わったら API を呼ぶ（300ms debounce）
+  useEffect(() => {
+    const trimmedQuery = searchQuery.trim();
+    if (!trimmedQuery && !hasAnyFilter) {
+      setSearchResults([]);
+      setSearching(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setSearching(true);
+      api.messages
+        .search(trimmedQuery, searchFilters)
+        .then(({ messages }) => setSearchResults(messages))
+        .catch((err) => {
+           
+          console.error(err);
+        })
+        .finally(() => setSearching(false));
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, searchFilters, hasAnyFilter]);
+
+  const handleNavigate = useCallback(
+    (channelId: number, messageId: number) => {
+      navigate(`/chat?channel=${channelId}#message-${messageId}`);
+    },
+    [navigate],
+  );
+
+  const handleSaveView = useCallback(
+    async ({ name, filters }: { name: string; filters: SearchFilters }) => {
+      try {
+        await api.savedViews.create({
+          name,
+          query: {
+            keyword: searchQuery || undefined,
+            dateFrom: filters.dateFrom,
+            dateTo: filters.dateTo,
+            userId: filters.userId,
+            hasAttachment: filters.hasAttachment,
+            tagIds: filters.tagIds,
+          },
+        });
+        showSuccess(`保存ビュー「${name}」を保存しました`);
+      } catch (err) {
+        showError(err instanceof Error ? err.message : '保存ビューの作成に失敗しました');
+      }
+    },
+    [searchQuery, showSuccess, showError],
+  );
+
+  return (
+    <AppLayout
+      sidebar={
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+          <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <ChannelList activeChannelId={null} onSelect={() => {}} />
+          </Box>
+          <SidebarDmList />
+        </Box>
+      }
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+        <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
+          <TextField
+            fullWidth
+            size="small"
+            placeholder="メッセージを検索..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            inputProps={{ 'aria-label': 'メッセージ検索' }}
+            autoFocus
+          />
+        </Box>
+        <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
+          <Box
+            sx={{
+              width: 240,
+              flexShrink: 0,
+              borderRight: 1,
+              borderColor: 'divider',
+              overflowY: 'auto',
+            }}
+          >
+            <Suspense fallback={null}>
+              <SearchFilterPanel
+                key={JSON.stringify(searchFilters)}
+                filters={searchFilters}
+                onFilterChange={setSearchFilters}
+                searchResults={searchResults}
+                onSaveView={handleSaveView}
+              />
+            </Suspense>
+          </Box>
+          <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+            {searching ? (
+              <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
+                <CircularProgress size={24} />
+              </Box>
+            ) : (
+              <SearchResults results={searchResults} onNavigate={handleNavigate} />
+            )}
+          </Box>
+        </Box>
+      </Box>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
## 概要

検索 UI 再構築の最初の Step。検索を独立ページ化（モーダル → ページ）し、Rail の検索アイコンから遷移できるようにする。同時に ChatPage 内に残置されていた検索系 dead code（保留 TODO #2）を全撤去する。

## 変更内容

### 新規
- `packages/client/src/pages/SearchPage.tsx` — 検索画面。既存 `SearchFilterPanel` / `SearchResults` を流用 + 検索クエリ入力欄 (`TextField`) + 結果クリックで `/chat?channel=X#message-Y` へ navigate + 「保存」ボタンで `api.savedViews.create`
- `packages/client/src/__tests__/SearchPage.test.tsx` — 描画 3 / 検索動作 3 / ナビゲーション 1 / 保存ビュー作成 1 の 8 件

### 修正
- `App.tsx` — `/search` ルート追加（`SocketProvider` 配下、`RequireAuth`）
- `Rail.tsx` — 検索アイコンを `disabled IconButton` → `NavLink to=\"/search\"` 化（保留 TODO #1 解消）
- `ChatPage.tsx` — 検索系 dead code を全撤去（約 130 行削減）
  - `searchQuery` / `searchFilters` / `searchResults` / `searchActive` state
  - `hasAnyFilter` / debounce `useEffect` / `handleNavigate` / `isSearchMode`
  - `SearchFilterPanel` / `SearchResults` / `MessageSearchResult` import
  - チャンネル切替時の検索リセット処理
- `Rail.test.tsx` — 上部 5 → 6 アイコン / 検索アイコン disabled テスト → /search リンクテスト
- `ChatPage.test.tsx` — `describe.skip('検索モードの切り替え')` 撤去 / AppLayout スタブの search props 撤去 / SearchFilterPanel / SearchResults スタブ撤去（検証は SearchPage.test に移譲）

### Step 7a スコープ外（後続）
- **7b**: 保存ビューのピル一覧表示 + クリックで条件適用
- **7c**: チップ式フィルタ入力欄 (`from:` `in:` `has:` `before:` `after:` `tag:`) + 結果リストのスニペットハイライト

## 影響範囲
- フロントのみ。サーバー / DB 変更なし
- ChatPage の表示動作: 検索モード切替が無くなり、メッセージタブは常にメッセージリスト + RichEditor 表示
- 検索動線: Rail 検索アイコン → `/search` ページへ遷移（クリックでフォーカス可能）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1411 件、skip 0）
- [x] バックエンドユニットテストがすべてパスする（1373 件、追加なし）
- [x] ビルドが正常に完了すること
- [ ] (手動確認) Rail 検索アイコンクリックで `/search` に遷移、クエリ入力で検索、結果クリックで `/chat?channel=X#message-Y` に遷移、保存ボタンでスナックバー表示

## 関連Issue
Fixes #N/A (UI/UX ブラッシュアップ Step 7a / 保留 TODO #1, #2 解消)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に実施
- [x] `it.todo` / 空ボディの `it` が残っていない（既存の `describe.skip` も撤去済み）

## 既存テストの変更
| ファイル | 変更箇所 | 理由 |
|---|---|---|
| `__tests__/ChatPage.test.tsx` | `describe.skip('検索モードの切り替え (#115)')` を撤去 / AppLayout スタブの search props と SearchFilterPanel / SearchResults スタブを撤去 | 仕様変更（検索 UI が ChatPage から SearchPage に分離。検証は SearchPage.test に移譲） |
| `__tests__/Rail.test.tsx` | 「5 つのアイコン」→「6 つのアイコン (検索追加)」 / 「検索アイコンは無効状態である」→「検索アイコンは /search にリンクする」 | 仕様変更（保留 TODO #1 解消で disabled IconButton を NavLink 化） |

## 実装メモ
- `SearchPage.tsx` は ChatPage 内の旧検索ロジックをほぼそのまま移植（debounce 300ms、`hasAnyFilter` 判定、`onSaveView` ハンドラ）
- `useNavigate('/chat?channel=X#message-Y')` で結果から元チャンネルへ遷移
- 既存 `SearchFilterPanel` / `SearchResults` は API 互換のままで再利用