### PR TITLE
feat(search): チップ式フィルタ入力 + channelId サーバー対応 (Step 7c-1)

### DIFF
--- a/packages/client/src/__tests__/ChipFilterInput.test.tsx
+++ b/packages/client/src/__tests__/ChipFilterInput.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * components/Search/ChipFilterInput.tsx のユニットテスト (Step 7c-1)
+ *
+ * テスト対象: 検索ページ上部のチップ式フィルタ入力欄。
+ *   - 入力テキストを `parseSearchChips` で解析
+ *   - 抽出した from:/in:/tag: を users / channels / tags の配列と照合して ID 変換
+ *   - 解析結果のチップを TextField の下に表示
+ *   - 親に `onResolved({ keyword, filters })` を通知
+ *
+ * 戦略:
+ *   - 純粋コンポーネント: users / channels / tags 配列を props で直接渡す
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import type { User, Channel, Tag } from '@chat-app/shared';
+import ChipFilterInput from '../components/Search/ChipFilterInput';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 1,
+    username: 'alice',
+    email: 'alice@example.com',
+    displayName: null,
+    avatarUrl: null,
+    role: 'user',
+    location: null,
+    createdAt: '2026-05-01T00:00:00Z',
+    isActive: true,
+    onboardingCompletedAt: null,
+    ...overrides,
+  };
+}
+
+function makeChannel(overrides: Partial<Channel> = {}): Channel {
+  return {
+    id: 100,
+    name: 'general',
+    description: null,
+    topic: null,
+    createdBy: 1,
+    createdAt: '2026-05-01T00:00:00Z',
+    isPrivate: false,
+    postingPermission: 'everyone',
+    unreadCount: 0,
+    ...overrides,
+  };
+}
+
+function makeTag(overrides: Partial<Tag> = {}): Tag {
+  return {
+    id: 10,
+    name: 'urgent',
+    useCount: 1,
+    createdAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+interface RenderOpts {
+  value?: string;
+  users?: User[];
+  channels?: Channel[];
+  tags?: Tag[];
+  onTextChange?: (text: string) => void;
+  onResolved?: (params: { keyword: string; filters: Record<string, unknown> }) => void;
+}
+
+function renderInput(opts: RenderOpts = {}) {
+  const onTextChange = opts.onTextChange ?? vi.fn();
+  const onResolved = opts.onResolved ?? vi.fn();
+  const utils = render(
+    <ChipFilterInput
+      value={opts.value ?? ''}
+      onTextChange={onTextChange}
+      onResolved={onResolved}
+      users={opts.users ?? []}
+      channels={opts.channels ?? []}
+      tags={opts.tags ?? []}
+    />,
+  );
+  return { ...utils, onTextChange, onResolved };
+}
+
+describe('ChipFilterInput (Step 7c-1)', () => {
+  describe('入力 + 通知', () => {
+    it('value props の初期値が TextField に表示される', () => {
+      renderInput({ value: 'hello' });
+      expect(screen.getByLabelText('メッセージ検索')).toHaveValue('hello');
+    });
+
+    it('入力するたびに onTextChange が呼ばれ、parse 結果が onResolved で通知される', async () => {
+      const onTextChange = vi.fn();
+      renderInput({ onTextChange });
+      const input = screen.getByLabelText('メッセージ検索');
+      await userEvent.type(input, 'a');
+      expect(onTextChange).toHaveBeenCalledWith('a');
+    });
+
+    it('プレーンテキスト入力時は keyword のみ通知される (filters は空)', () => {
+      const onResolved = vi.fn();
+      renderInput({ value: 'hello world', onResolved });
+      // 初回マウント時にも onResolved が呼ばれる
+      expect(onResolved).toHaveBeenCalled();
+      const lastCall = onResolved.mock.calls[onResolved.mock.calls.length - 1][0];
+      expect(lastCall.keyword).toBe('hello world');
+      expect(lastCall.filters).toEqual({});
+    });
+  });
+
+  describe('チップ表示', () => {
+    it('from:alice 入力時、送信者 alice のチップが表示される', () => {
+      renderInput({ value: 'from:alice' });
+      expect(screen.getByTestId('chip-from')).toHaveTextContent('alice');
+    });
+
+    it('in:general 入力時、チャンネル general のチップが表示される', () => {
+      renderInput({ value: 'in:general' });
+      expect(screen.getByTestId('chip-in')).toHaveTextContent('general');
+    });
+
+    it('has:file 入力時、添付ありのチップが表示される', () => {
+      renderInput({ value: 'has:file' });
+      expect(screen.getByTestId('chip-has')).toHaveTextContent('添付あり');
+    });
+
+    it('tag:urgent 入力時、タグ urgent のチップが表示される', () => {
+      renderInput({ value: 'tag:urgent' });
+      expect(screen.getByTestId('chip-tag')).toHaveTextContent('urgent');
+    });
+
+    it('複数構文が組み合わさると複数のチップが表示される', () => {
+      renderInput({ value: 'from:alice has:file tag:urgent' });
+      expect(screen.getByTestId('chip-from')).toBeInTheDocument();
+      expect(screen.getByTestId('chip-has')).toBeInTheDocument();
+      expect(screen.getByTestId('chip-tag')).toBeInTheDocument();
+    });
+  });
+
+  describe('マスタデータ照合', () => {
+    it('from:alice に対応するユーザーがいれば userId が filters に反映される', () => {
+      const onResolved = vi.fn();
+      renderInput({
+        value: 'from:alice',
+        users: [makeUser({ id: 42, username: 'alice' })],
+        onResolved,
+      });
+      const lastCall = onResolved.mock.calls[onResolved.mock.calls.length - 1][0];
+      expect(lastCall.filters.userId).toBe(42);
+    });
+
+    it('from:存在しないユーザー はチップ表示するが filters の userId は undefined', () => {
+      const onResolved = vi.fn();
+      renderInput({
+        value: 'from:bob',
+        users: [makeUser({ id: 1, username: 'alice' })],
+        onResolved,
+      });
+      const lastCall = onResolved.mock.calls[onResolved.mock.calls.length - 1][0];
+      expect(lastCall.filters.userId).toBeUndefined();
+      expect(screen.getByTestId('chip-from')).toBeInTheDocument(); // チップは表示
+    });
+
+    it('in:general に対応するチャンネルがいれば channelId が filters に反映される', () => {
+      const onResolved = vi.fn();
+      renderInput({
+        value: 'in:general',
+        channels: [makeChannel({ id: 99, name: 'general' })],
+        onResolved,
+      });
+      const lastCall = onResolved.mock.calls[onResolved.mock.calls.length - 1][0];
+      expect(lastCall.filters.channelId).toBe(99);
+    });
+
+    it('tag:urgent に対応するタグがいれば tagIds に反映される', () => {
+      const onResolved = vi.fn();
+      renderInput({
+        value: 'tag:urgent',
+        tags: [makeTag({ id: 7, name: 'urgent' })],
+        onResolved,
+      });
+      const lastCall = onResolved.mock.calls[onResolved.mock.calls.length - 1][0];
+      expect(lastCall.filters.tagIds).toEqual([7]);
+    });
+  });
+});

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -64,6 +64,45 @@ vi.mock('../components/Chat/SearchResults', () => ({
   ),
 }));
 
+// Step 7c-1: ChipFilterSection スタブ — 検索ページ上部のチップ入力欄。
+// onResolved を直接駆動できるようにし、 Suspense + use(promise) を経由しない。
+vi.mock('../components/Search/ChipFilterSection', () => ({
+  default: ({
+    value,
+    onTextChange,
+    onResolved,
+  }: {
+    value: string;
+    onTextChange: (text: string) => void;
+    onResolved: (params: {
+      keyword: string;
+      filters: { userId?: number; channelId?: number; tagIds?: number[] };
+    }) => void;
+  }) => (
+    <div data-testid="mock-chip-filter-section">
+      <input
+        data-testid="mock-chip-input"
+        aria-label="メッセージ検索"
+        value={value}
+        onChange={(e) => {
+          const next = e.target.value;
+          onTextChange(next);
+          // 本物では useEffect で resolved 通知が走るので、テスト用にスタブも同期通知する
+          onResolved({ keyword: next, filters: {} });
+        }}
+      />
+      <button
+        data-testid="emit-resolved-from-alice"
+        onClick={() =>
+          onResolved({ keyword: 'リリース', filters: { userId: 42, channelId: 7, tagIds: [3] } })
+        }
+      >
+        emit
+      </button>
+    </div>
+  ),
+}));
+
 // Step 7b: SavedViewsSection スタブ — Suspense + use(promise) を経由せずに
 // onSelect / onDelete をテストから直接駆動する。`mockSavedViewsForSection` で
 // 表示する保存ビューを各 it から制御する。
@@ -270,6 +309,24 @@ describe('SearchPage (Step 7a)', () => {
       await waitFor(() => {
         expect(mockSavedViewsDelete).toHaveBeenCalledWith(99);
       });
+    });
+  });
+
+  describe('チップ式フィルタ入力 (Step 7c-1)', () => {
+    it('ChipFilterSection の onResolved が呼ばれると、searchQuery と effectiveFilters が search API に渡される', async () => {
+      renderSearch();
+      await userEvent.click(screen.getByTestId('emit-resolved-from-alice'));
+      await waitFor(
+        () => {
+          expect(mockSearch).toHaveBeenCalled();
+        },
+        { timeout: 1000 },
+      );
+      const lastCall = mockSearch.mock.calls[mockSearch.mock.calls.length - 1];
+      expect(lastCall[0]).toBe('リリース');
+      expect(lastCall[1]).toEqual(
+        expect.objectContaining({ userId: 42, channelId: 7, tagIds: [3] }),
+      );
     });
   });
 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -226,6 +226,8 @@ export const api = {
       // Step 6b: 自分宛メンションのみ / 未読のみフィルタ
       if (filters?.mentionedToMe) params.set('mentionedToMe', 'true');
       if (filters?.unreadOnly) params.set('unreadOnly', 'true');
+      // Step 7c-1: in:channel チップ構文用
+      if (filters?.channelId !== undefined) params.set('channelId', String(filters.channelId));
       return request<{ messages: MessageSearchResult[] }>(`/messages/search?${params.toString()}`);
     },
     getReplies: (messageId: number) =>

