### PR TITLE
feat(search): 結果リストのスニペット + ハイライト (Step 7c-2)

### DIFF
--- a/packages/client/src/__tests__/SearchResults.test.tsx
+++ b/packages/client/src/__tests__/SearchResults.test.tsx
@@ -149,4 +149,51 @@ describe('SearchResults', () => {
       expect(screen.getByText('#bug')).toBeInTheDocument();
     });
   });
+
+  describe('スニペット + ハイライト (Step 7c-2)', () => {
+    it('keyword props 指定時、マッチ部分が <mark> でハイライト表示される', () => {
+      const result = makeResult({
+        content: JSON.stringify({ ops: [{ insert: '今夜のリリース計画について\n' }] }),
+      });
+      const { container } = render(
+        <SearchResults results={[result]} onNavigate={vi.fn()} keyword="リリース" />,
+      );
+      const mark = container.querySelector('mark');
+      expect(mark).not.toBeNull();
+      expect(mark?.textContent).toBe('リリース');
+    });
+
+    it('keyword 未指定（または空）のとき、ハイライトなしで本文先頭抜粋が表示される', () => {
+      const result = makeResult({
+        content: JSON.stringify({ ops: [{ insert: '今夜のリリース計画について\n' }] }),
+      });
+      const { container } = render(<SearchResults results={[result]} onNavigate={vi.fn()} />);
+      expect(container.querySelector('mark')).toBeNull();
+      expect(screen.getByTestId('search-result-snippet')).toHaveTextContent(
+        '今夜のリリース計画について',
+      );
+    });
+
+    it('keyword は大文字小文字を無視してマッチする', () => {
+      const result = makeResult({
+        content: JSON.stringify({ ops: [{ insert: 'Hello World\n' }] }),
+      });
+      const { container } = render(
+        <SearchResults results={[result]} onNavigate={vi.fn()} keyword="hello" />,
+      );
+      const mark = container.querySelector('mark');
+      expect(mark?.textContent).toBe('Hello'); // 元のケース保持
+    });
+
+    it('マッチがない場合は本文先頭抜粋を表示する（<mark> なし）', () => {
+      const result = makeResult({
+        content: JSON.stringify({ ops: [{ insert: 'テスト投稿\n' }] }),
+      });
+      const { container } = render(
+        <SearchResults results={[result]} onNavigate={vi.fn()} keyword="存在しない単語" />,
+      );
+      expect(container.querySelector('mark')).toBeNull();
+      expect(screen.getByTestId('search-result-snippet')).toHaveTextContent('テスト投稿');
+    });
+  });
 });

--- a/packages/client/src/components/Chat/SearchResults.tsx
+++ b/packages/client/src/components/Chat/SearchResults.tsx
@@ -4,10 +4,16 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import type { MessageSearchResult } from '@chat-app/shared';
 import TagChip from './TagChip';
 import { extractMessageText } from '../../utils/extractMessageText';
+import { buildSnippet } from '../../utils/buildSnippet';
 
 interface Props {
   results: MessageSearchResult[];
   onNavigate: (channelId: number, messageId: number) => void;
+  /**
+   * Step 7c-2: マッチ部分のハイライト + スニペット切り出し用のキーワード。
+   * 未指定 / 空のときは本文先頭抜粋を表示しハイライトしない。
+   */
+  keyword?: string;
 }
 
 function formatDate(iso: string): string {
@@ -20,7 +26,7 @@ function formatDate(iso: string): string {
   });
 }
 
-export default function SearchResults({ results, onNavigate }: Props) {
+export default function SearchResults({ results, onNavigate, keyword = '' }: Props) {
   const handleCopy = (result: MessageSearchResult) => {
     const url = `${window.location.origin}${window.location.pathname}?channel=${result.channelId}#message-${result.id}`;
     void navigator.clipboard.writeText(url);
@@ -79,9 +85,32 @@ export default function SearchResults({ results, onNavigate }: Props) {
                 {extractMessageText(result.rootMessageContent)}
               </Typography>
             )}
-            <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-              {extractMessageText(result.content)}
-            </Typography>
+            {(() => {
+              const snippet = buildSnippet(extractMessageText(result.content), keyword);
+              return (
+                <Typography
+                  variant="body2"
+                  sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                  data-testid="search-result-snippet"
+                >
+                  {snippet.before}
+                  {snippet.match && (
+                    <Box
+                      component="mark"
+                      sx={{
+                        bgcolor: 'var(--accent-soft, #fff59d)',
+                        color: 'inherit',
+                        px: 0.25,
+                        borderRadius: 0.5,
+                      }}
+                    >
+                      {snippet.match}
+                    </Box>
+                  )}
+                  {snippet.after}
+                </Typography>
+              );
+            })()}
             {result.tags && result.tags.length > 0 && (
               <Box
                 sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 0.5 }}

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -214,7 +214,11 @@ export default function SearchPage() {
                 <CircularProgress size={24} />
               </Box>
             ) : (
-              <SearchResults results={searchResults} onNavigate={handleNavigate} />
+              <SearchResults
+                results={searchResults}
+                onNavigate={handleNavigate}
+                keyword={searchQuery}
+              />
             )}
           </Box>
         </Box>

--- a/packages/client/src/utils/__tests__/buildSnippet.test.ts
+++ b/packages/client/src/utils/__tests__/buildSnippet.test.ts
@@ -1,0 +1,115 @@
+/**
+ * テスト対象: utils/buildSnippet.ts (Step 7c-2)
+ *
+ * 検索結果に表示するスニペット (前後 N 文字を抜粋 + マッチ部分を分離) を生成する純粋関数。
+ *
+ * 出力形式:
+ *   { before: string, match: string, after: string }
+ *   - before: マッチ部分の前のテキスト (必要に応じて先頭省略記号 …)
+ *   - match : マッチ部分の本体
+ *   - after : マッチ部分の後のテキスト (必要に応じて末尾省略記号 …)
+ *
+ * keyword が空 / マッチしない場合は match='', before=テキスト先頭抜粋, after='' を返す。
+ *
+ * 戦略: 同期関数なので props/state なし、純粋に文字列入出力を検証する。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildSnippet } from '../buildSnippet';
+
+describe('buildSnippet (Step 7c-2)', () => {
+  describe('キーワードなし / 未マッチ', () => {
+    it('keyword が空文字のとき、本文の先頭抜粋を before に返し match / after は空文字', () => {
+      const r = buildSnippet('hello world', '');
+      expect(r.before).toBe('hello world');
+      expect(r.match).toBe('');
+      expect(r.after).toBe('');
+    });
+
+    it('keyword がテキストに含まれないとき、本文の先頭抜粋を before に返し match は空文字', () => {
+      const r = buildSnippet('hello world', 'xyz');
+      expect(r.match).toBe('');
+      expect(r.before).toBe('hello world');
+    });
+
+    it('テキストが maxLength より短いときは省略記号を付けない', () => {
+      const r = buildSnippet('short', '', { maxLength: 80 });
+      expect(r.before).toBe('short');
+      expect(r.before.endsWith('…')).toBe(false);
+    });
+
+    it('テキストが maxLength より長いときは末尾に省略記号を付ける', () => {
+      const long = 'あ'.repeat(100);
+      const r = buildSnippet(long, '', { maxLength: 50 });
+      expect(r.before.endsWith('…')).toBe(true);
+      // 抜粋本体は 50 文字 + 省略記号 1 文字
+      expect(r.before.length).toBe(51);
+    });
+  });
+
+  describe('マッチあり', () => {
+    it('テキスト中央でマッチするとき、前後 N 文字を抜粋し before に先頭省略 / after に末尾省略を付ける', () => {
+      const text = 'A'.repeat(50) + 'TARGET' + 'B'.repeat(50);
+      const r = buildSnippet(text, 'TARGET', { contextLength: 10 });
+      expect(r.match).toBe('TARGET');
+      expect(r.before.startsWith('…')).toBe(true);
+      expect(r.before.endsWith('A'.repeat(10))).toBe(true);
+      expect(r.after.startsWith('B'.repeat(10))).toBe(true);
+      expect(r.after.endsWith('…')).toBe(true);
+    });
+
+    it('テキスト先頭でマッチするとき、before に先頭省略は付かない', () => {
+      const text = 'TARGET' + 'B'.repeat(50);
+      const r = buildSnippet(text, 'TARGET', { contextLength: 10 });
+      expect(r.before).toBe('');
+      expect(r.match).toBe('TARGET');
+      expect(r.after.startsWith('B'.repeat(10))).toBe(true);
+      expect(r.after.endsWith('…')).toBe(true);
+    });
+
+    it('テキスト末尾でマッチするとき、after に末尾省略は付かない', () => {
+      const text = 'A'.repeat(50) + 'TARGET';
+      const r = buildSnippet(text, 'TARGET', { contextLength: 10 });
+      expect(r.match).toBe('TARGET');
+      expect(r.after).toBe('');
+      expect(r.before.startsWith('…')).toBe(true);
+      expect(r.before.endsWith('A'.repeat(10))).toBe(true);
+    });
+
+    it('大文字小文字を無視してマッチする (HELLO で hello を検索)', () => {
+      const r = buildSnippet('Hello WORLD', 'hello');
+      expect(r.match).toBe('Hello'); // 元のケースを保持
+    });
+
+    it('複数マッチがある場合は最初のマッチを基準にする', () => {
+      const text = 'first FOO middle FOO last';
+      const r = buildSnippet(text, 'foo', { contextLength: 100 });
+      // 最初のマッチ (位置 6) が match に
+      expect(r.match).toBe('FOO');
+      // before に "first " (6 文字), 末尾省略なし (after にもう一つの FOO が含まれる)
+      expect(r.before).toBe('first ');
+      expect(r.after).toBe(' middle FOO last');
+    });
+
+    it('マッチ部分は元の大文字小文字を保持する (検索が小文字でも match は大文字のまま)', () => {
+      const r = buildSnippet('TARGET word', 'target');
+      expect(r.match).toBe('TARGET');
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('text が空文字のとき、すべて空文字で返る', () => {
+      const r = buildSnippet('', 'foo');
+      expect(r.before).toBe('');
+      expect(r.match).toBe('');
+      expect(r.after).toBe('');
+    });
+
+    it('text と keyword が完全一致のとき、match 全体 / before / after が空', () => {
+      const r = buildSnippet('hello', 'hello');
+      expect(r.match).toBe('hello');
+      expect(r.before).toBe('');
+      expect(r.after).toBe('');
+    });
+  });
+});

--- a/packages/client/src/utils/buildSnippet.ts
+++ b/packages/client/src/utils/buildSnippet.ts
@@ -1,0 +1,79 @@
+/**
+ * 検索結果のスニペット生成 (Step 7c-2)。
+ *
+ * keyword に対する text 中の最初のマッチを基準に、前後 N 文字を抜粋して返す。
+ * マッチ部分は元の大文字小文字を保持して `match` フィールドに切り出す。
+ *
+ * 出力:
+ *   - `before`: マッチ部分の前のテキスト (必要に応じて先頭省略記号 `…`)
+ *   - `match` : マッチ部分の本体 (= keyword 長と同じ、元のケース)
+ *   - `after` : マッチ部分の後のテキスト (必要に応じて末尾省略記号 `…`)
+ *
+ * keyword が空 / マッチしない場合は { before: text 先頭抜粋, match: '', after: '' }。
+ *
+ * 大文字小文字を無視してマッチする。複数マッチは最初のみ。
+ */
+
+export interface SnippetParts {
+  before: string;
+  match: string;
+  after: string;
+}
+
+interface Options {
+  /** マッチ前後それぞれの抜粋文字数 (デフォルト 30) */
+  contextLength?: number;
+  /** keyword なしのときの先頭抜粋最大長 (デフォルト 80) */
+  maxLength?: number;
+  /** 省略記号 (デフォルト `…`) */
+  ellipsis?: string;
+}
+
+const DEFAULT_CONTEXT = 30;
+const DEFAULT_MAX = 80;
+const DEFAULT_ELLIPSIS = '…';
+
+export function buildSnippet(text: string, keyword: string, options: Options = {}): SnippetParts {
+  const contextLength = options.contextLength ?? DEFAULT_CONTEXT;
+  const maxLength = options.maxLength ?? DEFAULT_MAX;
+  const ellipsis = options.ellipsis ?? DEFAULT_ELLIPSIS;
+
+  if (!text) return { before: '', match: '', after: '' };
+
+  const trimmedKeyword = keyword.trim();
+
+  // keyword なし / マッチしない → 先頭抜粋
+  if (trimmedKeyword === '') {
+    return buildHeadSnippet(text, maxLength, ellipsis);
+  }
+
+  const lowerText = text.toLowerCase();
+  const lowerKeyword = trimmedKeyword.toLowerCase();
+  const matchIdx = lowerText.indexOf(lowerKeyword);
+
+  if (matchIdx === -1) {
+    return buildHeadSnippet(text, maxLength, ellipsis);
+  }
+
+  const matchEnd = matchIdx + trimmedKeyword.length;
+  const matchText = text.slice(matchIdx, matchEnd);
+
+  // 前後抜粋
+  const beforeStart = Math.max(0, matchIdx - contextLength);
+  const afterEnd = Math.min(text.length, matchEnd + contextLength);
+
+  let before = text.slice(beforeStart, matchIdx);
+  let after = text.slice(matchEnd, afterEnd);
+
+  if (beforeStart > 0) before = ellipsis + before;
+  if (afterEnd < text.length) after = after + ellipsis;
+
+  return { before, match: matchText, after };
+}
+
+function buildHeadSnippet(text: string, maxLength: number, ellipsis: string): SnippetParts {
+  if (text.length <= maxLength) {
+    return { before: text, match: '', after: '' };
+  }
+  return { before: text.slice(0, maxLength) + ellipsis, match: '', after: '' };
+}


### PR DESCRIPTION
## 概要

検索結果リストでクエリにマッチした部分を `<mark>` でハイライト表示し、マッチ位置の前後を切り出してスニペット表示する。これにより検索結果の視認性が向上する。Step 7 系（検索ページ作り直し）の最終ステップ。

## 変更内容

### 新規
- `packages/client/src/utils/buildSnippet.ts` — 検索結果に表示するスニペット生成の純粋関数
  - 戻り値: `{ before: string, match: string, after: string }`
  - 大文字小文字無視マッチ、複数マッチは最初のみ
  - 前後 30 文字（デフォルト）抜粋、抜粋境界に `…` 付与
  - keyword 空 / 未マッチ時は本文先頭抜粋（デフォルト最大 80 文字）
- `packages/client/src/utils/__tests__/buildSnippet.test.ts` — 12 件

### 修正
- `packages/client/src/components/Chat/SearchResults.tsx`
  - `keyword?: string` props 追加（デフォルト空文字）
  - `buildSnippet(extractMessageText(result.content), keyword)` で本文を分割
  - `<Box component="mark">` + `bgcolor: 'var(--accent-soft, #fff59d)'` でハイライト
- `packages/client/src/__tests__/SearchResults.test.tsx`
  - スニペット + ハイライトテスト 4 件追加（マッチ時 / 未指定時 / 大文字小文字無視 / 未マッチ時）
- `packages/client/src/pages/SearchPage.tsx`
  - `<SearchResults>` に `keyword={searchQuery}` を渡す

## 影響範囲
- フロントのみ。サーバー / DB 変更なし
- 検索結果リストの表示挙動が変わる（スニペット抜粋 + ハイライト）
- `result.rootMessageContent`（スレッド親メッセージ表示）はそのまま、ハイライト対象外
- ChatPage 内の SearchResults 使用箇所はもう存在しない（Step 7a で撤去済み）ため、新 props 追加の影響は SearchPage のみ

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1463 件、skip 0）
- [x] バックエンドユニットテストがすべてパスする（1376 件、追加なし）
- [x] ビルドが正常に完了すること
- [ ] (手動確認) `/search` でクエリ入力 → 結果カードに `<mark>` ハイライト + 前後 30 文字のスニペット表示

## 関連Issue
Fixes #N/A (UI/UX ブラッシュアップ Step 7c-2 / Step 7 系完了)

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント (PROGRESS.md) の更新はマージ後に実施
- [x] `it.todo` / 空ボディの `it` が残っていない

## 既存テストの変更
変更なし（テスト追加のみ）。

## 実装メモ
- ハイライトカラー: `var(--accent-soft, #fff59d)` でフォールバック付き（CSS 変数が解決されない環境でも黄色系）
- 大文字小文字無視マッチ + 元のケース保持（`Hello WORLD` を `hello` で検索 → match は `Hello`）
- スニペット境界の `…` は全角省略記号
- `extractMessageText` で本文を Quill Delta / TipTap / プレーンテキストから純粋テキスト化してから snippet 生成