### PR TITLE
feat(search): 保存ビューのピル一覧表示 + ロード/削除アクション (Step 7b)

### DIFF
--- a/packages/client/src/__tests__/SavedViewPills.test.tsx
+++ b/packages/client/src/__tests__/SavedViewPills.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * components/Search/SavedViewPills.tsx のユニットテスト (Step 7b)
+ *
+ * テスト対象:
+ *   - SearchPage 上部に配置する保存ビューのピル一覧
+ *   - ピルクリックで onSelect、削除アイコンで onDelete を呼ぶ純粋コンポーネント
+ *
+ * 戦略:
+ *   - SavedView 配列を props で直接渡す（ネットワーク呼び出しなし）
+ *   - 親 (SearchPage) の Suspense で `use(promise)` を解決して配列を渡す責務分離パターンを踏襲
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import type { SavedView } from '@chat-app/shared';
+import SavedViewPills from '../components/Search/SavedViewPills';
+
+function makeView(overrides: Partial<SavedView> = {}): SavedView {
+  return {
+    id: 1,
+    userId: 1,
+    name: 'view1',
+    query: { keyword: 'hello' },
+    position: 0,
+    createdAt: '2026-05-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SavedViewPills (Step 7b)', () => {
+  it('views が空のとき何も描画しない (null)', () => {
+    const { container } = render(<SavedViewPills views={[]} onSelect={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('views が渡されたとき、各ピルに保存ビュー名が表示される', () => {
+    const views = [
+      makeView({ id: 1, name: '営業チーム' }),
+      makeView({ id: 2, name: '今週のリリース' }),
+    ];
+    render(<SavedViewPills views={views} onSelect={vi.fn()} />);
+    expect(screen.getByText('営業チーム')).toBeInTheDocument();
+    expect(screen.getByText('今週のリリース')).toBeInTheDocument();
+  });
+
+  it('ピルクリックで onSelect が該当 view で呼ばれる', async () => {
+    const onSelect = vi.fn();
+    const view = makeView({ id: 42, name: 'pick-me' });
+    render(<SavedViewPills views={[view]} onSelect={onSelect} />);
+    await userEvent.click(screen.getByText('pick-me'));
+    expect(onSelect).toHaveBeenCalledWith(view);
+  });
+
+  it('削除ボタンクリックで onDelete が該当 id で呼ばれる', async () => {
+    const onDelete = vi.fn();
+    const view = makeView({ id: 99, name: 'delete-me' });
+    render(<SavedViewPills views={[view]} onSelect={vi.fn()} onDelete={onDelete} />);
+    // MUI Chip の削除ボタンは aria-label 'delete' のスパン内に CloseIcon を含む
+    // CloseIcon は data-testid="CloseIcon" でアクセス可能
+    const deleteButton = screen.getByTestId('CloseIcon');
+    await userEvent.click(deleteButton);
+    expect(onDelete).toHaveBeenCalledWith(99);
+  });
+
+  it('onDelete が未指定の場合、削除ボタンは表示されない', () => {
+    const view = makeView({ id: 1, name: 'no-delete' });
+    render(<SavedViewPills views={[view]} onSelect={vi.fn()} />);
+    expect(screen.queryByTestId('CloseIcon')).toBeNull();
+  });
+});

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -64,6 +64,35 @@ vi.mock('../components/Chat/SearchResults', () => ({
   ),
 }));
 
+// Step 7b: SavedViewsSection スタブ — Suspense + use(promise) を経由せずに
+// onSelect / onDelete をテストから直接駆動する。`mockSavedViewsForSection` で
+// 表示する保存ビューを各 it から制御する。
+const mockSavedViewsForSection = vi.hoisted(() => ({
+  current: [] as Array<{ id: number; name: string; query: Record<string, unknown> }>,
+}));
+vi.mock('../components/Search/SavedViewsSection', () => ({
+  default: ({
+    onSelect,
+    onDelete,
+  }: {
+    onSelect: (view: { id: number; query: Record<string, unknown> }) => void;
+    onDelete: (id: number) => void;
+  }) => (
+    <div data-testid="mock-saved-views-section">
+      {mockSavedViewsForSection.current.map((v) => (
+        <div key={v.id}>
+          <button data-testid={`select-view-${v.id}`} onClick={() => onSelect(v)}>
+            {v.name}
+          </button>
+          <button data-testid={`delete-view-${v.id}`} onClick={() => onDelete(v.id)}>
+            delete
+          </button>
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
 // Snackbar
 const mockSnackbar = vi.hoisted(() => ({
   showSuccess: vi.fn(),
@@ -77,10 +106,16 @@ vi.mock('../contexts/SnackbarContext', () => ({
 // API モック
 const mockSearch = vi.hoisted(() => vi.fn());
 const mockSavedViewsCreate = vi.hoisted(() => vi.fn());
+const mockSavedViewsList = vi.hoisted(() => vi.fn());
+const mockSavedViewsDelete = vi.hoisted(() => vi.fn());
 vi.mock('../api/client', () => ({
   api: {
     messages: { search: (...args: unknown[]) => mockSearch(...args) },
-    savedViews: { create: (...args: unknown[]) => mockSavedViewsCreate(...args) },
+    savedViews: {
+      list: () => mockSavedViewsList(),
+      create: (...args: unknown[]) => mockSavedViewsCreate(...args),
+      delete: (...args: unknown[]) => mockSavedViewsDelete(...args),
+    },
   },
 }));
 
@@ -99,9 +134,14 @@ beforeEach(() => {
   mockSearch.mockResolvedValue({ messages: [] });
   mockSavedViewsCreate.mockReset();
   mockSavedViewsCreate.mockResolvedValue({ savedView: { id: 1, name: 'view1' } });
+  mockSavedViewsList.mockReset();
+  mockSavedViewsList.mockResolvedValue({ savedViews: [] });
+  mockSavedViewsDelete.mockReset();
+  mockSavedViewsDelete.mockResolvedValue(undefined);
   mockNavigate.mockReset();
   mockSnackbar.showSuccess.mockReset();
   mockSnackbar.showError.mockReset();
+  mockSavedViewsForSection.current = [];
 });
 
 function renderSearch() {
@@ -187,6 +227,49 @@ describe('SearchPage (Step 7a)', () => {
       const callArg = mockSavedViewsCreate.mock.calls[0][0];
       expect(callArg.name).toBe('view1');
       expect(callArg.query.tagIds).toEqual([42]);
+    });
+  });
+
+  describe('保存ビューのピル一覧 (Step 7b)', () => {
+    it('SavedViewPills の onSelect が呼ばれると、view.query から searchQuery / searchFilters が反映される', async () => {
+      mockSavedViewsForSection.current = [
+        {
+          id: 10,
+          name: '営業',
+          query: { keyword: 'クロスチャンネル', tagIds: [1, 2], hasAttachment: true },
+        },
+      ];
+      renderSearch();
+      const pill = screen.getByTestId('select-view-10');
+      await act(async () => {
+        await userEvent.click(pill);
+      });
+      // searchQuery が反映されて debounce 後 search が呼ばれる
+      await waitFor(
+        () => {
+          expect(mockSearch).toHaveBeenCalled();
+        },
+        { timeout: 1000 },
+      );
+      const lastCall = mockSearch.mock.calls[mockSearch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe('クロスチャンネル');
+      expect(lastCall[1]).toEqual(expect.objectContaining({ tagIds: [1, 2], hasAttachment: true }));
+    });
+
+    it('SavedViewPills の onDelete が呼ばれると api.savedViews.delete が該当 id で呼ばれる', async () => {
+      mockSavedViewsForSection.current = [
+        {
+          id: 99,
+          name: 'remove-me',
+          query: {},
+        },
+      ];
+      renderSearch();
+      const deleteBtn = screen.getByTestId('delete-view-99');
+      await userEvent.click(deleteBtn);
+      await waitFor(() => {
+        expect(mockSavedViewsDelete).toHaveBeenCalledWith(99);
+      });
     });
   });
 });

--- a/packages/client/src/components/Search/SavedViewPills.tsx
+++ b/packages/client/src/components/Search/SavedViewPills.tsx
@@ -1,0 +1,44 @@
+import { Box, Chip } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import type { SavedView } from '@chat-app/shared';
+
+interface Props {
+  views: SavedView[];
+  /** ピルクリック時に該当 view を渡す。SearchPage 側で query → state にロードする */
+  onSelect: (view: SavedView) => void;
+  /** 削除アイコン押下時に該当 id を渡す。未指定の場合は削除アイコンを表示しない */
+  onDelete?: (id: number) => void;
+}
+
+/**
+ * Step 7b: SearchPage 上部に配置する保存ビューのピル一覧。
+ *
+ * 純粋コンポーネント — Promise の解決は親 (SearchPage) の Suspense で行い、
+ * ここには配列を受け取って描画するだけにする責務分離パターン。
+ *
+ * 並び順は親が `api.savedViews.list()` で取得した順 (= position 順) をそのまま使う。
+ */
+export default function SavedViewPills({ views, onSelect, onDelete }: Props) {
+  if (views.length === 0) return null;
+  return (
+    <Box
+      sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}
+      data-testid="saved-view-pills"
+      role="list"
+    >
+      {views.map((view) => (
+        <Chip
+          key={view.id}
+          label={view.name}
+          onClick={() => onSelect(view)}
+          onDelete={onDelete ? () => onDelete(view.id) : undefined}
+          deleteIcon={onDelete ? <CloseIcon fontSize="small" /> : undefined}
+          size="small"
+          variant="outlined"
+          data-testid={`saved-view-pill-${view.id}`}
+          role="listitem"
+        />
+      ))}
+    </Box>
+  );
+}

--- a/packages/client/src/components/Search/SavedViewsSection.tsx
+++ b/packages/client/src/components/Search/SavedViewsSection.tsx
@@ -1,0 +1,24 @@
+import { use } from 'react';
+import type { SavedView } from '@chat-app/shared';
+import SavedViewPills from './SavedViewPills';
+
+interface Props {
+  promise: Promise<{ savedViews: SavedView[] }>;
+  onSelect: (view: SavedView) => void;
+  onDelete: (id: number) => void;
+}
+
+/**
+ * Step 7b: SearchPage 上部の保存ビューピル一覧の Suspense ラッパー。
+ *
+ * 親 (SearchPage) の Suspense 内で `use(promise)` を解決し、純粋コンポーネント
+ * SavedViewPills に配列を渡す責務分離パターン。
+ *
+ * ラッパーをこの別ファイルに切り出すことで、 SearchPage のテスト時に
+ * `vi.mock('../components/Search/SavedViewsSection')` で丸ごとスタブ化でき、
+ * jsdom + vitest 環境で Suspense 解決を経由せずにテスト可能にする。
+ */
+export default function SavedViewsSection({ promise, onSelect, onDelete }: Props) {
+  const { savedViews } = use(promise);
+  return <SavedViewPills views={savedViews} onSelect={onSelect} onDelete={onDelete} />;
+}

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, Suspense } from 'react';
+import { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
 import { Box, TextField, CircularProgress } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
@@ -6,8 +6,9 @@ import ChannelList from '../components/Channel/ChannelList';
 import SidebarDmList from '../components/Layout/SidebarDmList';
 import SearchResults from '../components/Chat/SearchResults';
 import SearchFilterPanel, { type SearchFilters } from '../components/Chat/SearchFilterPanel';
+import SavedViewsSection from '../components/Search/SavedViewsSection';
 import { api } from '../api/client';
-import type { MessageSearchResult } from '@chat-app/shared';
+import type { MessageSearchResult, SavedView } from '@chat-app/shared';
 import { useSnackbar } from '../contexts/SnackbarContext';
 
 /**
@@ -15,14 +16,17 @@ import { useSnackbar } from '../contexts/SnackbarContext';
  * これまで ChatPage 内で `isSearchMode` 切替表示していた検索 UI を独立ページに分離する。
  * Rail の検索アイコン (Step 7a で disabled 解除) からも本ページへ遷移する。
  *
+ * Step 7b: 保存ビューのピル一覧をクエリ入力欄の下に配置。
+ *   - ピルクリックで `view.query` から `searchQuery` / `searchFilters` を反映
+ *   - 削除アイコンで `api.savedViews.delete(id)` + 再フェッチ
+ *
  * スコープ:
  *   - 既存 SearchFilterPanel / SearchResults を流用
  *   - クエリ入力 (TextField) + フィルタの両方が空のときは API を呼ばない
  *   - 結果クリックで /chat?channel=X#message-Y へ navigate
  *   - 「保存」ボタン押下で api.savedViews.create を呼ぶ
  *
- * Step 7a スコープ外 (後続):
- *   - 保存ビューのピル一覧 → Step 7b
+ * Step 7b スコープ外 (後続):
  *   - チップ式フィルタ入力 (`from:` `in:` 等) + スニペットハイライト → Step 7c
  */
 export default function SearchPage() {
@@ -33,6 +37,10 @@ export default function SearchPage() {
   const [searchFilters, setSearchFilters] = useState<SearchFilters>({});
   const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
+
+  // Step 7b: 保存ビュー一覧 promise。削除/作成後に savedViewsKey をインクリメントして再フェッチ
+  const [savedViewsKey, setSavedViewsKey] = useState(0);
+  const savedViewsPromise = useMemo(() => api.savedViews.list(), [savedViewsKey]);
 
   const hasAnyFilter =
     (searchFilters.tagIds?.length ?? 0) > 0 ||
@@ -55,7 +63,6 @@ export default function SearchPage() {
         .search(trimmedQuery, searchFilters)
         .then(({ messages }) => setSearchResults(messages))
         .catch((err) => {
-           
           console.error(err);
         })
         .finally(() => setSearching(false));
@@ -85,11 +92,38 @@ export default function SearchPage() {
           },
         });
         showSuccess(`保存ビュー「${name}」を保存しました`);
+        // 保存ビュー一覧を再フェッチ
+        setSavedViewsKey((k) => k + 1);
       } catch (err) {
         showError(err instanceof Error ? err.message : '保存ビューの作成に失敗しました');
       }
     },
     [searchQuery, showSuccess, showError],
+  );
+
+  // Step 7b: ピルクリックで保存ビューの query を state に反映
+  const handleSelectSavedView = useCallback((view: SavedView) => {
+    setSearchQuery(view.query.keyword ?? '');
+    setSearchFilters({
+      dateFrom: view.query.dateFrom,
+      dateTo: view.query.dateTo,
+      userId: view.query.userId,
+      hasAttachment: view.query.hasAttachment,
+      tagIds: view.query.tagIds,
+    });
+  }, []);
+
+  // Step 7b: 保存ビュー削除
+  const handleDeleteSavedView = useCallback(
+    async (id: number) => {
+      try {
+        await api.savedViews.delete(id);
+        setSavedViewsKey((k) => k + 1);
+      } catch (err) {
+        showError(err instanceof Error ? err.message : '保存ビューの削除に失敗しました');
+      }
+    },
+    [showError],
   );
 
   return (
@@ -104,7 +138,17 @@ export default function SearchPage() {
       }
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-        <Box sx={{ p: 2, borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: 1,
+            borderColor: 'divider',
+            flexShrink: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 1,
+          }}
+        >
           <TextField
             fullWidth
             size="small"
@@ -114,6 +158,13 @@ export default function SearchPage() {
             inputProps={{ 'aria-label': 'メッセージ検索' }}
             autoFocus
           />
+          <Suspense fallback={null}>
+            <SavedViewsSection
+              promise={savedViewsPromise}
+              onSelect={handleSelectSavedView}
+              onDelete={handleDeleteSavedView}
+            />
+          </Suspense>
         </Box>
         <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
           <Box


### PR DESCRIPTION
## 概要

検索ページに保存ビューのピル一覧を追加する。クエリ入力欄の下にピル形式で並べ、クリックで条件適用、× アイコンで削除できる。Step 7a で既に実装済みの「保存」ボタンと連携し、保存後はピル一覧が自動で更新される。

## 変更内容

### 新規
- `components/Search/SavedViewPills.tsx` — 純粋コンポーネント。`views` 配列 + `onSelect` + `onDelete?` props で MUI `Chip` リストを描画
- `components/Search/SavedViewsSection.tsx` — Suspense ラッパー。`use(promise)` で `{ savedViews }` を解決して SavedViewPills に渡す責務分離パターン
- `__tests__/SavedViewPills.test.tsx` — 5 件（空配列の null 描画 / ピル名表示 / onSelect / onDelete / onDelete 未指定時の非表示）

### 修正
- `pages/SearchPage.tsx`
  - `useState<number>` で `savedViewsKey` を保持し、`useMemo(() => api.savedViews.list(), [savedViewsKey])` で promise 安定化
  - クエリ入力欄の下に `<Suspense fallback={null}>` でラップした `SavedViewsSection` を配置
  - `handleSelectSavedView`: `view.query` の `keyword` → `searchQuery`、それ以外 (`dateFrom` / `dateTo` / `userId` / `hasAttachment` / `tagIds`) → `searchFilters`
  - `handleDeleteSavedView`: `api.savedViews.delete(id)` + `savedViewsKey++` で再フェッチ
  - `handleSaveView`: 保存成功後にも `savedViewsKey++` を呼んで新規ピルを即時反映

### Step 7b スコープ外（後続 7c）
- チップ式フィルタ入力（`from:` `in:` `has:` 等の構文パーサー）
- 結果リストのスニペットハイライト

## 影響範囲
- フロントのみ。サーバー / DB 変更なし
- 既存 `api.savedViews.list / create / delete` を活用（API 追加なし）
- `SavedView.query.channelId` は現状の `SearchFilters` に無いため Step 7b の変換対象外

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1418 件、skip 0）
- [x] バックエンドユニットテストがすべてパスする（1373 件、追加なし）
- [x] ビルドが正常に完了すること
- [ ] (手動確認) `/search` でピルクリック → 条件適用、× 削除 → ピル消失、保存ボタン → 新規ピル即時表示

## 関連Issue
Fixes #N/A (UI/UX ブラッシュアップ Step 7b)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に実施
- [x] `it.todo` / 空ボディの `it` が残っていない

## 既存テストの変更
| ファイル | 変更箇所 | 理由 |
|---|---|---|
| `__tests__/SearchPage.test.tsx` | api モックに `savedViews.list` / `savedViews.delete` を追加 / `SavedViewsSection` スタブを追加（`mockSavedViewsForSection.current` で内容を制御）/ 保存ビュー連携テスト 2 件追加 | 仕様変更（保存ビューピル一覧追加 + Suspense 解決バイパス） |

## 実装メモ
- **重要発見の再確認**: `useMemo + Suspense + use(promise)` のテストが jsdom + vitest 環境で安定しないという Step 6a 由来のハマりどころが再発。**対策として、Suspense ラッパー (`SavedViewsSection`) を別ファイルに切り出してテストから `vi.mock` で丸ごとスタブ化する** パターンを確立。 Inbox では SearchPage 内の関数として定義していたが、本 PR で別ファイル化することでテスト容易性が大幅に向上した