--- a/packages/client/src/components/Chat/SearchFilterPanel.tsx
+++ b/packages/client/src/components/Chat/SearchFilterPanel.tsx
@@ -29,6 +29,8 @@ export interface SearchFilters {
   userId?: number;
   hasAttachment?: boolean;
   tagIds?: number[];
+  /** Step 7c-1: in:channel チップ構文用のチャンネル ID */
+  channelId?: number;
 }
 
 interface Props {

--- a/packages/client/src/components/Search/ChipFilterInput.tsx
+++ b/packages/client/src/components/Search/ChipFilterInput.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo } from 'react';
+import { Box, Chip, TextField, Typography } from '@mui/material';
+import type { User, Channel, Tag } from '@chat-app/shared';
+import { parseSearchChips, type ParsedSearchChips } from '../../utils/parseSearchChips';
+import type { SearchFilters } from '../Chat/SearchFilterPanel';
+
+interface Props {
+  /** 入力中の生テキスト */
+  value: string;
+  /** テキスト変更時に親に通知 (TextField 直接入力分) */
+  onTextChange: (text: string) => void;
+  /** 解析 + マスタ照合の結果を親に通知 */
+  onResolved: (params: { keyword: string; filters: Partial<SearchFilters> }) => void;
+  /** ID 変換用のマスタデータ */
+  users: User[];
+  channels: Channel[];
+  tags: Tag[];
+}
+
+/**
+ * Step 7c-1: 検索ページ上部のチップ式フィルタ入力欄。
+ *
+ * 純粋コンポーネント — マスタデータ (users / channels / tags) は親 (ChipFilterSection) が
+ * Suspense 経由で取得して props で渡す。
+ *
+ * 動作:
+ *   1. 入力テキストを `parseSearchChips` で同期解析
+ *   2. fromUsername / inChannelName / tagName を ID に変換 (大文字小文字無視で照合)
+ *   3. `{ keyword, filters }` を親に通知
+ *   4. 解析結果のチップを TextField の下に表示 (読み取り専用)
+ *
+ * `has:link` は Step 7c スコープ外。`hasFile` のみ対応。
+ */
+export default function ChipFilterInput({
+  value,
+  onTextChange,
+  onResolved,
+  users,
+  channels,
+  tags,
+}: Props) {
+  const parsed: ParsedSearchChips = useMemo(() => parseSearchChips(value), [value]);
+
+  // マスタ照合 → SearchFilters への変換
+  const resolved = useMemo(() => {
+    const filters: Partial<SearchFilters> = {};
+    if (parsed.fromUsername) {
+      const user = users.find(
+        (u) => u.username.toLowerCase() === parsed.fromUsername!.toLowerCase(),
+      );
+      if (user) filters.userId = user.id;
+    }
+    if (parsed.inChannelName) {
+      const channel = channels.find(
+        (c) => c.name.toLowerCase() === parsed.inChannelName!.toLowerCase(),
+      );
+      if (channel) filters.channelId = channel.id;
+    }
+    if (parsed.tagName) {
+      const tag = tags.find((t) => t.name.toLowerCase() === parsed.tagName!.toLowerCase());
+      if (tag) filters.tagIds = [tag.id];
+    }
+    if (parsed.hasFile !== undefined) filters.hasAttachment = parsed.hasFile;
+    if (parsed.beforeDate) filters.dateTo = parsed.beforeDate;
+    if (parsed.afterDate) filters.dateFrom = parsed.afterDate;
+    return { keyword: parsed.keyword, filters };
+  }, [parsed, users, channels, tags]);
+
+  // resolved が変わるたび親に通知
+  useEffect(() => {
+    onResolved(resolved);
+  }, [resolved, onResolved]);
+
+  // 解析結果のチップをまとめる (表示用)
+  const chips: Array<{ key: string; label: string; matched: boolean }> = [];
+  if (parsed.fromUsername) {
+    chips.push({
+      key: 'from',
+      label: `送信者: ${parsed.fromUsername}`,
+      matched: resolved.filters.userId !== undefined,
+    });
+  }
+  if (parsed.inChannelName) {
+    chips.push({
+      key: 'in',
+      label: `チャンネル: #${parsed.inChannelName}`,
+      matched: resolved.filters.channelId !== undefined,
+    });
+  }
+  if (parsed.hasFile) {
+    chips.push({ key: 'has', label: '添付あり', matched: true });
+  }
+  if (parsed.beforeDate) {
+    chips.push({ key: 'before', label: `〜 ${parsed.beforeDate}`, matched: true });
+  }
+  if (parsed.afterDate) {
+    chips.push({ key: 'after', label: `${parsed.afterDate} 〜`, matched: true });
+  }
+  if (parsed.tagName) {
+    chips.push({
+      key: 'tag',
+      label: `タグ: ${parsed.tagName}`,
+      matched: resolved.filters.tagIds !== undefined && resolved.filters.tagIds.length > 0,
+    });
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+      <TextField
+        fullWidth
+        size="small"
+        placeholder="例: from:alice has:file 議事録"
+        value={value}
+        onChange={(e) => onTextChange(e.target.value)}
+        inputProps={{ 'aria-label': 'メッセージ検索' }}
+        autoFocus
+      />
+      {chips.length > 0 && (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }} data-testid="chip-filter-chips">
+          {chips.map((c) => (
+            <Chip
+              key={c.key}
+              label={c.label}
+              size="small"
+              variant="outlined"
+              color={c.matched ? 'primary' : 'default'}
+              data-testid={`chip-${c.key}`}
+            />
+          ))}
+          {chips.some((c) => !c.matched) && (
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ alignSelf: 'center', ml: 1 }}
+            >
+              （灰色のチップはマスタに該当が無いため絞り込みに反映されません）
+            </Typography>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/packages/client/src/components/Search/ChipFilterSection.tsx
+++ b/packages/client/src/components/Search/ChipFilterSection.tsx
@@ -1,0 +1,58 @@
+import { use, useState } from 'react';
+import { api } from '../../api/client';
+import type { User, Channel, Tag, TagSuggestion } from '@chat-app/shared';
+import ChipFilterInput from './ChipFilterInput';
+import type { SearchFilters } from '../Chat/SearchFilterPanel';
+
+function suggestionToTag(s: TagSuggestion): Tag {
+  return { id: s.id, name: s.name, useCount: s.useCount, createdAt: '' };
+}
+
+interface Props {
+  value: string;
+  onTextChange: (text: string) => void;
+  onResolved: (params: { keyword: string; filters: Partial<SearchFilters> }) => void;
+}
+
+interface MasterData {
+  users: User[];
+  channels: Channel[];
+  tags: Tag[];
+}
+
+/**
+ * Step 7c-1: ChipFilterInput の Suspense ラッパー。
+ *
+ * 親 (SearchPage) の Suspense 内で `use(promise)` を解決し、純粋コンポーネント
+ * ChipFilterInput にマスタデータ (users / channels / tags) を渡す責務分離パターン。
+ *
+ * Step 7b で確立した「Suspense ラッパーは別ファイルに切り出す」パターンを踏襲し、
+ * SearchPage のテスト時に `vi.mock` で丸ごとスタブ化できるようにする。
+ */
+export default function ChipFilterSection({ value, onTextChange, onResolved }: Props) {
+  const [promise] = useState<Promise<MasterData>>(() =>
+    Promise.all([api.auth.users(), api.channels.list(), api.tags.suggestions('', 1000)]).then(
+      ([usersRes, channelsRes, tagsRes]: [
+        { users: User[] },
+        { channels: Channel[] },
+        { suggestions: TagSuggestion[] },
+      ]) => ({
+        users: usersRes.users,
+        channels: channelsRes.channels,
+        tags: tagsRes.suggestions.map(suggestionToTag),
+      }),
+    ),
+  );
+  const { users, channels, tags } = use(promise);
+
+  return (
+    <ChipFilterInput
+      value={value}
+      onTextChange={onTextChange}
+      onResolved={onResolved}
+      users={users}
+      channels={channels}
+      tags={tags}
+    />
+  );
+}

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
-import { Box, TextField, CircularProgress } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
@@ -7,6 +7,7 @@ import SidebarDmList from '../components/Layout/SidebarDmList';
 import SearchResults from '../components/Chat/SearchResults';
 import SearchFilterPanel, { type SearchFilters } from '../components/Chat/SearchFilterPanel';
 import SavedViewsSection from '../components/Search/SavedViewsSection';
+import ChipFilterSection from '../components/Search/ChipFilterSection';
 import { api } from '../api/client';
 import type { MessageSearchResult, SavedView } from '@chat-app/shared';
 import { useSnackbar } from '../contexts/SnackbarContext';
@@ -35,6 +36,10 @@ export default function SearchPage() {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [searchFilters, setSearchFilters] = useState<SearchFilters>({});
+  // Step 7c-1: チップ入力で指定されたフィルタ（SearchFilterPanel と独立に管理し、effective ではマージ）
+  const [chipFilters, setChipFilters] = useState<Partial<SearchFilters>>({});
+  // Step 7c-1: チップ入力欄の生テキスト
+  const [rawSearchText, setRawSearchText] = useState('');
   const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
 
@@ -42,12 +47,19 @@ export default function SearchPage() {
   const [savedViewsKey, setSavedViewsKey] = useState(0);
   const savedViewsPromise = useMemo(() => api.savedViews.list(), [savedViewsKey]);
 
+  // Step 7c-1: SearchFilterPanel 由来のフィルタとチップ由来のフィルタをマージ
+  const effectiveFilters: SearchFilters = useMemo(
+    () => ({ ...searchFilters, ...chipFilters }),
+    [searchFilters, chipFilters],
+  );
+
   const hasAnyFilter =
-    (searchFilters.tagIds?.length ?? 0) > 0 ||
-    !!searchFilters.dateFrom ||
-    !!searchFilters.dateTo ||
-    searchFilters.userId !== undefined ||
-    searchFilters.hasAttachment !== undefined;
+    (effectiveFilters.tagIds?.length ?? 0) > 0 ||
+    !!effectiveFilters.dateFrom ||
+    !!effectiveFilters.dateTo ||
+    effectiveFilters.userId !== undefined ||
+    effectiveFilters.hasAttachment !== undefined ||
+    effectiveFilters.channelId !== undefined;
 
   // 検索クエリ or フィルタが変わったら API を呼ぶ（300ms debounce）
   useEffect(() => {
@@ -60,7 +72,7 @@ export default function SearchPage() {
     const timer = setTimeout(() => {
       setSearching(true);
       api.messages
-        .search(trimmedQuery, searchFilters)
+        .search(trimmedQuery, effectiveFilters)
         .then(({ messages }) => setSearchResults(messages))
         .catch((err) => {
           console.error(err);
@@ -68,7 +80,7 @@ export default function SearchPage() {
         .finally(() => setSearching(false));
     }, 300);
     return () => clearTimeout(timer);
-  }, [searchQuery, searchFilters, hasAnyFilter]);
+  }, [searchQuery, effectiveFilters, hasAnyFilter]);
 
   const handleNavigate = useCallback(
     (channelId: number, messageId: number) => {
@@ -102,6 +114,7 @@ export default function SearchPage() {
   );
 
   // Step 7b: ピルクリックで保存ビューの query を state に反映
+  // Step 7c-1: チップ入力欄もリセットして保存ビューの内容に揃える
   const handleSelectSavedView = useCallback((view: SavedView) => {
     setSearchQuery(view.query.keyword ?? '');
     setSearchFilters({
@@ -111,7 +124,18 @@ export default function SearchPage() {
       hasAttachment: view.query.hasAttachment,
       tagIds: view.query.tagIds,
     });
+    setChipFilters({});
+    setRawSearchText(view.query.keyword ?? '');
   }, []);
+
+  // Step 7c-1: ChipFilterSection から resolved を受け取って searchQuery と chipFilters に反映
+  const handleChipResolved = useCallback(
+    ({ keyword, filters }: { keyword: string; filters: Partial<SearchFilters> }) => {
+      setSearchQuery(keyword);
+      setChipFilters(filters);
+    },
+    [],
+  );
 
   // Step 7b: 保存ビュー削除
   const handleDeleteSavedView = useCallback(
@@ -149,15 +173,13 @@ export default function SearchPage() {
             gap: 1,
           }}
         >
-          <TextField
-            fullWidth
-            size="small"
-            placeholder="メッセージを検索..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            inputProps={{ 'aria-label': 'メッセージ検索' }}
-            autoFocus
-          />
+          <Suspense fallback={null}>
+            <ChipFilterSection
+              value={rawSearchText}
+              onTextChange={setRawSearchText}
+              onResolved={handleChipResolved}
+            />
+          </Suspense>
           <Suspense fallback={null}>
             <SavedViewsSection
               promise={savedViewsPromise}

--- a/packages/client/src/utils/__tests__/parseSearchChips.test.ts
+++ b/packages/client/src/utils/__tests__/parseSearchChips.test.ts
@@ -1,0 +1,122 @@
+/**
+ * テスト対象: utils/parseSearchChips.ts (Step 7c-1)
+ *
+ * 検索クエリ文字列を Slack 風のチップ構文でパースする純粋関数。
+ * 認識する構文:
+ *   - from:username      → fromUsername
+ *   - in:channelname     → inChannelName
+ *   - has:file           → hasFile = true
+ *   - before:YYYY-MM-DD  → beforeDate
+ *   - after:YYYY-MM-DD   → afterDate
+ *   - tag:tagname        → tagName (1 件のみ Step 7c-1 では対応)
+ *   - それ以外           → keyword (空白区切りで結合)
+ *
+ * `has:link` は Step 7c スコープ外。
+ *
+ * 戦略: 同期関数なので props/state なし、純粋にテキスト → 構造化オブジェクトの変換テスト
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseSearchChips } from '../parseSearchChips';
+
+describe('parseSearchChips (Step 7c-1)', () => {
+  describe('キーワードのみ', () => {
+    it('プレーンテキストはすべて keyword に入る', () => {
+      expect(parseSearchChips('hello')).toEqual({ keyword: 'hello' });
+    });
+
+    it('複数単語は空白区切りで keyword に結合される', () => {
+      expect(parseSearchChips('hello world foo')).toEqual({ keyword: 'hello world foo' });
+    });
+
+    it('空文字 / 空白のみは keyword が空文字になる', () => {
+      expect(parseSearchChips('').keyword).toBe('');
+      expect(parseSearchChips('   ').keyword).toBe('');
+    });
+  });
+
+  describe('チップ構文', () => {
+    it('from:alice から fromUsername=alice を抽出する', () => {
+      const r = parseSearchChips('from:alice');
+      expect(r.fromUsername).toBe('alice');
+      expect(r.keyword).toBe('');
+    });
+
+    it('in:general から inChannelName=general を抽出する', () => {
+      const r = parseSearchChips('in:general');
+      expect(r.inChannelName).toBe('general');
+    });
+
+    it('has:file から hasFile=true を抽出する', () => {
+      const r = parseSearchChips('has:file');
+      expect(r.hasFile).toBe(true);
+    });
+
+    it('before:2026-01-01 から beforeDate=2026-01-01 を抽出する', () => {
+      const r = parseSearchChips('before:2026-01-01');
+      expect(r.beforeDate).toBe('2026-01-01');
+    });
+
+    it('after:2026-01-01 から afterDate=2026-01-01 を抽出する', () => {
+      const r = parseSearchChips('after:2026-01-01');
+      expect(r.afterDate).toBe('2026-01-01');
+    });
+
+    it('tag:urgent から tagName=urgent を抽出する', () => {
+      const r = parseSearchChips('tag:urgent');
+      expect(r.tagName).toBe('urgent');
+    });
+  });
+
+  describe('複数構文の組み合わせ', () => {
+    it('from:alice has:file 議事録 から keyword=議事録 / fromUsername=alice / hasFile=true を抽出', () => {
+      const r = parseSearchChips('from:alice has:file 議事録');
+      expect(r.keyword).toBe('議事録');
+      expect(r.fromUsername).toBe('alice');
+      expect(r.hasFile).toBe(true);
+    });
+
+    it('構文の出現順は問わない', () => {
+      const r1 = parseSearchChips('議事録 from:alice has:file');
+      const r2 = parseSearchChips('has:file 議事録 from:alice');
+      expect(r1.keyword).toBe('議事録');
+      expect(r2.keyword).toBe('議事録');
+      expect(r1.fromUsername).toBe('alice');
+      expect(r2.fromUsername).toBe('alice');
+      expect(r1.hasFile).toBe(true);
+      expect(r2.hasFile).toBe(true);
+    });
+
+    it('構文と通常テキストが混在しても適切に分離される', () => {
+      const r = parseSearchChips('リリース from:alice in:general 計画');
+      expect(r.keyword).toBe('リリース 計画');
+      expect(r.fromUsername).toBe('alice');
+      expect(r.inChannelName).toBe('general');
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('値が空の構文 (from:) はキーワードとして扱われる', () => {
+      const r = parseSearchChips('from: hello');
+      expect(r.fromUsername).toBeUndefined();
+      expect(r.keyword).toBe('from: hello');
+    });
+
+    it('日付の形式が不正な before:invalid はキーワードとして扱われる', () => {
+      const r = parseSearchChips('before:invalid');
+      expect(r.beforeDate).toBeUndefined();
+      expect(r.keyword).toBe('before:invalid');
+    });
+
+    it('has:invalid (file 以外) はキーワードとして扱われる', () => {
+      const r = parseSearchChips('has:link');
+      expect(r.hasFile).toBeUndefined();
+      expect(r.keyword).toBe('has:link');
+    });
+
+    it('未知のプレフィックス foo:bar はキーワードとして扱われる', () => {
+      const r = parseSearchChips('foo:bar');
+      expect(r.keyword).toBe('foo:bar');
+    });
+  });
+});

--- a/packages/client/src/utils/parseSearchChips.ts
+++ b/packages/client/src/utils/parseSearchChips.ts
@@ -1,0 +1,103 @@
+/**
+ * 検索クエリ文字列を Slack 風のチップ構文でパースする (Step 7c-1)。
+ *
+ * 認識する構文:
+ *   - from:username      → fromUsername
+ *   - in:channelname     → inChannelName
+ *   - has:file           → hasFile = true
+ *   - before:YYYY-MM-DD  → beforeDate
+ *   - after:YYYY-MM-DD   → afterDate
+ *   - tag:tagname        → tagName (1 件のみ)
+ *   - それ以外           → keyword (空白区切りで結合)
+ *
+ * `has:link` は Step 7c スコープ外。
+ *
+ * パース結果は **マスタデータ照合前** の文字列ベース。
+ * 親 (ChipFilterInput / SearchPage) で users / channels / tags 配列と照合して
+ * userId / channelId / tagIds に変換する。
+ */
+
+export interface ParsedSearchChips {
+  keyword: string;
+  fromUsername?: string;
+  inChannelName?: string;
+  hasFile?: boolean;
+  beforeDate?: string;
+  afterDate?: string;
+  tagName?: string;
+}
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDate(text: string): boolean {
+  if (!ISO_DATE_REGEX.test(text)) return false;
+  const d = new Date(text);
+  return !isNaN(d.getTime());
+}
+
+export function parseSearchChips(text: string): ParsedSearchChips {
+  const result: ParsedSearchChips = { keyword: '' };
+  const keywordParts: string[] = [];
+
+  if (!text || text.trim() === '') {
+    return result;
+  }
+
+  // 空白区切りでトークン分割
+  const tokens = text.trim().split(/\s+/);
+
+  for (const token of tokens) {
+    const colonIdx = token.indexOf(':');
+    if (colonIdx <= 0 || colonIdx === token.length - 1) {
+      // プレフィックスなし or 値が空 → キーワード扱い
+      keywordParts.push(token);
+      continue;
+    }
+    const prefix = token.slice(0, colonIdx);
+    const value = token.slice(colonIdx + 1);
+
+    switch (prefix) {
+      case 'from':
+        if (result.fromUsername === undefined) result.fromUsername = value;
+        else keywordParts.push(token);
+        break;
+      case 'in':
+        if (result.inChannelName === undefined) result.inChannelName = value;
+        else keywordParts.push(token);
+        break;
+      case 'has':
+        if (value === 'file' && result.hasFile === undefined) {
+          result.hasFile = true;
+        } else {
+          // has:link や has:invalid はキーワードとして扱う
+          keywordParts.push(token);
+        }
+        break;
+      case 'before':
+        if (isValidDate(value) && result.beforeDate === undefined) {
+          result.beforeDate = value;
+        } else {
+          keywordParts.push(token);
+        }
+        break;
+      case 'after':
+        if (isValidDate(value) && result.afterDate === undefined) {
+          result.afterDate = value;
+        } else {
+          keywordParts.push(token);
+        }
+        break;
+      case 'tag':
+        if (result.tagName === undefined) result.tagName = value;
+        else keywordParts.push(token);
+        break;
+      default:
+        // 未知のプレフィックスはキーワード扱い
+        keywordParts.push(token);
+        break;
+    }
+  }
+
+  result.keyword = keywordParts.join(' ');
+  return result;
+}

--- a/packages/server/src/__tests__/integration/search.test.ts
+++ b/packages/server/src/__tests__/integration/search.test.ts
@@ -175,6 +175,52 @@ describe('GET /api/messages/search', () => {
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body.messages)).toBe(true);
     });
+
+    // Step 7c-1: in:channel 構文サポートのため channelId フィルタを追加
+    it('q が空でも channelId が指定されていれば 200 を返す', async () => {
+      const { token } = await registerUser(app, 'fsearch5', 'fsearch5@example.com');
+
+      const res = await request(app)
+        .get('/api/messages/search?q=&channelId=1')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.messages)).toBe(true);
+    });
+
+    it('channelId フィルタで指定したチャンネルのメッセージのみ返る', async () => {
+      const { token, userId } = await registerUser(app, 'fsearch6', 'fsearch6@example.com');
+      const ch1 = await createChannelReq(app, token, 'fsearch-ch6a');
+      const ch2 = await createChannelReq(app, token, 'fsearch-ch6b');
+      const msg1 = await insertMessage(ch1, userId, 'チャンネル1の投稿');
+      await insertMessage(ch2, userId, 'チャンネル2の投稿');
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=&channelId=${ch1}`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      const ids = (res.body.messages as { id: number }[]).map((m) => m.id);
+      expect(ids).toContain(msg1);
+      expect(res.body.messages).toHaveLength(1);
+    });
+
+    it('channelId + q の組み合わせで keyword + チャンネル絞り込みが効く', async () => {
+      const { token, userId } = await registerUser(app, 'fsearch7', 'fsearch7@example.com');
+      const ch1 = await createChannelReq(app, token, 'fsearch-ch7a');
+      const ch2 = await createChannelReq(app, token, 'fsearch-ch7b');
+      const target = await insertMessage(ch1, userId, '探したい単語スシ');
+      await insertMessage(ch1, userId, 'ch1だけど不一致');
+      await insertMessage(ch2, userId, '探したい単語スシ'); // 別チャンネル
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('スシ')}&channelId=${ch1}`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.messages).toHaveLength(1);
+      expect(res.body.messages[0].id).toBe(target);
+    });
   });
 
   describe('Step 6b: mentionedToMe / unreadOnly フィルタ', () => {

--- a/packages/server/src/controllers/messageController.ts
+++ b/packages/server/src/controllers/messageController.ts
@@ -14,8 +14,16 @@ export async function searchMessages(
     const qRaw = req.query.q;
     const q = typeof qRaw === 'string' ? qRaw.trim() : '';
 
-    const { dateFrom, dateTo, userId, hasAttachment, tagIds, mentionedToMe, unreadOnly } =
-      req.query;
+    const {
+      dateFrom,
+      dateTo,
+      userId,
+      hasAttachment,
+      tagIds,
+      mentionedToMe,
+      unreadOnly,
+      channelId,
+    } = req.query;
 
     const filters = {
       dateFrom: typeof dateFrom === 'string' && dateFrom ? dateFrom : undefined,
@@ -38,6 +46,11 @@ export async function searchMessages(
       // Step 6b: 自分宛メンションのみ / 未読のみフィルタ
       mentionedToMe: mentionedToMe === 'true' ? true : undefined,
       unreadOnly: unreadOnly === 'true' ? true : undefined,
+      // Step 7c-1: in:channel チップ構文用
+      channelId:
+        typeof channelId === 'string' && channelId !== '' && !isNaN(Number(channelId))
+          ? Number(channelId)
+          : undefined,
     };
 
     const hasAnyFilter =
@@ -46,7 +59,8 @@ export async function searchMessages(
       filters.userId !== undefined ||
       filters.hasAttachment !== undefined ||
       (filters.tagIds !== undefined && filters.tagIds.length > 0) ||
-      filters.mentionedToMe === true;
+      filters.mentionedToMe === true ||
+      filters.channelId !== undefined;
 
     // q が空でフィルターも未指定なら 400
     if (q === '' && !hasAnyFilter) {

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -371,7 +371,8 @@ export async function searchMessages(
   filters: MessageSearchFilters = {},
   currentUserId?: number,
 ): Promise<MessageSearchResult[]> {
-  const { dateFrom, dateTo, userId, hasAttachment, tagIds, mentionedToMe, unreadOnly } = filters;
+  const { dateFrom, dateTo, userId, hasAttachment, tagIds, mentionedToMe, unreadOnly, channelId } =
+    filters;
 
   // dateFrom > dateTo の場合は空を返す（早期リターン）
   if (
@@ -456,6 +457,12 @@ export async function searchMessages(
   if (userId !== undefined) {
     sql += ` AND m.user_id = $${idx++}`;
     params.push(userId);
+  }
+
+  // Step 7c-1: in:channel チップ構文用のチャンネル絞り込み
+  if (channelId !== undefined) {
+    sql += ` AND m.channel_id = $${idx++}`;
+    params.push(channelId);
   }
 
   sql += ` ORDER BY m.created_at DESC LIMIT 100`;

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -71,6 +71,8 @@ export interface MessageSearchFilters {
   mentionedToMe?: boolean;
   /** Step 6b: mentionedToMe と組み合わせて、is_read = false のメンションのみに絞る */
   unreadOnly?: boolean;
+  /** Step 7c-1: 検索ページのチップ構文 `in:channel` で指定するチャンネル ID */
+  channelId?: number;
 }
 
 export interface SendMessageInput {


### PR DESCRIPTION
## 概要

検索ページに Slack 風のチップ式フィルタ入力欄を追加する。`from:user` / `in:channel` / `has:file` / `before:date` / `after:date` / `tag:name` の構文をリアルタイム解析し、認識した条件をチップとして可視化する。`in:channel` 対応のためサーバー側 `searchMessages` に `channelId` フィルタを追加する。

## 変更内容

### 新規（クライアント）
- `utils/parseSearchChips.ts` — Slack 風構文を解析する純粋関数
- `utils/__tests__/parseSearchChips.test.ts` — 16 件
- `components/Search/ChipFilterInput.tsx` — `TextField` + 解析チップ表示の純粋コンポーネント。`users` / `channels` / `tags` を props で受け取り、大文字小文字無視で照合して ID 変換。マスタに該当が無い項目はチップ表示するが filters には反映しない（color="default" で色分け）
- `__tests__/ChipFilterInput.test.tsx` — 12 件
- `components/Search/ChipFilterSection.tsx` — Suspense ラッパー。`Promise.all([api.auth.users(), api.channels.list(), api.tags.suggestions('', 1000)])` を `use(promise)` で解決して ChipFilterInput にマスタを渡す（Step 7b で確立した別ファイル化パターンを踏襲）

### サーバー
- `shared/types/message.ts` — `MessageSearchFilters.channelId?: number` 追加
- `server/services/messageService.ts` — `searchMessages` に `channelId` フィルタ追加
- `server/controllers/messageController.ts` — `channelId` クエリ受け付け + `hasAnyFilter` 判定に追加
- `server/__tests__/integration/search.test.ts` — `channelId` フィルタテスト 3 件追加

### クライアント既存
- `api/client.ts` — `messages.search` の URLSearchParams に `channelId` 送信を追加
- `components/Chat/SearchFilterPanel.tsx` — `SearchFilters` 型に `channelId?: number` 追加
- `pages/SearchPage.tsx` — 既存 `TextField` を `ChipFilterSection` に置換。`searchFilters` (SearchFilterPanel 由来) と独立に `chipFilters` (チップ由来) を管理し、`effectiveFilters` でマージして検索 API に渡す
- `__tests__/SearchPage.test.tsx` — `ChipFilterSection` スタブ追加 + Step 7c-1 テスト 1 件追加

### Step 7c-1 スコープ外（後続 Step 7c-2）
- 結果リストのスニペット + ハイライト

### `has:link` の扱い
スコープ外。`has:link` 入力時は parser が「未認識」として keyword に含めるため、結果に副作用なし。

## 影響範囲
- フロント / サーバー両方を変更（channelId フィルタの追加）
- DB 変更なし
- `SearchFilterPanel` は変更なし。`ChipFilterInput` と併存し両方からフィルタを設定できる

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1447 件、skip 0）
- [x] バックエンドユニットテストがすべてパスする（1376 件、search に +3 件）
- [x] ビルドが正常に完了すること
- [ ] (手動確認) `/search` で `from:alice has:file 議事録` のような構文を入力 → チップ表示 + 検索結果が絞り込まれる

## 関連Issue
Fixes #N/A (UI/UX ブラッシュアップ Step 7c-1)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に実施
- [x] `it.todo` / 空ボディの `it` が残っていない

## 既存テストの変更
| ファイル | 変更箇所 | 理由 |
|---|---|---|
| `__tests__/SearchPage.test.tsx` | `ChipFilterSection` スタブを追加（aria-label="メッセージ検索" の input + emit ボタン）/ 旧 TextField 直接テストはスタブ経由で動作する | 仕様変更（クエリ入力欄が `ChipFilterSection` に変わったため） |
| `server/__tests__/integration/search.test.ts` | Step 7c-1 章として `channelId` フィルタテスト 3 件追加 | 新機能追加 |

## 実装メモ
- `chipFilters` と `searchFilters` のマージ動作: チップ由来のフィールドが SearchFilterPanel 由来を上書きする（Step 7c-1 の合理的妥協。双方向同期は Step 8 後に検討）
- マスタ照合時、該当が無いユーザー/チャンネル/タグはチップを「グレー（color=\"default\"）」で表示し、フィルタへは反映しない（誤入力時の UX）