### PR TITLE
feat(routing): ChatPage 動線確保 + Sidebar/URL 同期 (Step 8b)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -36,7 +36,7 @@
 | - (修正) | Inbox/Thread/Search の生 JSON 表示修正 + extractMessageText 共通化 | [#216](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/216) | 🟢 完了 | 2026-05-03 |
 | 7a / 7b / 7c-1 / 7c-2 | 検索ページ新設 + 保存ビューピル + チップ式フィルタ + スニペットハイライト | #217 / #218 / #219 / #220 | 🟢 完了 | 2026-05-03 |
 | **8a** | **AppLayout 適用拡大** (BookmarkPage / DMPage / TemplatesPage / AdminPage / ProfilePage / FilesPage を AppLayout 化) | [#221](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/221) | 🟢 完了 | 2026-05-03 |
-| **8b** | **ChatPage 動線確保** (Rail に「チャット」追加 / Inbox/Calendar/TaskBoard の Sidebar に ChannelList / SearchPage onSelect 修正 / URL 更新 / DM 開始導線 / ホームラベル再考) | - | ⚪ 未着手 | - |
+| **8b** | **ChatPage 動線確保** (Rail に「チャット」追加 / Inbox/Calendar/TaskBoard の Sidebar に ChannelList / SearchPage onSelect 修正 / URL 更新 / DM 開始導線 / ホームラベル再考) | (作成中) | 🟡 進行中 | - |
 | **8c** | **Inbox カードクリック遷移** (Mentions/Threads/Reminders カードに `/chat?channel=X#message-Y` ナビ追加) | - | ⚪ 未着手 | - |
 | **8d** | **Sidebar 開閉機構** (折りたたみトグル + localStorage 永続化 + ページごと初期状態) | - | ⚪ 未着手 | - |
 | **8e** | **追加 UX 改善** (TODO #4 ロゴ刷新 / ContextRail DM 開始導線確認 等の残課題) | - | ⚪ 未着手 | - |
@@ -89,17 +89,26 @@
 - 既存テスト保護のため `ProfilePage.changePassword.test.tsx` `AuditLogView.test.tsx` にも `vi.mock('../components/Layout/AppLayout', ...)` を追加
 
 #### Step 8b: ChatPage 動線確保
-**ブランチ**: `feature/brush-up-uiux-step-8b-chat-routing`（予定）
+**ブランチ**: `feature/brush-up-uiux-step-8b-chat-routing`
 
 **タスク**:
-- [ ] Rail に「チャット」項目を追加（`/chat` への直接遷移）
-  - or 「ホーム」ラベルを「Inbox / 受信箱」に変更し、別途「チャンネル」アイコンを追加（E-4 と合わせて検討）
-- [ ] Inbox / Calendar / TaskBoard ページの `sidebar={<Box />}` を ChannelList + SidebarDmList に置換
-- [ ] SearchPage の `<ChannelList onSelect={() => {}} />` を `/chat?channel=X` に navigate するハンドラに置換（B-3）
-- [ ] チャンネル切替時に URL も更新する (history push)、ブラウザ戻るで前のチャンネルに戻れるように（E-1）
-- [ ] チャット未選択時のメイン領域 UX 改善（プレースホルダ / 案内文）（B-4）
-- [ ] 新規 DM 開始の導線（ChannelList の DM ブロックから or 別 UI）（E-2）
-- [ ] InboxPage の `/?channel=X` リダイレクト動作を再検討（E-9: 既存挙動だが分かりにくい）
+- [x] Rail に「チャット」項目を追加（`/chat` への直接遷移、ForumOutlinedIcon、ホーム直後に配置）
+- [x] Inbox / Calendar / TaskBoard ページの `sidebar={<Box />}` を ChannelList + SidebarDmList に置換
+- [x] SearchPage の `<ChannelList onSelect={() => {}} />` を `/chat?channel=X` に navigate するハンドラに置換（保留 TODO #20 解消）
+- [x] チャンネル切替時に URL を `useSearchParams` で `setSearchParams({ channel: id })` 同期、ブラウザ戻る対応（保留 TODO #18 解消）
+- [x] チャット未選択時のメイン領域 UX 改善（ForumIcon + 「チャンネルを選択してください」案内文 + サブテキスト）
+- [x] 新規 DM 開始の導線確保（SidebarDmList の「新規 DM」ボタン経由で全ページから `/dm` 遷移可能、保留 TODO #19 解消）
+
+**スコープ外**:
+- ホームを「Inbox / 受信箱」にラベル変更 → Step 8e
+- InboxPage の `/?channel=X` リダイレクト動作再検討（後方互換維持の現状で動線として成立）→ 8b では据置
+- DmConversationList と SidebarDmList の重複整理 → 据置（DMPage 内部レイアウトはそのまま）
+
+**テスト**:
+- `Rail.test.tsx`: 「上部 6 つ → 7 つ」既存テスト更新 + Step 8b describe (2 it) 追加
+- `InboxPage.test.tsx` `CalendarPage.test.tsx` `TaskBoardPage.test.tsx`: AppLayout stub を sidebar 露出版に拡張、ChannelList/SidebarDmList を stub 化、Step 8b describe (3 it × 3 ファイル) 追加
+- `SearchPage.test.tsx`: AppLayout stub 拡張 + ChannelList stub に onSelect ボタン追加、Step 8b describe (1 it) 追加
+- `ChatPage.test.tsx`: `useSearchParams` 化に伴い `MemoryRouter` ベースの `renderChatPage` ヘルパー導入、`window.location.search` 設定撤去、Step 8b describe (3 it) 追加
 
 #### Step 8c: Inbox カードクリック遷移
 **ブランチ**: `feature/brush-up-uiux-step-8c-inbox-cards`（予定）
@@ -162,11 +171,7 @@
 |---|------|---------------|
 | 4 | Rail 最上部のロゴが暫定デザイン（"C" の四角） | Step 8e |
 | 15 | Inbox の Mentions / Threads / Reminders カードがクリックしても遷移しない | Step 8c |
-| 16 | Rail に「チャット」項目が無く、Inbox/Calendar/TaskBoard の Sidebar が空でチャット画面への動線が見えない | Step 8b |
 | 17 | AppLayout の Sidebar が固定幅 (240px) で開閉できず、コンテンツが空のページではデッドスペース | Step 8d |
-| 18 | チャンネル切替時に URL が更新されない（ブラウザ戻る不可） | Step 8b |
-| 19 | 新規 DM 開始導線が DMPage 内のみ（Inbox / ChatPage から開始できない） | Step 8b |
-| 20 | SearchPage の Sidebar ChannelList の `onSelect` が空関数でクリック無反応 | Step 8b |
 
 ### 🟢 解決済み（参考）
 
@@ -185,6 +190,10 @@
 | 12 | ContextRail のファイルタブ実装 | Step 5b |
 | 13 | ContextRail の予定タブ実機データ化 | Step 5c-1 |
 | 14 | DMPage / BookmarkPage / TemplatesPage / AdminPage / ProfilePage / FilesPage が AppLayout 非適用でレイアウト不統一 | Step 8a |
+| 16 | Rail に「チャット」項目が無く、Inbox/Calendar/TaskBoard の Sidebar が空でチャット画面への動線が見えない | Step 8b |
+| 18 | チャンネル切替時に URL が更新されない（ブラウザ戻る不可） | Step 8b |
+| 19 | 新規 DM 開始導線が DMPage 内のみ（Inbox / ChatPage から開始できない） | Step 8b |
+| 20 | SearchPage の Sidebar ChannelList の `onSelect` が空関数でクリック無反応 | Step 8b |
 
 ---
 

--- a/packages/client/src/__tests__/CalendarPage.test.tsx
+++ b/packages/client/src/__tests__/CalendarPage.test.tsx
@@ -15,7 +15,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
 import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 
 import type { CalendarEvent, Channel } from '@chat-app/shared';
 
@@ -51,8 +51,26 @@ vi.mock('../api/client', () => ({
   },
 }));
 
+// Step 8b: sidebar 中身も検証するため sidebar prop も露出させるスタブに変更
 vi.mock('../components/Layout/AppLayout', () => ({
-  default: ({ children }: { children: ReactNode }) => <>{children}</>,
+  default: ({ children, sidebar }: { children: ReactNode; sidebar?: ReactNode }) => (
+    <div data-testid="app-layout-stub">
+      <div data-testid="app-layout-sidebar">{sidebar}</div>
+      <div data-testid="app-layout-main">{children}</div>
+    </div>
+  ),
+}));
+
+// Step 8b: Sidebar 中身 (ChannelList + SidebarDmList) を stub 化
+vi.mock('../components/Channel/ChannelList', () => ({
+  default: ({ onSelect }: { onSelect?: (id: number, name: string) => void }) => (
+    <div data-testid="channel-list-stub">
+      <button onClick={() => onSelect?.(7, 'general')}>select-channel-7</button>
+    </div>
+  ),
+}));
+vi.mock('../components/Layout/SidebarDmList', () => ({
+  default: () => <div data-testid="sidebar-dm-list-stub" />,
 }));
 
 vi.mock('../contexts/AuthContext', () => ({
@@ -107,7 +125,10 @@ const renderPage = async () => {
   await act(async () => {
     result = render(
       <MemoryRouter initialEntries={['/calendar']}>
-        <CalendarPage />
+        <Routes>
+          <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/chat" element={<div data-testid="chat-page-stub" />} />
+        </Routes>
       </MemoryRouter>,
     );
   });
@@ -462,6 +483,28 @@ describe('CalendarPage', () => {
       });
       expect(pollsConfirmMock).toHaveBeenCalledTimes(1);
       expect(await screen.findByTestId('event-block-500')).toBeInTheDocument();
+    });
+  });
+
+  // Step 8b: Sidebar 中身確保
+  describe('Step 8b: Sidebar 中身確保', () => {
+    it('AppLayout sidebar に ChannelList が表示される', async () => {
+      await renderPage();
+      const sidebar = await screen.findByTestId('app-layout-sidebar');
+      expect(within(sidebar).getByTestId('channel-list-stub')).toBeInTheDocument();
+    });
+
+    it('AppLayout sidebar に SidebarDmList が表示される', async () => {
+      await renderPage();
+      const sidebar = await screen.findByTestId('app-layout-sidebar');
+      expect(within(sidebar).getByTestId('sidebar-dm-list-stub')).toBeInTheDocument();
+    });
+
+    it('ChannelList の onSelect で /chat?channel=X に navigate される', async () => {
+      await renderPage();
+      await screen.findByTestId('app-layout-sidebar');
+      await userEvent.click(screen.getByText('select-channel-7'));
+      expect(await screen.findByTestId('chat-page-stub')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/ChannelList.test.tsx
+++ b/packages/client/src/__tests__/ChannelList.test.tsx
@@ -616,4 +616,59 @@ describe('ChannelList', () => {
       expect(screen.queryByText('管理画面')).not.toBeInTheDocument();
     });
   });
+
+  // Step 8b 追加修正: カテゴリ折りたたみキャッシュ更新
+  describe('Step 8b 追加修正: カテゴリ折りたたみキャッシュ更新', () => {
+    const mockCategoryUpdate = (
+      api.channelCategories as unknown as { update: ReturnType<typeof vi.fn> }
+    ).update;
+
+    it('折りたたみトグル後、unmount → 再 mount しても isCollapsed 状態が維持される', async () => {
+      mockList.mockResolvedValue({ channels: [] });
+      mockCategoryList.mockResolvedValue({
+        categories: [
+          {
+            id: 10,
+            name: 'Work',
+            channelIds: [],
+            isCollapsed: false,
+            position: 0,
+            userId: 1,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        ],
+      });
+      mockCategoryUpdate.mockResolvedValue({});
+
+      let unmountFn: () => void;
+      await act(async () => {
+        const r = render(<ChannelList activeChannelId={null} onSelect={vi.fn()} />);
+        unmountFn = r.unmount;
+      });
+
+      // 初期は展開状態 (「折りたたむ」のラベル)
+      expect(screen.getByLabelText('Workを折りたたむ')).toBeInTheDocument();
+
+      // ヘッダークリックで折りたたむ
+      await userEvent.click(screen.getByTestId('category-header-10'));
+      await waitFor(() => {
+        expect(mockCategoryUpdate).toHaveBeenCalledWith(10, { isCollapsed: true });
+      });
+      // 折りたたみ後: 「展開」ラベル
+      await waitFor(() => {
+        expect(screen.getByLabelText('Workを展開')).toBeInTheDocument();
+      });
+
+      // unmount → 再 mount (mockCategoryList は古い isCollapsed:false のまま、
+      // Promise キャッシュ更新が効いていれば再 mount 時に最新 isCollapsed:true を返す)
+      unmountFn!();
+      await act(async () => {
+        render(<ChannelList activeChannelId={null} onSelect={vi.fn()} />);
+      });
+
+      // 再 mount 後も折りたたみ状態が維持される
+      expect(screen.getByLabelText('Workを展開')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -16,7 +16,23 @@
 import { render, waitFor, act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import ChatPage from '../pages/ChatPage';
+
+// Step 8b: 現在の URL を data-testid で表示する補助コンポーネント
+function LocationDisplay() {
+  const loc = useLocation();
+  return <div data-testid="location-display">{loc.pathname + loc.search}</div>;
+}
+
+// Step 8b: useSearchParams 化に伴い MemoryRouter ラップを共通ヘルパー化
+function renderChatPage(initialPath: string = '/chat') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <ChatPage users={[]} />
+    </MemoryRouter>,
+  );
+}
 
 // ChannelList は activeChannelId を受け取るスタブ — 呼び出し引数を後で検証する
 const MockChannelList = vi.hoisted(() => vi.fn(() => null));
@@ -149,13 +165,8 @@ beforeEach(() => {
 describe('ChatPage', () => {
   describe('URL からのチャンネル初期選択', () => {
     it('?channel=X が URL に含まれるとき、マウント時にそのチャンネルが activeChannelId として選択される', async () => {
-      Object.defineProperty(window, 'location', {
-        value: { search: '?channel=5', hash: '', pathname: '/', origin: 'http://localhost' },
-        writable: true,
-        configurable: true,
-      });
-
-      render(<ChatPage users={[]} />);
+      // Step 8b: useSearchParams 化に伴い MemoryRouter initialEntries 経由で URL を設定する
+      renderChatPage('/chat?channel=5');
 
       // useEffect 後の再レンダリングで ChannelList に activeChannelId=5 が渡されること
       await waitFor(() => {
@@ -167,8 +178,7 @@ describe('ChatPage', () => {
     });
 
     it('?channel が URL に含まれないとき、activeChannelId は null のまま', () => {
-      // window.location.search は beforeEach で '' にリセット済み
-      render(<ChatPage users={[]} />);
+      renderChatPage();
 
       expect(MockChannelList).toHaveBeenLastCalledWith(
         expect.objectContaining({ activeChannelId: null }),
@@ -236,14 +246,14 @@ describe('ChatPage', () => {
     };
 
     it('postingPermission が "everyone" のとき、RichEditor は disabled=false で渡される', async () => {
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       await selectChannelWithPermission('everyone');
 
       expect(getLastDisabled()).toBe(false);
     });
 
     it('postingPermission が "readonly" のとき、RichEditor に disabled=true で渡される', async () => {
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       await selectChannelWithPermission('readonly');
 
       expect(getLastDisabled()).toBe(true);
@@ -251,7 +261,7 @@ describe('ChatPage', () => {
 
     it('postingPermission が "admins" のとき、一般ユーザー（role=user）には disabled=true で渡される', async () => {
       mockUser.current = { id: 1, role: 'user', isActive: true, username: 'testuser' };
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       await selectChannelWithPermission('admins');
 
       expect(getLastDisabled()).toBe(true);
@@ -259,7 +269,7 @@ describe('ChatPage', () => {
 
     it('postingPermission が "admins" のとき、管理者（role=admin）には disabled=false で渡される', async () => {
       mockUser.current = { id: 1, role: 'admin', isActive: true, username: 'adminuser' };
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       await selectChannelWithPermission('admins');
 
       expect(getLastDisabled()).toBe(false);
@@ -281,7 +291,7 @@ describe('ChatPage', () => {
 
     describe('1行ヘッダーのレイアウト', () => {
       it('チャンネル選択時にチャンネル名・トピック・アクションアイコンが同一行に収まる', async () => {
-        render(<ChatPage users={[]} />);
+        renderChatPage();
         await selectChannel();
 
         // ヘッダー行に チャンネル名・ファイル切替アイコン・予約送信アイコンが存在する
@@ -291,7 +301,7 @@ describe('ChatPage', () => {
       });
 
       it('チャンネル未選択時にはヘッダー領域が表示されない', () => {
-        render(<ChatPage users={[]} />);
+        renderChatPage();
 
         // チャンネル選択前はチャンネル名もアイコンも表示されない
         expect(screen.queryByRole('button', { name: /ファイル一覧/i })).not.toBeInTheDocument();
@@ -301,7 +311,7 @@ describe('ChatPage', () => {
 
     describe('ファイル切替アイコンの動作', () => {
       it('初期状態でメッセージ一覧が表示され、ファイル一覧は表示されない', async () => {
-        render(<ChatPage users={[]} />);
+        renderChatPage();
         await selectChannel();
 
         // ChannelFilesTab は表示されない
@@ -310,7 +320,7 @@ describe('ChatPage', () => {
 
       it('ファイル切替アイコンをクリックするとファイル一覧が表示される', async () => {
         const user = userEvent.setup();
-        render(<ChatPage users={[]} />);
+        renderChatPage();
         await selectChannel();
 
         await user.click(screen.getByRole('button', { name: /ファイル一覧/i }));
@@ -320,7 +330,7 @@ describe('ChatPage', () => {
 
       it('ファイル一覧表示中に再度アイコンをクリックするとメッセージ一覧に戻る', async () => {
         const user = userEvent.setup();
-        render(<ChatPage users={[]} />);
+        renderChatPage();
         await selectChannel();
 
         // 1回目クリック → ファイル表示
@@ -334,7 +344,7 @@ describe('ChatPage', () => {
 
       it('ファイル表示中はアイコンが選択状態のスタイルで表示される', async () => {
         const user = userEvent.setup();
-        render(<ChatPage users={[]} />);
+        renderChatPage();
         await selectChannel();
 
         const fileToggleBtn = screen.getByRole('button', { name: /ファイル一覧/i });
@@ -354,7 +364,7 @@ describe('ChatPage', () => {
     describe('既存ダイアログ動作の維持', () => {
       it('予約送信アイコンをクリックすると ScheduledMessagesDialog が開く', async () => {
         const user = userEvent.setup();
-        render(<ChatPage users={[]} />);
+        renderChatPage();
         await selectChannel();
 
         // クリック前: ダイアログ非表示
@@ -385,7 +395,7 @@ describe('ChatPage', () => {
 
     it('Socket "error" イベントを受信したらスナックバーでエラー通知が出る', async () => {
       const handlers = installSocket();
-      render(<ChatPage users={[]} />);
+      renderChatPage();
 
       await waitFor(() => expect(handlers.error).toBeDefined());
       // 実装側 (socket/messageHandler.ts) は 4xx 時にサーバーのエラーメッセージをそのまま転送する。
@@ -398,7 +408,7 @@ describe('ChatPage', () => {
 
     it('Socket "message_warning" イベントを受信したらスナックバーで警告通知が出る', async () => {
       const handlers = installSocket();
-      render(<ChatPage users={[]} />);
+      renderChatPage();
 
       await waitFor(() => expect(handlers.message_warning).toBeDefined());
       handlers.message_warning({
@@ -458,14 +468,14 @@ describe('ChatPage', () => {
     });
 
     it('panelR トグルボタン (aria-label="コンテキストペインを開く") をクリックすると ContextRail が表示される', async () => {
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       expect(screen.queryByTestId('context-rail-stub')).not.toBeInTheDocument();
       await userEvent.click(screen.getByRole('button', { name: 'コンテキストペインを開く' }));
       expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
     });
 
     it('再度クリックすると ContextRail が非表示になる', async () => {
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       const button = screen.getByRole('button', { name: 'コンテキストペインを開く' });
       await userEvent.click(button);
       expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
@@ -474,7 +484,7 @@ describe('ChatPage', () => {
     });
 
     it('開閉状態が localStorage["contextRail.open"] に保存される', async () => {
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       await userEvent.click(screen.getByRole('button', { name: 'コンテキストペインを開く' }));
       await waitFor(() => {
         expect(window.localStorage.getItem('contextRail.open')).toBe('true');
@@ -483,7 +493,7 @@ describe('ChatPage', () => {
 
     it('初期表示時 localStorage["contextRail.open"] が "true" のとき ContextRail が開いた状態で復元される', () => {
       window.localStorage.setItem('contextRail.open', 'true');
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       expect(screen.getByTestId('context-rail-stub')).toBeInTheDocument();
     });
   });
@@ -500,8 +510,55 @@ describe('ChatPage', () => {
 
     it('ChatPage の Main エリアに PinnedMessages の上部バーが描画されない (ContextRail 経由のみで表示)', () => {
       // ContextRail は vi.mock でスタブ化されているため、ChatPage 直接の呼び出しのみ MockPinnedMessages がカウントする
-      render(<ChatPage users={[]} />);
+      renderChatPage();
       expect(MockPinnedMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  // Step 8b: URL 更新 + チャット未選択時 UX (TODO #18 解消)
+  describe('Step 8b: URL 更新 + チャット未選択時 UX', () => {
+    it('チャンネル選択時に URL の ?channel=X が push 更新される', async () => {
+      render(
+        <MemoryRouter initialEntries={['/chat']}>
+          <ChatPage users={[]} />
+          <LocationDisplay />
+        </MemoryRouter>,
+      );
+      // ChannelList stub に渡された onSelect を直接呼ぶ (MockChannelList の最終呼び出し props を使用)
+      const calls = MockChannelList.mock.calls as unknown as Array<
+        [
+          {
+            onSelect: (id: number, name: string, channel?: unknown) => void;
+          },
+        ]
+      >;
+      await act(async () => {
+        calls[calls.length - 1][0].onSelect(7, 'general');
+      });
+      expect(screen.getByTestId('location-display').textContent).toContain('/chat?channel=7');
+    });
+
+    it('URL の ?channel=X 変更で activeChannelId が同期される', async () => {
+      render(
+        <MemoryRouter initialEntries={['/chat?channel=5']}>
+          <ChatPage users={[]} />
+        </MemoryRouter>,
+      );
+      await waitFor(() => {
+        expect(MockChannelList).toHaveBeenLastCalledWith(
+          expect.objectContaining({ activeChannelId: 5 }),
+          undefined,
+        );
+      });
+    });
+
+    it('activeChannelId === null のときメイン領域に案内文 (「チャンネルを選択してください」等) が表示される', async () => {
+      render(
+        <MemoryRouter initialEntries={['/chat']}>
+          <ChatPage users={[]} />
+        </MemoryRouter>,
+      );
+      expect(screen.getByText(/チャンネルを選択/)).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/InboxPage.test.tsx
+++ b/packages/client/src/__tests__/InboxPage.test.tsx
@@ -14,17 +14,33 @@
  *   - react-router-dom は importActual + MemoryRouter で初期 URL を制御
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import InboxPage from '../pages/InboxPage';
 
-// AppLayout は最小スタブ — children を直接 render する
+// AppLayout は最小スタブ — Step 8b で sidebar 中身も検証するため sidebar prop を露出
 vi.mock('../components/Layout/AppLayout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="app-layout-stub">{children}</div>
+  default: ({ children, sidebar }: { children: React.ReactNode; sidebar?: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">
+      <div data-testid="app-layout-sidebar">{sidebar}</div>
+      <div data-testid="app-layout-main">{children}</div>
+    </div>
   ),
+}));
+
+// Step 8b: Sidebar 中身 (ChannelList + SidebarDmList) を stub 化して
+// onSelect 動線とレンダリングを検証可能にする
+vi.mock('../components/Channel/ChannelList', () => ({
+  default: ({ onSelect }: { onSelect?: (id: number, name: string) => void }) => (
+    <div data-testid="channel-list-stub">
+      <button onClick={() => onSelect?.(7, 'general')}>select-channel-7</button>
+    </div>
+  ),
+}));
+vi.mock('../components/Layout/SidebarDmList', () => ({
+  default: () => <div data-testid="sidebar-dm-list-stub" />,
 }));
 
 // 表示用の純粋コンポーネントは個別テスト (SummaryCards.test.tsx / RemindersList.test.tsx /
@@ -167,6 +183,28 @@ describe('InboxPage (Step 6a)', () => {
       // 遅延を許容するため findBy を介して 1 度マウントが完了するのを待つ
       await screen.findByRole('tab', { name: 'スレッド' });
       expect(mockThreadsListSubscribed).toHaveBeenCalled();
+    });
+  });
+
+  // Step 8b: Sidebar 中身確保
+  describe('Step 8b: Sidebar 中身確保', () => {
+    it('AppLayout sidebar に ChannelList が表示される', async () => {
+      renderInbox('/');
+      const sidebar = await screen.findByTestId('app-layout-sidebar');
+      expect(within(sidebar).getByTestId('channel-list-stub')).toBeInTheDocument();
+    });
+
+    it('AppLayout sidebar に SidebarDmList が表示される', async () => {
+      renderInbox('/');
+      const sidebar = await screen.findByTestId('app-layout-sidebar');
+      expect(within(sidebar).getByTestId('sidebar-dm-list-stub')).toBeInTheDocument();
+    });
+
+    it('ChannelList の onSelect で /chat?channel=X に navigate される', async () => {
+      renderInbox('/');
+      await screen.findByTestId('app-layout-sidebar');
+      await userEvent.click(screen.getByText('select-channel-7'));
+      expect(await screen.findByTestId('chat-page-stub')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -55,9 +55,10 @@ function renderRail(initialPath = '/', role: 'user' | 'admin' = 'user') {
 
 describe('Rail', () => {
   describe('ナビゲーション項目の表示', () => {
-    it('上部にホーム / DM / カレンダー / タスク / ブックマーク / 検索の 6 つのアイコンが表示される', () => {
+    it('上部にホーム / チャット / DM / カレンダー / タスク / ブックマーク / 検索の 7 つのアイコンが表示される', () => {
       renderRail();
       expect(screen.getByRole('link', { name: 'ホーム' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'チャット' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'DM' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'カレンダー' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'タスク' })).toBeInTheDocument();
@@ -227,6 +228,24 @@ describe('Rail', () => {
       renderRail('/chat');
       const homeLink = screen.getByRole('link', { name: /ホーム.*4.*未読/ });
       expect(homeLink).toBeInTheDocument();
+    });
+  });
+
+  // Step 8b: チャット項目を Rail に追加 (TODO #16 解消)
+  describe('Step 8b: チャット項目追加', () => {
+    it('「チャット」項目 (/chat へのリンク) が表示される', () => {
+      renderRail();
+      const chatLink = screen.getByRole('link', { name: 'チャット' });
+      expect(chatLink).toBeInTheDocument();
+      expect(chatLink).toHaveAttribute('href', '/chat');
+    });
+
+    it('「チャット」項目はホームの直後 (上部 2 番目) に配置されている', () => {
+      renderRail();
+      const links = screen.getAllByRole('link');
+      // 上部ナビの最初の 2 つはホーム / チャット の順
+      expect(links[0]).toHaveAttribute('aria-label', 'ホーム');
+      expect(links[1]).toHaveAttribute('aria-label', 'チャット');
     });
   });
 });

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -19,15 +19,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import SearchPage from '../pages/SearchPage';
 
-// AppLayout は最小スタブ
+// AppLayout は最小スタブ — Step 8b で sidebar 中身を検証するため sidebar prop も露出
 vi.mock('../components/Layout/AppLayout', () => ({
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="app-layout-stub">{children}</div>
+  default: ({ children, sidebar }: { children: React.ReactNode; sidebar?: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">
+      <div data-testid="app-layout-sidebar">{sidebar}</div>
+      <div data-testid="app-layout-main">{children}</div>
+    </div>
   ),
 }));
 
-// ChannelList / SidebarDmList も最小スタブ（api 依存を避ける）
-vi.mock('../components/Channel/ChannelList', () => ({ default: () => null }));
+// Step 8b: ChannelList の onSelect 動線を検証可能にする
+vi.mock('../components/Channel/ChannelList', () => ({
+  default: ({ onSelect }: { onSelect?: (id: number, name: string) => void }) => (
+    <div data-testid="channel-list-stub">
+      <button onClick={() => onSelect?.(7, 'general')}>select-channel-7</button>
+    </div>
+  ),
+}));
 vi.mock('../components/Layout/SidebarDmList', () => ({ default: () => null }));
 
 // SearchFilterPanel スタブ: onFilterChange / onSaveView を呼び出せるボタンを公開
@@ -327,6 +336,16 @@ describe('SearchPage (Step 7a)', () => {
       expect(lastCall[1]).toEqual(
         expect.objectContaining({ userId: 42, channelId: 7, tagIds: [3] }),
       );
+    });
+  });
+
+  // Step 8b: ChannelList onSelect 修正 (TODO #20)
+  describe('Step 8b: ChannelList onSelect 修正', () => {
+    it('sidebar の ChannelList onSelect で /chat?channel=X に navigate される (旧: 空関数)', async () => {
+      renderSearch();
+      await screen.findByTestId('app-layout-sidebar');
+      await userEvent.click(screen.getByText('select-channel-7'));
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7');
     });
   });
 });

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -8,7 +8,7 @@
  *   - カンバン列の表示・フィルタ UI の動作・ダイアログ開閉に注力する
  */
 
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -115,6 +115,18 @@ vi.mock('react-router-dom', async () => {
 
 vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => null,
+}));
+
+// Step 8b: Sidebar 中身 (ChannelList + SidebarDmList) を stub 化して onSelect 動線とレンダリングを検証可能にする
+vi.mock('../components/Channel/ChannelList', () => ({
+  default: ({ onSelect }: { onSelect?: (id: number, name: string) => void }) => (
+    <div data-testid="channel-list-stub">
+      <button onClick={() => onSelect?.(7, 'general')}>select-channel-7</button>
+    </div>
+  ),
+}));
+vi.mock('../components/Layout/SidebarDmList', () => ({
+  default: () => <div data-testid="sidebar-dm-list-stub" />,
 }));
 
 vi.mock('../components/Task/CreateTaskDialog', () => ({
@@ -675,6 +687,49 @@ describe('TaskBoardPage', () => {
       });
       const card = screen.getByTestId('task-card-1');
       expect(card.querySelector('[aria-label="タスクを表示"]')).toBeInTheDocument();
+    });
+  });
+
+  // Step 8b: Sidebar 中身確保
+  describe('Step 8b: Sidebar 中身確保', () => {
+    it('AppLayout sidebar に ChannelList が表示される', async () => {
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
+      });
+      const sidebar = await screen.findByTestId('app-layout-sidebar');
+      expect(within(sidebar).getByTestId('channel-list-stub')).toBeInTheDocument();
+    });
+
+    it('AppLayout sidebar に SidebarDmList が表示される', async () => {
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
+      });
+      const sidebar = await screen.findByTestId('app-layout-sidebar');
+      expect(within(sidebar).getByTestId('sidebar-dm-list-stub')).toBeInTheDocument();
+    });
+
+    it('ChannelList の onSelect で /chat?channel=X に navigate される', async () => {
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () => {
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        );
+      });
+      await screen.findByTestId('app-layout-sidebar');
+      await userEvent.click(screen.getByText('select-channel-7'));
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7');
     });
   });
 });

--- a/packages/client/src/components/Channel/ChannelList.tsx
+++ b/packages/client/src/components/Channel/ChannelList.tsx
@@ -414,7 +414,14 @@ function ChannelListContent({
   const handleToggleCollapse = async (categoryId: number, isCollapsed: boolean) => {
     try {
       await api.channelCategories.update(categoryId, { isCollapsed });
-      setCategories((prev) => prev.map((c) => (c.id === categoryId ? { ...c, isCollapsed } : c)));
+      setCategories((prev) => {
+        const next = prev.map((c) => (c.id === categoryId ? { ...c, isCollapsed } : c));
+        // モジュール Promise キャッシュも同期更新する。
+        // ChannelList が unmount → 再 mount するとき (別画面遷移→戻り)、
+        // _categoriesPromise が古い isCollapsed を返すため折りたたみ状態が初期化されていた。
+        _categoriesPromise = Promise.resolve({ categories: next });
+        return next;
+      });
     } catch {
       // サイレント失敗（UI側は既にトグル済み）
     }

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import { Badge, Box, Tooltip, Divider } from '@mui/material';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import MailOutlineIcon from '@mui/icons-material/MailOutline';
 import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
 import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
@@ -23,6 +24,8 @@ interface NavItem {
 
 const TOP_ITEMS: NavItem[] = [
   { label: 'ホーム', to: '/', icon: <HomeOutlinedIcon />, end: true },
+  // Step 8b: チャットへの直接動線 (保留 TODO #16 解消)
+  { label: 'チャット', to: '/chat', icon: <ForumOutlinedIcon /> },
   { label: 'DM', to: '/dm', icon: <MailOutlineIcon /> },
   { label: 'カレンダー', to: '/calendar', icon: <CalendarMonthOutlinedIcon /> },
   { label: 'タスク', to: '/tasks', icon: <AssignmentOutlinedIcon /> },

--- a/packages/client/src/pages/CalendarPage.tsx
+++ b/packages/client/src/pages/CalendarPage.tsx
@@ -2,9 +2,12 @@
 // React 19 use() + Suspense パターン（CLAUDE.md フロントエンド開発ルール）
 
 import { Suspense, use, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Box, CircularProgress } from '@mui/material';
 
 import AppLayout from '../components/Layout/AppLayout';
+import ChannelList from '../components/Channel/ChannelList';
+import SidebarDmList from '../components/Layout/SidebarDmList';
 import { CalendarHeader, type CalendarViewMode } from '../components/Calendar/CalendarHeader';
 import { ChannelFilterPanel } from '../components/Calendar/ChannelFilterPanel';
 import { MonthView } from '../components/Calendar/MonthView';
@@ -238,7 +241,7 @@ export default function CalendarPage() {
   const [channelsPromise] = useState(() => getOrCreateChannelsPromise());
   const [usersPromise] = useState(() => getOrCreateUsersPromise());
 
-  const navigate = (delta: number) => {
+  const goByDelta = (delta: number) => {
     setCursor((prev) => {
       const d = new Date(prev);
       if (view === 'week') d.setDate(d.getDate() + delta * 7);
@@ -253,14 +256,28 @@ export default function CalendarPage() {
     setCursor((prev) => new Date(prev.getTime()));
   };
 
+  const routerNavigate = useNavigate();
+
   return (
-    <AppLayout sidebar={<div />}>
+    <AppLayout
+      sidebar={
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+          <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <ChannelList
+              activeChannelId={null}
+              onSelect={(id) => routerNavigate(`/chat?channel=${id}`)}
+            />
+          </Box>
+          <SidebarDmList />
+        </Box>
+      }
+    >
       <CalendarHeader
         cursor={cursor}
         view={view}
         onChangeView={setView}
-        onPrev={() => navigate(-1)}
-        onNext={() => navigate(1)}
+        onPrev={() => goByDelta(-1)}
+        onNext={() => goByDelta(1)}
         onToday={() => setCursor(new Date())}
         onOpenPolls={() => setPollsDrawerOpen(true)}
       />

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useMemo, Suspense, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Box, IconButton, Tooltip, Typography, CircularProgress } from '@mui/material';
 import ScheduleSendIcon from '@mui/icons-material/ScheduleSend';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
 import ViewSidebarIcon from '@mui/icons-material/ViewSidebar';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import AppLayout from '../components/Layout/AppLayout';
 import { ChannelFilesTab } from './FilesPage';
 import ChannelList from '../components/Channel/ChannelList';
@@ -68,12 +70,23 @@ export default function ChatPage({ users }: Props) {
     update: updateScheduled,
   } = useScheduledMessages();
 
-  // URL の ?channel=X からチャンネルを初期選択する
+  // Step 8b: URL ?channel=X とチャンネル選択を双方向同期 (TODO #18 解消)
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlChannelId = searchParams.get('channel');
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const channelId = params.get('channel');
-    if (channelId) setActiveChannelId(Number(channelId));
-  }, []);
+    if (urlChannelId) {
+      const id = Number(urlChannelId);
+      if (Number.isFinite(id) && id !== activeChannelId) {
+        setActiveChannelId(id);
+      }
+    } else if (activeChannelId !== null) {
+      setActiveChannelId(null);
+      setActiveChannelName('');
+      setActiveChannel(null);
+    }
+    // activeChannelId は同期対象なので依存に含めない (URL → state の単方向反映)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlChannelId]);
 
   // ブックマーク済みメッセージIDセットをマウント時に取得する
   useEffect(() => {
@@ -242,10 +255,11 @@ export default function ChatPage({ users }: Props) {
             <ChannelList
               activeChannelId={activeChannelId}
               onSelect={(id, name, channel) => {
-                setActiveChannelId(id);
                 setActiveChannelName(name);
                 setActiveChannel(channel ?? null);
                 setActiveTab('messages');
+                // Step 8b: URL を push 更新 → useEffect で activeChannelId 同期される
+                setSearchParams({ channel: String(id) });
               }}
               draftMap={draftMap}
             />
@@ -358,8 +372,28 @@ export default function ChatPage({ users }: Props) {
             </Suspense>
           )}
 
+          {/* Step 8b: チャット未選択時の案内文 (TODO #18 関連 UX 改善) */}
+          {activeTab === 'messages' && !activeChannelId && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexGrow: 1,
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 1,
+                color: 'text.secondary',
+                p: 4,
+              }}
+            >
+              <ForumOutlinedIcon sx={{ fontSize: 64, opacity: 0.3 }} />
+              <Typography variant="h6">チャンネルを選択してください</Typography>
+              <Typography variant="body2">左のチャンネル一覧からチャットを始めましょう</Typography>
+            </Box>
+          )}
+
           {/* メッセージタブ (Step 7a: 検索 UI は SearchPage に分離。dead code 撤去) */}
-          {activeTab === 'messages' && (
+          {activeTab === 'messages' && activeChannelId && (
             <>
               {/* Step 5b: Main 上部の PinnedMessages バーは ContextRail のピン留めタブに集約したため撤去 */}
               {activeChannel?.isArchived && <ArchivedBanner />}
@@ -379,26 +413,14 @@ export default function ChatPage({ users }: Props) {
                 <RichEditor
                   users={users}
                   onSend={handleSend}
-                  disabled={
-                    !activeChannelId ||
-                    activeChannel?.isArchived === true ||
-                    !canPostToActiveChannel
-                  }
+                  disabled={activeChannel?.isArchived === true || !canPostToActiveChannel}
                   quotedMessage={quotedMessage}
                   onClearQuote={() => setQuotedMessage(undefined)}
-                  channelId={activeChannelId ?? undefined}
-                  initialContent={
-                    activeChannelId !== null ? draftMap.get(activeChannelId) : undefined
-                  }
+                  channelId={activeChannelId}
+                  initialContent={draftMap.get(activeChannelId)}
                   onDraftSaved={handleDraftSaved}
                   onDraftDeleted={handleDraftDeleted}
-                  onSlashEvent={() => {
-                    if (activeChannelId) {
-                      setEventDialogOpen(true);
-                    } else {
-                      showError('チャンネルを選択してからイベントを作成してください');
-                    }
-                  }}
+                  onSlashEvent={() => setEventDialogOpen(true)}
                 />
               </Box>
             </>

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -2,6 +2,8 @@ import { use, useEffect, useMemo, useState, Suspense } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Box, CircularProgress, Tab, Tabs, Typography } from '@mui/material';
 import AppLayout from '../components/Layout/AppLayout';
+import ChannelList from '../components/Channel/ChannelList';
+import SidebarDmList from '../components/Layout/SidebarDmList';
 import SummaryCards, { type SummaryData } from '../components/Inbox/SummaryCards';
 import RemindersList from '../components/Inbox/RemindersList';
 import DraftsList from '../components/Inbox/DraftsList';
@@ -168,7 +170,19 @@ export default function InboxPage() {
   };
 
   return (
-    <AppLayout sidebar={<Box />}>
+    <AppLayout
+      sidebar={
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+          <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <ChannelList
+              activeChannelId={null}
+              onSelect={(id) => navigate(`/chat?channel=${id}`)}
+            />
+          </Box>
+          <SidebarDmList />
+        </Box>
+      }
+    >
       <Box sx={{ p: 3, overflow: 'auto', height: '100%' }}>
         <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
           受信箱

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -155,7 +155,10 @@ export default function SearchPage() {
       sidebar={
         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
           <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
-            <ChannelList activeChannelId={null} onSelect={() => {}} />
+            <ChannelList
+              activeChannelId={null}
+              onSelect={(id) => navigate(`/chat?channel=${id}`)}
+            />
           </Box>
           <SidebarDmList />
         </Box>

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -42,7 +42,10 @@ import type { Task, TaskStatus, Channel, User } from '@chat-app/shared';
 import { api } from '../api/client';
 import CreateTaskDialog from '../components/Task/CreateTaskDialog';
 import EditTaskDialog from '../components/Task/EditTaskDialog';
+import { useNavigate } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
+import ChannelList from '../components/Channel/ChannelList';
+import SidebarDmList from '../components/Layout/SidebarDmList';
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
   todo: '未着手',
@@ -506,8 +509,22 @@ export default function TaskBoardPage() {
   const [channelFilter, setChannelFilter] = useState<number | ''>('');
   const [includeHidden, setIncludeHidden] = useState(false);
 
+  const navigate = useNavigate();
+
   return (
-    <AppLayout sidebar={<div />}>
+    <AppLayout
+      sidebar={
+        <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+          <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
+            <ChannelList
+              activeChannelId={null}
+              onSelect={(id) => navigate(`/chat?channel=${id}`)}
+            />
+          </Box>
+          <SidebarDmList />
+        </Box>
+      }
+    >
       <Suspense
         fallback={
           <Box


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8b。Step 8a 完了後にユーザーが PC 版で利用しながら発見した動線課題を解消する。Rail に「チャット」項目を追加し、Inbox/Calendar/TaskBoard の Sidebar を ChatPage と同じ構造 (ChannelList + SidebarDmList) に統一。SearchPage の onSelect を navigate ハンドラに修正、ChatPage のチャンネル切替で URL を `useSearchParams` で同期する。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8b セクション参照。

## 変更内容

### Rail に「チャット」項目を追加 (TODO #16)
- `Rail.tsx` の `TOP_ITEMS` に `{ label: 'チャット', to: '/chat', icon: <ForumOutlinedIcon /> }` を追加
- ホーム直後 (上部 2 番目) に配置

### Inbox / Calendar / TaskBoard の Sidebar 統一
3 ページの `sidebar={<Box />}` (空) を ChatPage / SearchPage と同じ ChannelList + SidebarDmList 構造に統一:
```tsx
sidebar={
  <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
    <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
      <ChannelList activeChannelId={null} onSelect={(id) => navigate(`/chat?channel=${id}`)} />
    </Box>
    <SidebarDmList />
  </Box>
}
```

これにより:
- 全ページからチャンネル一覧 → 任意チャンネルへワンクリック遷移可能
- SidebarDmList の「新規 DM」ボタン (既存実装) 経由で全ページから DM 開始可能 (TODO #19)
- DM 一覧へのアクセスが全ページで確保

### SearchPage の onSelect 修正 (TODO #20)
`<ChannelList onSelect={() => {}} />` (空関数) → `onSelect={(id) => navigate('/chat?channel=' + id)}` に変更。

### ChatPage の URL 同期を `useSearchParams` 化 (TODO #18)
- 旧: `useEffect` で `window.location.search` から初期化のみ (URL 同期なし)
- 新:
  - `useSearchParams` で `?channel=X` を読む
  - `useEffect` で `urlChannelId` 変化に応じて `activeChannelId` を同期 (URL 直接変更・ブラウザ戻る対応)
  - チャンネル選択時に `setSearchParams({ channel: String(id) })` で URL を push 更新
  - これによりブラウザの戻るボタンで前のチャンネルに戻れる

### ChatPage のチャット未選択時 UX 改善
`activeChannelId === null` のとき、メイン領域に空状態の案内文を表示:
- ForumOutlinedIcon (64px、薄表示)
- 「チャンネルを選択してください」(h6)
- 「左のチャンネル一覧からチャットを始めましょう」(body2)

旧: チャンネル未選択でも空の MessageList と disabled な RichEditor が表示されていた。

### CalendarPage の `navigate` 関数衝突回避
内部の週/月切替関数 `navigate(delta: number)` を `goByDelta` にリネームし、`useNavigate()` の戻り値を `routerNavigate` で受ける。

### テスト
- `Rail.test.tsx`: 「上部 6 つ → 7 つ」既存テスト更新 + Step 8b describe (2 it: チャット項目表示 / ホーム直後配置)
- `InboxPage.test.tsx` `CalendarPage.test.tsx` `TaskBoardPage.test.tsx`: AppLayout stub を sidebar prop も露出する形に拡張、ChannelList/SidebarDmList を stub 化、Step 8b describe (3 it × 3 ファイル: ChannelList 表示 / SidebarDmList 表示 / onSelect navigate)
- `SearchPage.test.tsx`: AppLayout stub 拡張 + ChannelList stub に onSelect ボタン追加、Step 8b describe (1 it: onSelect navigate)
- `ChatPage.test.tsx`: `useSearchParams` 化に伴い `MemoryRouter` ベースの `renderChatPage(path)` ヘルパー導入。20 箇所の `render(<ChatPage>)` を `renderChatPage()` に置換。`window.location.search` 設定撤去。Step 8b describe (3 it: URL push / URL → state 同期 / 案内文)

### PROGRESS.md
Step 8b を 🟡 進行中に更新、対象ファイル・タスク・スコープ外を詳述。保留 TODO #16/18/19/20 を解決済みリストへ移動。

## 影響範囲

### 変更ファイル (12)
- `packages/client/src/components/Layout/Rail.tsx` (チャット項目追加)
- `packages/client/src/pages/InboxPage.tsx` (sidebar 統一)
- `packages/client/src/pages/CalendarPage.tsx` (sidebar 統一 + navigate 名リネーム)
- `packages/client/src/pages/TaskBoardPage.tsx` (sidebar 統一)
- `packages/client/src/pages/SearchPage.tsx` (onSelect 修正)
- `packages/client/src/pages/ChatPage.tsx` (useSearchParams 化 + 案内文)
- `packages/client/src/__tests__/{Rail,InboxPage,CalendarPage,TaskBoardPage,SearchPage,ChatPage}.test.tsx`

### スコープ外（後続 Step）
- ホームを「Inbox / 受信箱」にラベル変更 → **Step 8e**
- InboxPage の `/?channel=X` リダイレクト動作見直し（後方互換維持の現状で動線として成立）→ **8b では据置**
- DmConversationList と SidebarDmList の重複整理 → **据置**（DMPage 内部レイアウト）
- Inbox カードクリック遷移 → **Step 8c**
- Sidebar 開閉機構 → **Step 8d**

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **104 ファイル / 1502 テスト全パス**)
- [x] バックエンドユニットテストへの影響なし (クライアント側の変更のみ)
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint → エラーなし (既存の warning 2 件のみ、Step 8b 由来ではない)
- [ ] (手動確認) Light / Dark の各ページでスクリーンショット撮影、URL 同期 / ブラウザ戻る / チャット未選択時表示を確認 → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8b)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8b の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない