### PR TITLE
feat(layout): 6 ページを AppLayout 化 + 統一見出し行 (Step 8a)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -35,7 +35,7 @@
 | 6a / 6b / 6c / 6d | InboxPage 新設 + メンション/スレッドタブ + バッジ + クイックアクション | #212 / #213 / #214 / #215 | 🟢 完了 | 2026-05-02 |
 | - (修正) | Inbox/Thread/Search の生 JSON 表示修正 + extractMessageText 共通化 | [#216](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/216) | 🟢 完了 | 2026-05-03 |
 | 7a / 7b / 7c-1 / 7c-2 | 検索ページ新設 + 保存ビューピル + チップ式フィルタ + スニペットハイライト | #217 / #218 / #219 / #220 | 🟢 完了 | 2026-05-03 |
-| **8a** | **AppLayout 適用拡大** (BookmarkPage / DMPage / TemplatesPage / AdminPage / ProfilePage / FilesPage を AppLayout 化) | - | ⚪ 未着手 | - |
+| **8a** | **AppLayout 適用拡大** (BookmarkPage / DMPage / TemplatesPage / AdminPage / ProfilePage / FilesPage を AppLayout 化) | (作成中) | 🟡 進行中 | - |
 | **8b** | **ChatPage 動線確保** (Rail に「チャット」追加 / Inbox/Calendar/TaskBoard の Sidebar に ChannelList / SearchPage onSelect 修正 / URL 更新 / DM 開始導線 / ホームラベル再考) | - | ⚪ 未着手 | - |
 | **8c** | **Inbox カードクリック遷移** (Mentions/Threads/Reminders カードに `/chat?channel=X#message-Y` ナビ追加) | - | ⚪ 未着手 | - |
 | **8d** | **Sidebar 開閉機構** (折りたたみトグル + localStorage 永続化 + ページごと初期状態) | - | ⚪ 未着手 | - |
@@ -61,26 +61,32 @@
 これらに加えて Step 1〜7 の刷新で生じた追加の動線・UX 課題が複数あり、Step 9 (モバイル) 前に解消する。
 
 #### Step 8a: AppLayout 適用拡大
-**ブランチ**: `feature/brush-up-uiux-step-8a-applayout-expand`（予定）
+**ブランチ**: `feature/brush-up-uiux-step-8a-applayout-expand`
 
 **対象ページ（AppLayout 非適用 → 適用化）**:
-- `pages/BookmarkPage.tsx`
-- `pages/DMPage.tsx`
-- `pages/TemplatesPage.tsx`
-- `pages/AdminPage.tsx`
-- `pages/ProfilePage.tsx`
-- `pages/FilesPage.tsx`
+- `pages/BookmarkPage.tsx` 🟢
+- `pages/DMPage.tsx` 🟢
+- `pages/TemplatesPage.tsx` 🟢
+- `pages/AdminPage.tsx` 🟢
+- `pages/ProfilePage.tsx` 🟢
+- `pages/FilesPage.tsx` 🟢
 
 **タスク**:
-- [ ] 各ページの独自 `AppBar` を撤去し `AppLayout` の `sidebar` / `children` 構造に揃える
-- [ ] 各ページの page heading（h1 / 見出し）を統一様式に
-- [ ] `FilesPage` と `ChatPage` 内 `activeTab='files'` の二重化を整理（E-6）
-- [ ] AppLayout 化により SidebarFooter (テーマ切替・通知・プロフィール・ログアウト) への到達経路が全ページで確保される（E-3）
-- [ ] DMPage 内 `DmConversationList` と新規 `SidebarDmList` の重複を整理
+- [x] 各ページの独自 `AppBar` を撤去し `AppLayout` の `sidebar={<Box />}` / `children` 構造に揃える
+- [x] 各ページのメイン領域上部に統一見出し行 (Icon + h6 + `borderBottom: 1px solid var(--border)` + `background: var(--bg-elev)` + `px:3 py:2`) を配置
+- [x] `FilesPage` と `ChatPage` 内 `activeTab='files'` の二重化整理 (E-6) — 既に `ChannelFilesTab` 共有で整理済みであることを確認、FilesPage 側を AppLayout 化することで完了
+- [x] AppLayout 化により SidebarFooter (テーマ切替・通知・プロフィール・ログアウト) への到達経路が全ページで確保される (E-3)
+- [x] App.tsx で `/admin /bookmarks /templates /profile /channels/:channelId/files` を `SocketProvider` 内に移動し、Rail の DM/メンション未読バッジを全ページで動作させる
+- [x] BookmarkPage の `handleJump` を `/?channel=...` → `/chat?channel=...` に変更 (ルート / が Inbox に変わったため)
 
 **スコープ外**:
 - AppLayout の `sidebar` 中身の標準化（ChannelList を全ページに置くか等）→ Step 8b
 - Sidebar の開閉機構 → Step 8d
+- DMPage 内 `DmConversationList` と新規 `SidebarDmList` の重複整理 → Step 8b で再検討（DMPage 内部では DmConversationList を据え置き、AppLayout の sidebar は空 Box）
+
+**テスト**:
+- `BookmarkPage.test.tsx` `DMPage.test.tsx` `TemplatesPage.test.tsx` `AdminPage.test.tsx` `ProfilePage.test.tsx` `FilesPage.test.tsx` に Step 8a describe ブロック (合計 23 it) 追加
+- 既存テスト保護のため `ProfilePage.changePassword.test.tsx` `AuditLogView.test.tsx` にも `vi.mock('../components/Layout/AppLayout', ...)` を追加
 
 #### Step 8b: ChatPage 動線確保
 **ブランチ**: `feature/brush-up-uiux-step-8b-chat-routing`（予定）

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -171,11 +171,15 @@ function AppRoutes() {
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/invite/:token" element={<InviteRedeemPage />} />
         <Route path="/g/:token" element={<GuestChannelPage />} />
+        {/* Step 8a: AppLayout 適用拡大に伴い、Rail の DM/メンション未読バッジを動作させるため
+            SocketProvider 内に移動 */}
         <Route
           path="/profile"
           element={
             <RequireAuth>
-              <ProfilePage />
+              <SocketProvider>
+                <ProfilePage />
+              </SocketProvider>
             </RequireAuth>
           }
         />
@@ -183,7 +187,9 @@ function AppRoutes() {
           path="/admin"
           element={
             <RequireAuth>
-              <AdminPage />
+              <SocketProvider>
+                <AdminPage />
+              </SocketProvider>
             </RequireAuth>
           }
         />
@@ -191,7 +197,9 @@ function AppRoutes() {
           path="/bookmarks"
           element={
             <RequireAuth>
-              <BookmarkPage />
+              <SocketProvider>
+                <BookmarkPage />
+              </SocketProvider>
             </RequireAuth>
           }
         />
@@ -199,7 +207,9 @@ function AppRoutes() {
           path="/templates"
           element={
             <RequireAuth>
-              <TemplatesPage />
+              <SocketProvider>
+                <TemplatesPage />
+              </SocketProvider>
             </RequireAuth>
           }
         />
@@ -235,7 +245,9 @@ function AppRoutes() {
           path="/channels/:channelId/files"
           element={
             <RequireAuth>
-              <FilesPageWrapper />
+              <SocketProvider>
+                <FilesPageWrapper />
+              </SocketProvider>
             </RequireAuth>
           }
         />

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -6,7 +6,7 @@
  * 統計・ユーザー管理・チャンネル管理の各タブの動作を検証する。
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -21,6 +21,13 @@ vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
   return { ...actual, useNavigate: () => mockNavigate };
 });
+
+// Step 8a: AppLayout を最小スタブ化
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
 
 const mockAdminUsers: AdminUser[] = [
   {
@@ -716,5 +723,43 @@ describe('AdminPage: 通報キュータブ (#116)', () => {
     await openReportQueueTab();
     await waitFor(() => expect(screen.getByText('bob')).toBeInTheDocument());
     expect(mockedApi.admin.reports.list).toHaveBeenCalled();
+  });
+});
+
+// Step 8a: AppLayout 適用拡大
+describe('AdminPage: Step 8a: AppLayout 化', () => {
+  it('admin ユーザーで AppLayout 内にレンダリングされる', async () => {
+    await renderAdminPage();
+    expect(screen.getByTestId('app-layout-stub')).toBeInTheDocument();
+  });
+
+  it('独自 AppBar (position="fixed") が撤去されている', async () => {
+    await renderAdminPage();
+    expect(document.querySelector('.MuiAppBar-positionFixed')).toBeNull();
+  });
+
+  it('AppLayout 内に統一見出し行「管理画面」が表示される', async () => {
+    await renderAdminPage();
+    const layout = screen.getByTestId('app-layout-stub');
+    expect(within(layout).getByRole('heading', { name: '管理画面' })).toBeInTheDocument();
+  });
+
+  it('非管理者はトップにリダイレクトされる (既存挙動維持)', async () => {
+    mockedUseAuth.mockReturnValue({
+      user: { id: 2, username: 'bob', role: 'user', isActive: true },
+    });
+    await renderAdminPage();
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('6 つのタブが AppLayout 内に表示される', async () => {
+    await renderAdminPage();
+    const layout = screen.getByTestId('app-layout-stub');
+    expect(within(layout).getByRole('tab', { name: '統計' })).toBeInTheDocument();
+    expect(within(layout).getByRole('tab', { name: 'ユーザー管理' })).toBeInTheDocument();
+    expect(within(layout).getByRole('tab', { name: 'チャンネル管理' })).toBeInTheDocument();
+    expect(within(layout).getByRole('tab', { name: '監査ログ' })).toBeInTheDocument();
+    expect(within(layout).getByRole('tab', { name: /モデレーション設定/ })).toBeInTheDocument();
+    expect(within(layout).getByRole('tab', { name: /通報キュー/ })).toBeInTheDocument();
   });
 });

--- a/packages/client/src/__tests__/AuditLogView.test.tsx
+++ b/packages/client/src/__tests__/AuditLogView.test.tsx
@@ -58,6 +58,13 @@ vi.mock('../contexts/AuthContext', () => ({
   useAuth: vi.fn(),
 }));
 
+// Step 8a: AdminPage が AppLayout を内側に含むようになったため最小スタブ化する
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
+
 import { api } from '../api/client';
 import { useAuth } from '../contexts/AuthContext';
 

--- a/packages/client/src/__tests__/BookmarkPage.test.tsx
+++ b/packages/client/src/__tests__/BookmarkPage.test.tsx
@@ -6,7 +6,7 @@
  *   - ブックマーク登録・解除操作はAPIモックを通じて検証する
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -41,6 +41,13 @@ vi.mock('../components/Chat/RichEditor', () => ({
     <div data-testid="rich-editor">
       <button onClick={onCancel}>Cancel</button>
     </div>
+  ),
+}));
+
+// Step 8a: AppLayout を最小スタブ化 (Rail / SidebarFooter の hook 連鎖を切るため)
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
   ),
 }));
 
@@ -178,7 +185,31 @@ describe('BookmarkPage', () => {
       mockApi.bookmarks.list.mockResolvedValue({ bookmarks: [makeBookmark()] });
       await renderBookmarkPage();
       await userEvent.click(screen.getByText('Hello world'));
-      expect(mockNavigate).toHaveBeenCalledWith('/?channel=1&message=10');
+      // Step 8a: ルート / は Inbox に変わったため /chat?... へ遷移する
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=1&message=10');
+    });
+  });
+
+  // Step 8a: AppLayout 適用拡大 — 独自 AppBar 撤去 + AppLayout 内レンダ + 統一見出し行
+  describe('Step 8a: AppLayout 化', () => {
+    beforeEach(() => {
+      mockApi.bookmarks.list.mockResolvedValue({ bookmarks: [] });
+    });
+
+    it('AppLayout 内にレンダリングされる', async () => {
+      await renderBookmarkPage();
+      expect(screen.getByTestId('app-layout-stub')).toBeInTheDocument();
+    });
+
+    it('独自 AppBar の戻るボタン (aria-label="戻る") が撤去されている', async () => {
+      await renderBookmarkPage();
+      expect(screen.queryByRole('button', { name: '戻る' })).not.toBeInTheDocument();
+    });
+
+    it('AppLayout 内に統一見出し行「ブックマーク」が表示される', async () => {
+      await renderBookmarkPage();
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(within(layout).getByRole('heading', { name: 'ブックマーク' })).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/DMPage.test.tsx
+++ b/packages/client/src/__tests__/DMPage.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import type { DmConversationWithDetails, DmMessage } from '@chat-app/shared';
@@ -62,6 +62,13 @@ vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
   return { ...actual, useNavigate: () => mockNavigate };
 });
+
+// Step 8a: AppLayout を最小スタブ化
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
 
 import { api } from '../api/client';
 import DMPage, { resetDmConversationsCache } from '../pages/DMPage';
@@ -439,5 +446,45 @@ describe('サイドバーのDM一覧', () => {
         expect(visibleNumericBadges.length).toBe(0);
       });
     });
+  });
+});
+
+// Step 8a: AppLayout 適用拡大
+describe('DMPage: Step 8a: AppLayout 化', () => {
+  beforeEach(() => {
+    Object.keys(socketHandlers).forEach((k) => {
+      delete socketHandlers[k];
+    });
+    mockApi.dm.markAsRead.mockResolvedValue(undefined);
+    mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+    mockApi.dm.listConversations.mockResolvedValue({ conversations: [] });
+    resetDmConversationsCache();
+  });
+
+  it('AppLayout 内にレンダリングされる', async () => {
+    await renderDMPage();
+    expect(screen.getByTestId('app-layout-stub')).toBeInTheDocument();
+  });
+
+  it('独自 AppBar の戻るボタン (aria-label="戻る") が撤去されている', async () => {
+    await renderDMPage();
+    expect(screen.queryByRole('button', { name: '戻る' })).not.toBeInTheDocument();
+  });
+
+  it('AppLayout 内に統一見出し行「ダイレクトメッセージ」が表示される', async () => {
+    await renderDMPage();
+    const layout = screen.getByTestId('app-layout-stub');
+    // 注: 内部の DmConversationList にも同じ見出しがあるため getAllByRole で 1 件以上を確認。
+    // Step 8b で Sidebar 整理時に DmConversationList の見出しを撤去予定。
+    const headings = within(layout).getAllByRole('heading', { name: 'ダイレクトメッセージ' });
+    expect(headings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('内部の DmConversationList とメッセージエリアが従来どおり表示される', async () => {
+    mockApi.dm.listConversations.mockResolvedValue({
+      conversations: [makeConversation()],
+    });
+    await renderDMPage();
+    expect(screen.getByText('bob')).toBeInTheDocument();
   });
 });

--- a/packages/client/src/__tests__/FilesPage.test.tsx
+++ b/packages/client/src/__tests__/FilesPage.test.tsx
@@ -6,7 +6,7 @@
  *   - ファイルタイプフィルタリング操作をAPIモックを通じて検証する
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -29,6 +29,13 @@ vi.mock('../api/client', () => ({
 
 vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => ({ emit: vi.fn(), on: vi.fn(), off: vi.fn() }),
+}));
+
+// Step 8a: AppLayout を最小スタブ化
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
 }));
 
 import { api } from '../api/client';
@@ -240,6 +247,38 @@ describe('FilesPage', () => {
       await userEvent.click(screen.getByRole('button', { name: 'プレビュー' }));
       expect(openSpy).toHaveBeenCalledWith('/uploads/doc.pdf', '_blank');
       openSpy.mockRestore();
+    });
+  });
+
+  // Step 8a: AppLayout 適用拡大
+  describe('Step 8a: AppLayout 化', () => {
+    beforeEach(() => {
+      mockApi.channels.getAttachments.mockResolvedValue({ attachments: [] });
+    });
+
+    it('AppLayout 内にレンダリングされる', async () => {
+      await renderFilesPage();
+      expect(screen.getByTestId('app-layout-stub')).toBeInTheDocument();
+    });
+
+    it('独自 AppBar の戻るボタン (aria-label="戻る") が撤去されている', async () => {
+      await renderFilesPage();
+      expect(screen.queryByRole('button', { name: '戻る' })).not.toBeInTheDocument();
+    });
+
+    it('AppLayout 内に統一見出し行「ファイル一覧 — #{channelName}」が表示される', async () => {
+      await renderFilesPage(1, 'general');
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(
+        within(layout).getByRole('heading', { name: /ファイル一覧.*general/ }),
+      ).toBeInTheDocument();
+    });
+
+    it('ChannelFilesTab のフィルター UI が AppLayout 内に表示される', async () => {
+      await renderFilesPage();
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(within(layout).getByRole('button', { name: 'すべて' })).toBeInTheDocument();
+      expect(within(layout).getByRole('button', { name: '画像' })).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/ProfilePage.changePassword.test.tsx
+++ b/packages/client/src/__tests__/ProfilePage.changePassword.test.tsx
@@ -59,6 +59,13 @@ vi.mock('../contexts/SnackbarContext', () => ({
   }),
 }));
 
+// Step 8a: ProfilePage が AppLayout を内側に含むようになったため最小スタブ化する
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
+
 beforeEach(() => {
   vi.clearAllMocks();
 });

--- a/packages/client/src/__tests__/ProfilePage.test.tsx
+++ b/packages/client/src/__tests__/ProfilePage.test.tsx
@@ -9,7 +9,7 @@
  *   - mockUserState オブジェクトを beforeEach でリセットし、テストごとに状態を制御する
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import ProfilePage from '../pages/ProfilePage';
@@ -58,6 +58,13 @@ vi.mock('../contexts/SnackbarContext', () => ({
     showError: mockShowError,
     showInfo: vi.fn(),
   }),
+}));
+
+// Step 8a: AppLayout を最小スタブ化
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
 }));
 
 beforeEach(() => {
@@ -214,7 +221,9 @@ describe('ProfilePage', () => {
       await userEvent.click(screen.getByRole('button', { name: /パスワードを変更/i }));
 
       await waitFor(() => {
-        expect(screen.getByText('新しいパスワードは8文字以上で入力してください')).toBeInTheDocument();
+        expect(
+          screen.getByText('新しいパスワードは8文字以上で入力してください'),
+        ).toBeInTheDocument();
       });
       expect(mockChangePassword).not.toHaveBeenCalled();
     });
@@ -265,6 +274,32 @@ describe('ProfilePage', () => {
       await waitFor(() => {
         expect(mockShowError).toHaveBeenCalledWith('現在のパスワードが正しくありません');
       });
+    });
+  });
+
+  // Step 8a: AppLayout 適用拡大
+  describe('Step 8a: AppLayout 化', () => {
+    it('AppLayout 内にレンダリングされる', () => {
+      render(<ProfilePage />);
+      expect(screen.getByTestId('app-layout-stub')).toBeInTheDocument();
+    });
+
+    it('独自ヘッダの戻るボタン (aria-label="戻る") が撤去されている', () => {
+      render(<ProfilePage />);
+      expect(screen.queryByRole('button', { name: '戻る' })).not.toBeInTheDocument();
+    });
+
+    it('AppLayout 内に統一見出し行「プロフィール設定」が表示される', () => {
+      render(<ProfilePage />);
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(within(layout).getByRole('heading', { name: 'プロフィール設定' })).toBeInTheDocument();
+    });
+
+    it('プロフィール編集 / パスワード変更フォームが AppLayout 内に表示される', () => {
+      render(<ProfilePage />);
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(within(layout).getByLabelText('表示名')).toBeInTheDocument();
+      expect(within(layout).getByLabelText('現在のパスワード')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/TemplatesPage.test.tsx
+++ b/packages/client/src/__tests__/TemplatesPage.test.tsx
@@ -6,7 +6,7 @@
  *   - テンプレートの CRUD 操作と並び替えを重点的に検証する
  */
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
@@ -27,6 +27,13 @@ vi.mock('../api/client', () => ({
       reorder: vi.fn(),
     },
   },
+}));
+
+// Step 8a: AppLayout を最小スタブ化
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
 }));
 
 import { api } from '../api/client';
@@ -283,6 +290,32 @@ describe('TemplatesPage', () => {
 
       const downButtons = screen.getAllByRole('button', { name: '下に移動' });
       expect(downButtons[downButtons.length - 1]).toBeDisabled();
+    });
+  });
+
+  // Step 8a: AppLayout 適用拡大
+  describe('Step 8a: AppLayout 化', () => {
+    it('AppLayout 内にレンダリングされる', async () => {
+      await renderPage();
+      expect(screen.getByTestId('app-layout-stub')).toBeInTheDocument();
+    });
+
+    it('独自 AppBar の戻るボタン (aria-label="戻る") が撤去されている', async () => {
+      await renderPage();
+      expect(screen.queryByRole('button', { name: '戻る' })).not.toBeInTheDocument();
+    });
+
+    it('AppLayout 内に統一見出し行「テンプレート管理」が表示される', async () => {
+      await renderPage();
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(within(layout).getByRole('heading', { name: 'テンプレート管理' })).toBeInTheDocument();
+    });
+
+    it('テンプレート CRUD UI が AppLayout 内に表示される', async () => {
+      await renderPage();
+      const layout = screen.getByTestId('app-layout-stub');
+      expect(within(layout).getByPlaceholderText('タイトルを入力')).toBeInTheDocument();
+      expect(within(layout).getByRole('button', { name: '追加' })).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -1,10 +1,8 @@
 import { useState, useMemo, use, Suspense, Component, ReactNode } from 'react';
 import {
-  AppBar,
   Box,
   Tab,
   Tabs,
-  Toolbar,
   Typography,
   Card,
   CardContent,
@@ -21,13 +19,10 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
-  IconButton,
-  Tooltip,
   Paper,
   Avatar,
   Checkbox,
 } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import PeopleIcon from '@mui/icons-material/People';
 import ForumIcon from '@mui/icons-material/Forum';
@@ -42,6 +37,7 @@ import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
 import AuditLogView from '../components/AuditLogView';
 import ModerationContent from '../components/Admin/ModerationContent';
 import ModerationQueue from '../components/Admin/ModerationQueue';
+import AppLayout from '../components/Layout/AppLayout';
 
 // ─── 統計タブ ────────────────────────────────────────────────
 const STAT_CARDS = [
@@ -493,74 +489,70 @@ export default function AdminPage() {
   );
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      {/* AppLayout と同じ AppBar */}
-      <AppBar position="fixed" sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
-        <Toolbar sx={{ gap: 1 }}>
-          <Tooltip title="ホーム画面に戻る">
-            <IconButton color="inherit" aria-label="ホーム画面に戻る" onClick={() => navigate('/')}>
-              <ArrowBackIcon />
-            </IconButton>
-          </Tooltip>
-
-          <AdminPanelSettingsIcon sx={{ fontSize: 22 }} />
-
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            管理画面
-          </Typography>
-        </Toolbar>
-      </AppBar>
-
-      {/* AppBar の高さ分のスペーサー */}
-      <Toolbar />
-
-      {/* コンテンツ */}
-      <Box sx={{ flexGrow: 1, p: 3, bgcolor: 'grey.50' }}>
-        <Tabs
-          value={tab}
-          onChange={(_, v: number) => setTab(v)}
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
           sx={{
-            mb: 3,
-            bgcolor: 'white',
-            borderRadius: 1,
-            border: '1px solid',
-            borderColor: 'divider',
-            px: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
           }}
         >
-          <Tab label="統計" />
-          <Tab label="ユーザー管理" />
-          <Tab label="チャンネル管理" />
-          <Tab label="監査ログ" />
-          <Tab label="モデレーション設定" />
-          <Tab label="通報キュー" />
-        </Tabs>
+          <AdminPanelSettingsIcon />
+          <Typography variant="h6">管理画面</Typography>
+        </Box>
 
-        {tab === 0 && (
-          <ErrorBoundary>
-            <Suspense fallback={fallback}>
-              <StatsContent statsPromise={statsPromise} />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-        {tab === 1 && (
-          <ErrorBoundary>
-            <Suspense fallback={fallback}>
-              <UsersContent usersPromise={usersPromise} currentUserId={user.id} />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-        {tab === 2 && (
-          <ErrorBoundary>
-            <Suspense fallback={fallback}>
-              <ChannelsContent channelsPromise={channelsPromise} />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-        {tab === 3 && <AuditLogView actors={actors} />}
-        {tab === 4 && <ModerationContent />}
-        {tab === 5 && <ModerationQueue />}
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 3, bgcolor: 'grey.50' }}>
+          <Tabs
+            value={tab}
+            onChange={(_, v: number) => setTab(v)}
+            sx={{
+              mb: 3,
+              bgcolor: 'white',
+              borderRadius: 1,
+              border: '1px solid',
+              borderColor: 'divider',
+              px: 1,
+            }}
+          >
+            <Tab label="統計" />
+            <Tab label="ユーザー管理" />
+            <Tab label="チャンネル管理" />
+            <Tab label="監査ログ" />
+            <Tab label="モデレーション設定" />
+            <Tab label="通報キュー" />
+          </Tabs>
+
+          {tab === 0 && (
+            <ErrorBoundary>
+              <Suspense fallback={fallback}>
+                <StatsContent statsPromise={statsPromise} />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+          {tab === 1 && (
+            <ErrorBoundary>
+              <Suspense fallback={fallback}>
+                <UsersContent usersPromise={usersPromise} currentUserId={user.id} />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+          {tab === 2 && (
+            <ErrorBoundary>
+              <Suspense fallback={fallback}>
+                <ChannelsContent channelsPromise={channelsPromise} />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+          {tab === 3 && <AuditLogView actors={actors} />}
+          {tab === 4 && <ModerationContent />}
+          {tab === 5 && <ModerationQueue />}
+        </Box>
       </Box>
-    </Box>
+    </AppLayout>
   );
 }

--- a/packages/client/src/pages/BookmarkPage.tsx
+++ b/packages/client/src/pages/BookmarkPage.tsx
@@ -9,17 +9,15 @@ import {
   ListItemSecondaryAction,
   IconButton,
   CircularProgress,
-  AppBar,
-  Toolbar,
   Tooltip,
   Divider,
   Paper,
   Avatar,
 } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import BookmarkIcon from '@mui/icons-material/Bookmark';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { useNavigate } from 'react-router-dom';
+import AppLayout from '../components/Layout/AppLayout';
 import { api } from '../api/client';
 import type { Bookmark } from '@chat-app/shared';
 
@@ -63,7 +61,8 @@ function BookmarkListContent({ bookmarksPromise }: BookmarkListContentProps) {
 
   const handleJump = (bookmark: Bookmark) => {
     if (bookmark.message?.channelId) {
-      navigate(`/?channel=${bookmark.message.channelId}&message=${bookmark.messageId}`);
+      // Step 8a: ルート / は Inbox に変わったため /chat 配下に遷移する
+      navigate(`/chat?channel=${bookmark.message.channelId}&message=${bookmark.messageId}`);
     }
   };
 
@@ -146,36 +145,40 @@ function BookmarkListContent({ bookmarksPromise }: BookmarkListContentProps) {
 
 function BookmarkPageInner() {
   const [bookmarksPromise] = useState(() => getOrCreateBookmarksPromise());
-  const navigate = useNavigate();
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Tooltip title="戻る">
-            <IconButton color="inherit" edge="start" onClick={() => navigate(-1)} sx={{ mr: 1 }}>
-              <ArrowBackIcon />
-            </IconButton>
-          </Tooltip>
-          <BookmarkIcon sx={{ mr: 1 }} />
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
+          }}
+        >
+          <BookmarkIcon />
           <Typography variant="h6">ブックマーク</Typography>
-        </Toolbar>
-      </AppBar>
+        </Box>
 
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
-        <Paper elevation={0} variant="outlined" sx={{ maxWidth: 800, mx: 'auto' }}>
-          <Suspense
-            fallback={
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-                <CircularProgress />
-              </Box>
-            }
-          >
-            <BookmarkListContent bookmarksPromise={bookmarksPromise} />
-          </Suspense>
-        </Paper>
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
+          <Paper elevation={0} variant="outlined" sx={{ maxWidth: 800, mx: 'auto' }}>
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+                  <CircularProgress />
+                </Box>
+              }
+            >
+              <BookmarkListContent bookmarksPromise={bookmarksPromise} />
+            </Suspense>
+          </Paper>
+        </Box>
       </Box>
-    </Box>
+    </AppLayout>
   );
 }
 

--- a/packages/client/src/pages/DMPage.tsx
+++ b/packages/client/src/pages/DMPage.tsx
@@ -1,17 +1,8 @@
 import { use, useState, useEffect, useMemo, Suspense } from 'react';
-import {
-  Box,
-  Typography,
-  CircularProgress,
-  AppBar,
-  Toolbar,
-  IconButton,
-  Tooltip,
-  Paper,
-} from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { Box, Typography, CircularProgress, Paper } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+import AppLayout from '../components/Layout/AppLayout';
 import { api } from '../api/client';
 import { useSocket } from '../contexts/SocketContext';
 import { useAuth } from '../contexts/AuthContext';
@@ -245,47 +236,51 @@ interface DMPageInnerProps {
 
 function DMPageInner({ users, currentUserId }: DMPageInnerProps) {
   const [conversationsPromise] = useState(() => getOrCreateConversationsPromise());
-  const navigate = useNavigate();
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Tooltip title="戻る">
-            <IconButton color="inherit" edge="start" onClick={() => navigate(-1)} sx={{ mr: 1 }}>
-              <ArrowBackIcon />
-            </IconButton>
-          </Tooltip>
-          <ChatIcon sx={{ mr: 1 }} />
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
+          }}
+        >
+          <ChatIcon />
           <Typography variant="h6">ダイレクトメッセージ</Typography>
-        </Toolbar>
-      </AppBar>
+        </Box>
 
-      <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
-        <Paper elevation={0} sx={{ height: '100%' }}>
-          <Suspense
-            fallback={
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  height: '100%',
-                }}
-              >
-                <CircularProgress />
-              </Box>
-            }
-          >
-            <DMPageContent
-              conversationsPromise={conversationsPromise}
-              users={users}
-              currentUserId={currentUserId}
-            />
-          </Suspense>
-        </Paper>
+        <Box sx={{ flexGrow: 1, overflow: 'hidden' }}>
+          <Paper elevation={0} sx={{ height: '100%' }}>
+            <Suspense
+              fallback={
+                <Box
+                  sx={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    height: '100%',
+                  }}
+                >
+                  <CircularProgress />
+                </Box>
+              }
+            >
+              <DMPageContent
+                conversationsPromise={conversationsPromise}
+                users={users}
+                currentUserId={currentUserId}
+              />
+            </Suspense>
+          </Paper>
+        </Box>
       </Box>
-    </Box>
+    </AppLayout>
   );
 }
 

--- a/packages/client/src/pages/FilesPage.tsx
+++ b/packages/client/src/pages/FilesPage.tsx
@@ -19,17 +19,14 @@ import {
   ListItemText,
   Paper,
   Chip,
-  AppBar,
-  Toolbar,
 } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import FolderIcon from '@mui/icons-material/Folder';
 import ImageIcon from '@mui/icons-material/Image';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import InsertDriveFileIcon from '@mui/icons-material/InsertDriveFile';
 import DownloadIcon from '@mui/icons-material/Download';
 import VisibilityIcon from '@mui/icons-material/Visibility';
-import { useNavigate } from 'react-router-dom';
+import AppLayout from '../components/Layout/AppLayout';
 import { api } from '../api/client';
 import type { ChannelAttachment } from '@chat-app/shared';
 
@@ -239,32 +236,35 @@ interface FilesPageProps {
 
 /** 直URLアクセス用のスタンドアロンページ */
 export default function FilesPage({ channelId, channelName }: FilesPageProps) {
-  const navigate = useNavigate();
-
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Tooltip title="戻る">
-            <IconButton color="inherit" edge="start" onClick={() => navigate(-1)} sx={{ mr: 1 }}>
-              <ArrowBackIcon />
-            </IconButton>
-          </Tooltip>
-          <FolderIcon sx={{ mr: 1 }} />
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
+          }}
+        >
+          <FolderIcon />
           <Typography variant="h6">ファイル一覧 — #{channelName}</Typography>
-        </Toolbar>
-      </AppBar>
-      <Suspense
-        fallback={
-          <Box
-            sx={{ display: 'flex', flexGrow: 1, alignItems: 'center', justifyContent: 'center' }}
-          >
-            <CircularProgress />
-          </Box>
-        }
-      >
-        <ChannelFilesTab channelId={channelId} />
-      </Suspense>
-    </Box>
+        </Box>
+        <Suspense
+          fallback={
+            <Box
+              sx={{ display: 'flex', flexGrow: 1, alignItems: 'center', justifyContent: 'center' }}
+            >
+              <CircularProgress />
+            </Box>
+          }
+        >
+          <ChannelFilesTab channelId={channelId} />
+        </Suspense>
+      </Box>
+    </AppLayout>
   );
 }

--- a/packages/client/src/pages/ProfilePage.tsx
+++ b/packages/client/src/pages/ProfilePage.tsx
@@ -5,22 +5,20 @@ import {
   TextField,
   Typography,
   Avatar,
-  IconButton,
   Alert,
   CircularProgress,
   Paper,
   Divider,
 } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
-import { useNavigate } from 'react-router-dom';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import { useAuth } from '../contexts/AuthContext';
 import { api } from '../api/client';
 import { getAvatarColor } from '../utils/avatarColor';
 import { useSnackbar } from '../contexts/SnackbarContext';
+import AppLayout from '../components/Layout/AppLayout';
 
 export default function ProfilePage() {
   const { user, updateUser } = useAuth();
-  const navigate = useNavigate();
   const { showSuccess, showError } = useSnackbar();
 
   const [displayName, setDisplayName] = useState(user?.displayName ?? '');
@@ -102,125 +100,147 @@ export default function ProfilePage() {
   const avatarLabel = displayName || user?.username || '';
 
   return (
-    <Box sx={{ maxWidth: 480, mx: 'auto', mt: 4, px: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', mb: 3, gap: 1 }}>
-        <IconButton onClick={() => navigate(-1)} aria-label="戻る">
-          <ArrowBackIcon />
-        </IconButton>
-        <Typography variant="h6">プロフィール設定</Typography>
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
+          }}
+        >
+          <AccountCircleIcon />
+          <Typography variant="h6">プロフィール設定</Typography>
+        </Box>
+
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
+          <Box sx={{ maxWidth: 480, mx: 'auto' }}>
+            <Paper sx={{ p: 3 }}>
+              {/* アバター */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  mb: 3,
+                  gap: 1,
+                }}
+              >
+                {avatarPreview ? (
+                  <Box
+                    data-testid="avatar-preview"
+                    component="img"
+                    src={avatarPreview}
+                    alt="アバタープレビュー"
+                    role="img"
+                    aria-label="アバター"
+                    sx={{ width: 80, height: 80, borderRadius: '50%', objectFit: 'cover' }}
+                  />
+                ) : (
+                  <Avatar
+                    sx={{
+                      width: 80,
+                      height: 80,
+                      fontSize: 32,
+                      bgcolor: getAvatarColor(user?.email ?? ''),
+                    }}
+                  >
+                    {(avatarLabel[0] ?? '').toUpperCase()}
+                  </Avatar>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/*"
+                  style={{ display: 'none' }}
+                  onChange={handleFileChange}
+                  aria-label="アバター画像を選択"
+                />
+                <Button size="small" onClick={() => fileInputRef.current?.click()}>
+                  画像を変更
+                </Button>
+              </Box>
+
+              {/* フォーム */}
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  label="表示名"
+                  value={displayName}
+                  onChange={(e) => setDisplayName(e.target.value)}
+                  fullWidth
+                  inputProps={{ 'aria-label': '表示名' }}
+                />
+                <TextField
+                  label="勤務地"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  fullWidth
+                  inputProps={{ 'aria-label': '勤務地' }}
+                />
+
+                {error && <Alert severity="error">{error}</Alert>}
+
+                <Button
+                  variant="contained"
+                  onClick={() => void handleSave()}
+                  disabled={saving}
+                  startIcon={saving ? <CircularProgress size={16} /> : null}
+                >
+                  保存
+                </Button>
+              </Box>
+
+              <Divider sx={{ my: 3 }} />
+
+              {/* パスワード変更フォーム */}
+              <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
+                パスワード変更
+              </Typography>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  label="現在のパスワード"
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  fullWidth
+                  inputProps={{ 'aria-label': '現在のパスワード' }}
+                />
+                <TextField
+                  label="新しいパスワード"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  fullWidth
+                  inputProps={{ 'aria-label': '新しいパスワード' }}
+                />
+                <TextField
+                  label="新しいパスワード（確認）"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  fullWidth
+                  inputProps={{ 'aria-label': '新しいパスワード（確認）' }}
+                />
+
+                {passwordError && <Alert severity="error">{passwordError}</Alert>}
+
+                <Button
+                  variant="outlined"
+                  onClick={() => void handleChangePassword()}
+                  disabled={changingPassword}
+                  startIcon={changingPassword ? <CircularProgress size={16} /> : null}
+                >
+                  パスワードを変更
+                </Button>
+              </Box>
+            </Paper>
+          </Box>
+        </Box>
       </Box>
-
-      <Paper sx={{ p: 3 }}>
-        {/* アバター */}
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 3, gap: 1 }}>
-          {avatarPreview ? (
-            <Box
-              data-testid="avatar-preview"
-              component="img"
-              src={avatarPreview}
-              alt="アバタープレビュー"
-              role="img"
-              aria-label="アバター"
-              sx={{ width: 80, height: 80, borderRadius: '50%', objectFit: 'cover' }}
-            />
-          ) : (
-            <Avatar
-              sx={{
-                width: 80,
-                height: 80,
-                fontSize: 32,
-                bgcolor: getAvatarColor(user?.email ?? ''),
-              }}
-            >
-              {(avatarLabel[0] ?? '').toUpperCase()}
-            </Avatar>
-          )}
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
-            style={{ display: 'none' }}
-            onChange={handleFileChange}
-            aria-label="アバター画像を選択"
-          />
-          <Button size="small" onClick={() => fileInputRef.current?.click()}>
-            画像を変更
-          </Button>
-        </Box>
-
-        {/* フォーム */}
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            label="表示名"
-            value={displayName}
-            onChange={(e) => setDisplayName(e.target.value)}
-            fullWidth
-            inputProps={{ 'aria-label': '表示名' }}
-          />
-          <TextField
-            label="勤務地"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            fullWidth
-            inputProps={{ 'aria-label': '勤務地' }}
-          />
-
-          {error && <Alert severity="error">{error}</Alert>}
-
-          <Button
-            variant="contained"
-            onClick={() => void handleSave()}
-            disabled={saving}
-            startIcon={saving ? <CircularProgress size={16} /> : null}
-          >
-            保存
-          </Button>
-        </Box>
-
-        <Divider sx={{ my: 3 }} />
-
-        {/* パスワード変更フォーム */}
-        <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 2 }}>
-          パスワード変更
-        </Typography>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            label="現在のパスワード"
-            type="password"
-            value={currentPassword}
-            onChange={(e) => setCurrentPassword(e.target.value)}
-            fullWidth
-            inputProps={{ 'aria-label': '現在のパスワード' }}
-          />
-          <TextField
-            label="新しいパスワード"
-            type="password"
-            value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
-            fullWidth
-            inputProps={{ 'aria-label': '新しいパスワード' }}
-          />
-          <TextField
-            label="新しいパスワード（確認）"
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            fullWidth
-            inputProps={{ 'aria-label': '新しいパスワード（確認）' }}
-          />
-
-          {passwordError && <Alert severity="error">{passwordError}</Alert>}
-
-          <Button
-            variant="outlined"
-            onClick={() => void handleChangePassword()}
-            disabled={changingPassword}
-            startIcon={changingPassword ? <CircularProgress size={16} /> : null}
-          >
-            パスワードを変更
-          </Button>
-        </Box>
-      </Paper>
-    </Box>
+    </AppLayout>
   );
 }

--- a/packages/client/src/pages/TemplatesPage.tsx
+++ b/packages/client/src/pages/TemplatesPage.tsx
@@ -1,6 +1,5 @@
 import { use, useState, Suspense, useCallback } from 'react';
 import {
-  AppBar,
   Box,
   Button,
   CircularProgress,
@@ -10,17 +9,15 @@ import {
   ListItem,
   Paper,
   TextField,
-  Toolbar,
   Tooltip,
   Typography,
 } from '@mui/material';
-import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import ArticleIcon from '@mui/icons-material/Article';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { useNavigate } from 'react-router-dom';
+import AppLayout from '../components/Layout/AppLayout';
 import { api } from '../api/client';
 import type { MessageTemplate } from '@chat-app/shared';
 
@@ -282,36 +279,40 @@ function TemplatesListContent({ templatesPromise }: TemplatesListContentProps) {
 
 function TemplatesPageInner() {
   const [templatesPromise] = useState(() => getOrCreateTemplatesPromise());
-  const navigate = useNavigate();
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-      <AppBar position="static">
-        <Toolbar>
-          <Tooltip title="戻る">
-            <IconButton color="inherit" edge="start" onClick={() => navigate(-1)} sx={{ mr: 1 }}>
-              <ArrowBackIcon />
-            </IconButton>
-          </Tooltip>
-          <ArticleIcon sx={{ mr: 1 }} />
+    <AppLayout sidebar={<Box />}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            px: 3,
+            py: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
+          }}
+        >
+          <ArticleIcon />
           <Typography variant="h6">テンプレート管理</Typography>
-        </Toolbar>
-      </AppBar>
+        </Box>
 
-      <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
-        <Paper elevation={0} variant="outlined" sx={{ maxWidth: 800, mx: 'auto', p: 2 }}>
-          <Suspense
-            fallback={
-              <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
-                <CircularProgress />
-              </Box>
-            }
-          >
-            <TemplatesListContent templatesPromise={templatesPromise} />
-          </Suspense>
-        </Paper>
+        <Box sx={{ flexGrow: 1, overflow: 'auto', p: 2 }}>
+          <Paper elevation={0} variant="outlined" sx={{ maxWidth: 800, mx: 'auto', p: 2 }}>
+            <Suspense
+              fallback={
+                <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
+                  <CircularProgress />
+                </Box>
+              }
+            >
+              <TemplatesListContent templatesPromise={templatesPromise} />
+            </Suspense>
+          </Paper>
+        </Box>
       </Box>
-    </Box>
+    </AppLayout>
   );
 }
 


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8a。AppLayout 非適用だった 6 ページ (BookmarkPage / DMPage / TemplatesPage / AdminPage / ProfilePage / FilesPage) を AppLayout でラップし、独自 AppBar / 戻るボタンを撤去、メイン領域上部に統一見出し行を配置する。これにより全ページで Rail / SidebarFooter (テーマ切替・通知・プロフィール・ログアウト) への到達経路が確保される。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8a セクション参照。

## 変更内容

### 6 ページの AppLayout 化
各ページを以下の構造に統一:

```tsx
<AppLayout sidebar={<Box />}>
  <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
    {/* 統一見出し行 */}
    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 3, py: 2,
               borderBottom: '1px solid var(--border)', background: 'var(--bg-elev)' }}>
      <Icon />
      <Typography variant="h6">{ページタイトル}</Typography>
    </Box>
    {/* メインコンテンツ */}
    <Box sx={{ flexGrow: 1, overflow: 'auto', ... }}>...</Box>
  </Box>
</AppLayout>
```

- 独自 `AppBar` / `Toolbar` / 戻るボタン (`ArrowBackIcon`) を撤去
- 不要になった `useNavigate` / `IconButton` / `Tooltip` の import を整理
- `AdminPage` は `position="fixed"` の AppBar + Toolbar スペーサーを撤去

### App.tsx
`/admin /bookmarks /templates /profile /channels/:channelId/files` の 5 ルートを `SocketProvider` 内に移動。Rail の `useDmUnreadCount` / `useMentionUnreadCount` が socket イベントを購読できるようになり、全ページで未読バッジが動作する。

### BookmarkPage の遷移先変更
`handleJump` の `navigate('/?channel=X&message=Y')` → `navigate('/chat?channel=X&message=Y')`。ルート `/` は Step 6a で Inbox に変わったため、チャンネル + メッセージ位置に飛ばすには `/chat` 配下を指定する必要がある。

### テスト
- 6 ページの `*.test.tsx` に `describe('Step 8a: AppLayout 化', ...)` を追加 (合計 **23 it**)
  - AppLayout (`data-testid="app-layout-stub"`) 内にレンダリングされることの確認
  - 戻るボタン (`role='button', name='戻る'`) が撤去されていることの確認
  - AppLayout 内に統一見出し行 (h6) が表示されることの確認 (`within(layout).getByRole('heading', ...)`)
  - 既存機能 (CRUD / 6 タブ / フォーム / フィルター 等) が AppLayout 内で従来どおり動作することの確認
- 既存テスト保護: `ProfilePage.changePassword.test.tsx` `AuditLogView.test.tsx` に AppLayout 最小スタブ (`vi.mock('../components/Layout/AppLayout', ...)`) を追加
- `BookmarkPage.test.tsx` の既存「メッセージへのジャンプ」テストの期待値を `/?channel=...` → `/chat?channel=...` に更新
- `DMPage` のテストは内部 `DmConversationList` にも同名見出しがあるため `getAllByRole(...).length >= 1` で確認 (Step 8b で sidebar 整理時に DmConversationList の見出し撤去予定)

### PROGRESS.md
Step 8a を 🟡 進行中に更新、対象ページごとの完了マーク・タスク・スコープ外を詳述。

## 影響範囲

### 変更ファイル (16)
- `packages/client/src/pages/{Bookmark,DM,Templates,Admin,Profile,Files}Page.tsx` (6 ページ)
- `packages/client/src/App.tsx` (SocketProvider 拡張)
- `packages/client/src/__tests__/{Bookmark,DM,Templates,Admin,Profile,Files}Page.test.tsx` (Step 8a describe 追加)
- `packages/client/src/__tests__/{ProfilePage.changePassword,AuditLogView}.test.tsx` (AppLayout スタブ追加)
- `doc/brushup-uiux-plan/PROGRESS.md`

### スコープ外（後続 Step）
- AppLayout の `sidebar` (240px 列) に ChannelList / SidebarDmList を入れる作業 → **Step 8b**
- Sidebar 開閉機構 → **Step 8d**
- Inbox カードクリック遷移 → **Step 8c**
- DMPage 内 `DmConversationList` と `SidebarDmList` の重複整理 → **Step 8b** で再検討
- ロゴデザイン刷新 → **Step 8e**
- モバイル対応 → **Step 9**

### 動線が未完成のままの UI 要素
- DMPage の AppLayout sidebar は `<Box />` (空)。内部の `DmConversationList` を据え置き。Step 8b で sidebar 中身を整理予定
- 各ページの AppLayout sidebar は同じく空 `<Box />`。Step 8b で ChannelList / SidebarDmList を入れる予定

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **104 ファイル / 1487 テスト全パス**)
- [x] バックエンドユニットテストへの影響なし (クライアント側の変更のみ)
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint (`npx eslint <変更ファイル>`) → クリーン
- [ ] (手動確認) Light / Dark の各ページでスクリーンショット撮影 → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8a)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8a の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない