### PR TITLE
feat(inbox): カードクリックで該当メッセージへナビ (Step 8c)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -37,7 +37,7 @@
 | 7a / 7b / 7c-1 / 7c-2 | 検索ページ新設 + 保存ビューピル + チップ式フィルタ + スニペットハイライト | #217 / #218 / #219 / #220 | 🟢 完了 | 2026-05-03 |
 | **8a** | **AppLayout 適用拡大** (BookmarkPage / DMPage / TemplatesPage / AdminPage / ProfilePage / FilesPage を AppLayout 化) | [#221](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/221) | 🟢 完了 | 2026-05-03 |
 | **8b** | **ChatPage 動線確保** (Rail に「チャット」追加 / Inbox/Calendar/TaskBoard の Sidebar に ChannelList / SearchPage onSelect 修正 / URL 更新 / DM 開始導線 / ホームラベル再考) | [#222](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/222) | 🟢 完了 | 2026-05-03 |
-| **8c** | **Inbox カードクリック遷移** (Mentions/Threads/Reminders カードに `/chat?channel=X#message-Y` ナビ追加) | - | ⚪ 未着手 | - |
+| **8c** | **Inbox カードクリック遷移** (Mentions/Threads/Reminders カードに `/chat?channel=X#message-Y` ナビ追加) | (作成中) | 🟡 進行中 | - |
 | **8d** | **Sidebar 開閉機構** (折りたたみトグル + localStorage 永続化 + ページごと初期状態) | - | ⚪ 未着手 | - |
 | **8e** | **追加 UX 改善** (TODO #4 ロゴ刷新 / ContextRail DM 開始導線確認 等の残課題) | - | ⚪ 未着手 | - |
 | 9 | モバイル対応（ボトムタブ + ContextRail のボトムシート化） | - | ⚪ 未着手 | - |
@@ -111,13 +111,23 @@
 - `ChatPage.test.tsx`: `useSearchParams` 化に伴い `MemoryRouter` ベースの `renderChatPage` ヘルパー導入、`window.location.search` 設定撤去、Step 8b describe (3 it) 追加
 
 #### Step 8c: Inbox カードクリック遷移
-**ブランチ**: `feature/brush-up-uiux-step-8c-inbox-cards`（予定）
+**ブランチ**: `feature/brush-up-uiux-step-8c-inbox-cards`
 
 **タスク**:
-- [ ] `MentionsList` カードクリック → `/chat?channel=X#message-Y` へ navigate（C-1）
-- [ ] `ThreadsList` カードクリック → 該当ルートメッセージへ navigate（スレッドペイン open or hash 遷移）（C-2）
-- [ ] `RemindersList` カードクリック → 該当メッセージへ navigate（C-3、完了ボタンとは別動線）
-- [ ] 各カードの hover で「クリック可能」と分かる視覚フィードバック（カーソル / 背景色）
+- [x] `MentionsList` カードクリック → `/chat?channel=${m.channelId}#message-${m.id}` へ navigate
+- [x] `ThreadsList` カードクリック → rootMessage の `/chat?channel=X#message-Y` へ navigate (hash 遷移、スレッドペイン自動 open はスコープ外)
+- [x] `RemindersList` カードクリック → `r.message.channelId` / `r.messageId` で navigate (完了ボタンは `e.stopPropagation()` で別動線、`message` undefined のときはクリック無効)
+- [x] 各カードの hover で視覚フィードバック (`cursor: pointer` + `&:hover { bgcolor: 'action.hover' }`)
+- [x] A11y: `role="button"` + `tabIndex={0}` + `onKeyDown` (Enter/Space) + `aria-label`
+
+**スコープ外**:
+- スレッドペイン自動 open (ChatPage 側で `?thread=Y` URL 対応必要、複雑)
+- ハッシュ `#message-Y` 自動スクロール処理 → 既に `MessageList.tsx:84-93` に実装済 (流用)
+
+**テスト**:
+- `MentionsList.test.tsx` `ThreadsList.test.tsx` `RemindersList.test.tsx` に Step 8c describe (合計 10 it) 追加
+  - クリック navigate / Enter キー navigate / role="button" 属性検証
+  - Reminders は完了ボタン stopPropagation / message undefined 時の無効化も検証
 
 #### Step 8d: Sidebar 開閉機構
 **ブランチ**: `feature/brush-up-uiux-step-8d-sidebar-collapse`（予定）
@@ -170,7 +180,6 @@
 | # | 内容 | 解決予定 Step |
 |---|------|---------------|
 | 4 | Rail 最上部のロゴが暫定デザイン（"C" の四角） | Step 8e |
-| 15 | Inbox の Mentions / Threads / Reminders カードがクリックしても遷移しない | Step 8c |
 | 17 | AppLayout の Sidebar が固定幅 (240px) で開閉できず、コンテンツが空のページではデッドスペース | Step 8d |
 
 ### 🟢 解決済み（参考）
@@ -190,6 +199,7 @@
 | 12 | ContextRail のファイルタブ実装 | Step 5b |
 | 13 | ContextRail の予定タブ実機データ化 | Step 5c-1 |
 | 14 | DMPage / BookmarkPage / TemplatesPage / AdminPage / ProfilePage / FilesPage が AppLayout 非適用でレイアウト不統一 | Step 8a |
+| 15 | Inbox の Mentions / Threads / Reminders カードがクリックしても遷移しない | Step 8c |
 | 16 | Rail に「チャット」項目が無く、Inbox/Calendar/TaskBoard の Sidebar が空でチャット画面への動線が見えない | Step 8b |
 | 18 | チャンネル切替時に URL が更新されない（ブラウザ戻る不可） | Step 8b |
 | 19 | 新規 DM 開始導線が DMPage 内のみ（Inbox / ChatPage から開始できない） | Step 8b |

--- a/packages/client/src/__tests__/MentionsList.test.tsx
+++ b/packages/client/src/__tests__/MentionsList.test.tsx
@@ -5,9 +5,17 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import MentionsList from '../components/Inbox/MentionsList';
 import type { MessageSearchResult } from '@chat-app/shared';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 function makeSearchResult(overrides: Partial<MessageSearchResult> = {}): MessageSearchResult {
   return {
@@ -63,5 +71,45 @@ describe('MentionsList (Step 6b)', () => {
     ];
     render(<MentionsList messages={messages} />);
     expect(screen.getAllByTestId('mention-card')).toHaveLength(2);
+  });
+
+  // Step 8c: カードクリック遷移 (TODO #15 解消)
+  describe('Step 8c: カードクリック遷移', () => {
+    beforeEach(() => {
+      mockNavigate.mockReset();
+    });
+
+    it('カードクリックで /chat?channel=X#message-Y に navigate される', async () => {
+      render(
+        <MemoryRouter>
+          <MentionsList messages={[makeSearchResult({ id: 42, channelId: 7 })]} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('mention-card'));
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7#message-42');
+    });
+
+    it('Enter キー押下でも navigate される (a11y)', async () => {
+      render(
+        <MemoryRouter>
+          <MentionsList messages={[makeSearchResult({ id: 42, channelId: 7 })]} />
+        </MemoryRouter>,
+      );
+      const card = screen.getByTestId('mention-card');
+      card.focus();
+      await userEvent.keyboard('{Enter}');
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7#message-42');
+    });
+
+    it('カードに role="button" / cursor: pointer が設定されている', () => {
+      render(
+        <MemoryRouter>
+          <MentionsList messages={[makeSearchResult()]} />
+        </MemoryRouter>,
+      );
+      const card = screen.getByTestId('mention-card');
+      expect(card).toHaveAttribute('role', 'button');
+      expect(card).toHaveAttribute('tabindex', '0');
+    });
   });
 });

--- a/packages/client/src/__tests__/RemindersList.test.tsx
+++ b/packages/client/src/__tests__/RemindersList.test.tsx
@@ -7,9 +7,16 @@
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import RemindersList from '../components/Inbox/RemindersList';
 import type { Reminder } from '@chat-app/shared';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
   return {
@@ -84,6 +91,61 @@ describe('RemindersList (Step 6a)', () => {
 
     it('onComplete が未指定でも描画はクラッシュしない', () => {
       expect(() => render(<RemindersList reminders={[makeReminder()]} />)).not.toThrow();
+    });
+  });
+
+  // Step 8c: カードクリック遷移 (TODO #15 解消)
+  describe('Step 8c: カードクリック遷移', () => {
+    beforeEach(() => {
+      mockNavigate.mockReset();
+    });
+
+    it('message が存在するときカードクリックで /chat?channel=X#message-Y に navigate される', async () => {
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={[makeReminder({ messageId: 10 })]} />
+        </MemoryRouter>,
+      );
+      // 完了ボタン以外の領域 (CardContent) をクリック
+      const card = screen.getByTestId('reminder-card');
+      await userEvent.click(card);
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=1#message-10');
+    });
+
+    it('完了ボタンクリックではカードの navigate が発火しない (stopPropagation)', async () => {
+      const onComplete = vi.fn();
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={[makeReminder({ id: 5 })]} onComplete={onComplete} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByRole('button', { name: '完了' }));
+      expect(onComplete).toHaveBeenCalledWith(5);
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('message が undefined のときカードクリックは無効 (navigate 呼ばれない)', async () => {
+      const reminderWithoutMessage = makeReminder();
+      // message を明示的に削除
+      const r: Reminder = { ...reminderWithoutMessage, message: undefined };
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={[r]} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('reminder-card'));
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('カードに role="button" / tabIndex が設定されている (message ありのみ)', () => {
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={[makeReminder()]} />
+        </MemoryRouter>,
+      );
+      const card = screen.getByTestId('reminder-card');
+      expect(card).toHaveAttribute('role', 'button');
+      expect(card).toHaveAttribute('tabindex', '0');
     });
   });
 });

--- a/packages/client/src/__tests__/ThreadsList.test.tsx
+++ b/packages/client/src/__tests__/ThreadsList.test.tsx
@@ -10,9 +10,17 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import type { ThreadSummary, Message } from '@chat-app/shared';
 import ThreadsList from '../components/Inbox/ThreadsList';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 function makeMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -78,5 +86,51 @@ describe('ThreadsList (Step 6c)', () => {
     expect(cards[0]).toHaveTextContent('一番目');
     expect(cards[1]).toHaveTextContent('二番目');
     expect(cards[2]).toHaveTextContent('三番目');
+  });
+
+  // Step 8c: カードクリック遷移 (TODO #15 解消)
+  describe('Step 8c: カードクリック遷移', () => {
+    beforeEach(() => {
+      mockNavigate.mockReset();
+    });
+
+    it('カードクリックで rootMessage の /chat?channel=X#message-Y に navigate される', async () => {
+      const thread = makeThread({
+        rootMessage: makeMessage({ id: 99, channelId: 5 }),
+      });
+      render(
+        <MemoryRouter>
+          <ThreadsList threads={[thread]} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('thread-card'));
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=5#message-99');
+    });
+
+    it('Enter キー押下でも navigate される (a11y)', async () => {
+      const thread = makeThread({
+        rootMessage: makeMessage({ id: 99, channelId: 5 }),
+      });
+      render(
+        <MemoryRouter>
+          <ThreadsList threads={[thread]} />
+        </MemoryRouter>,
+      );
+      const card = screen.getByTestId('thread-card');
+      card.focus();
+      await userEvent.keyboard('{Enter}');
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=5#message-99');
+    });
+
+    it('カードに role="button" / cursor: pointer が設定されている', () => {
+      render(
+        <MemoryRouter>
+          <ThreadsList threads={[makeThread()]} />
+        </MemoryRouter>,
+      );
+      const card = screen.getByTestId('thread-card');
+      expect(card).toHaveAttribute('role', 'button');
+      expect(card).toHaveAttribute('tabindex', '0');
+    });
   });
 });

--- a/packages/client/src/components/Inbox/MentionsList.tsx
+++ b/packages/client/src/components/Inbox/MentionsList.tsx
@@ -1,4 +1,5 @@
 import { Box, Card, CardContent, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import type { MessageSearchResult } from '@chat-app/shared';
 import { extractMessageText } from '../../utils/extractMessageText';
 
@@ -25,6 +26,8 @@ function formatDateTime(iso: string): string {
  * 送信元チャンネル名 / 投稿者名 / 本文を一覧表示する。
  */
 export default function MentionsList({ messages }: Props) {
+  const navigate = useNavigate();
+
   if (messages.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
@@ -34,16 +37,39 @@ export default function MentionsList({ messages }: Props) {
   }
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {messages.map((m) => (
-        <Card key={m.id} variant="outlined" data-testid="mention-card">
-          <CardContent>
-            <Typography variant="caption" color="text.secondary">
-              📨 #{m.channelName} · {m.username} · {formatDateTime(m.createdAt)}
-            </Typography>
-            <Typography variant="body2">{extractMessageText(m.content)}</Typography>
-          </CardContent>
-        </Card>
-      ))}
+      {messages.map((m) => {
+        // Step 8c: カードクリックで該当メッセージにジャンプ
+        const goTo = () => navigate(`/chat?channel=${m.channelId}#message-${m.id}`);
+        return (
+          <Card
+            key={m.id}
+            variant="outlined"
+            data-testid="mention-card"
+            role="button"
+            tabIndex={0}
+            aria-label={`#${m.channelName} の ${m.username} のメンションを開く`}
+            onClick={goTo}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                goTo();
+              }
+            }}
+            sx={{
+              cursor: 'pointer',
+              transition: 'background-color 120ms',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+          >
+            <CardContent>
+              <Typography variant="caption" color="text.secondary">
+                📨 #{m.channelName} · {m.username} · {formatDateTime(m.createdAt)}
+              </Typography>
+              <Typography variant="body2">{extractMessageText(m.content)}</Typography>
+            </CardContent>
+          </Card>
+        );
+      })}
     </Box>
   );
 }

--- a/packages/client/src/components/Inbox/RemindersList.tsx
+++ b/packages/client/src/components/Inbox/RemindersList.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Card, CardActions, CardContent, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import type { Reminder } from '@chat-app/shared';
 import { extractMessageText } from '../../utils/extractMessageText';
 
@@ -27,6 +28,8 @@ function formatDateTime(iso: string): string {
  * 押下で onComplete?.(id) を呼ぶ。実際の API 呼び出し (api.reminders.delete) は親に委譲。
  */
 export default function RemindersList({ reminders, onComplete }: Props) {
+  const navigate = useNavigate();
+
   if (reminders.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
@@ -36,23 +39,63 @@ export default function RemindersList({ reminders, onComplete }: Props) {
   }
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {reminders.map((r) => (
-        <Card key={r.id} variant="outlined" data-testid="reminder-card">
-          <CardContent>
-            <Typography variant="caption" color="text.secondary">
-              ⏰ {formatDateTime(r.remindAt)}
-            </Typography>
-            <Typography variant="body2">
-              {r.message ? extractMessageText(r.message.content) : '(メッセージが見つかりません)'}
-            </Typography>
-          </CardContent>
-          <CardActions sx={{ justifyContent: 'flex-end', pt: 0 }}>
-            <Button size="small" onClick={() => onComplete?.(r.id)}>
-              完了
-            </Button>
-          </CardActions>
-        </Card>
-      ))}
+      {reminders.map((r) => {
+        // Step 8c: message が存在するときのみカードクリックでジャンプ可能にする
+        const canNavigate = r.message != null;
+        const goTo = () => {
+          if (r.message) {
+            navigate(`/chat?channel=${r.message.channelId}#message-${r.messageId}`);
+          }
+        };
+        return (
+          <Card
+            key={r.id}
+            variant="outlined"
+            data-testid="reminder-card"
+            role="button"
+            tabIndex={0}
+            aria-label={
+              r.message
+                ? `${formatDateTime(r.remindAt)} のリマインダーメッセージを開く`
+                : 'メッセージが見つからないリマインダー'
+            }
+            onClick={canNavigate ? goTo : undefined}
+            onKeyDown={
+              canNavigate
+                ? (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      goTo();
+                    }
+                  }
+                : undefined
+            }
+            sx={{
+              cursor: canNavigate ? 'pointer' : 'default',
+              transition: 'background-color 120ms',
+              ...(canNavigate ? { '&:hover': { bgcolor: 'action.hover' } } : {}),
+            }}
+          >
+            <CardContent>
+              <Typography variant="caption" color="text.secondary">
+                ⏰ {formatDateTime(r.remindAt)}
+              </Typography>
+              <Typography variant="body2">
+                {r.message ? extractMessageText(r.message.content) : '(メッセージが見つかりません)'}
+              </Typography>
+            </CardContent>
+            {/* 完了ボタンクリックではカード遷移を発火させない */}
+            <CardActions
+              sx={{ justifyContent: 'flex-end', pt: 0 }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Button size="small" onClick={() => onComplete?.(r.id)}>
+                完了
+              </Button>
+            </CardActions>
+          </Card>
+        );
+      })}
     </Box>
   );
 }

--- a/packages/client/src/components/Inbox/ThreadsList.tsx
+++ b/packages/client/src/components/Inbox/ThreadsList.tsx
@@ -1,4 +1,5 @@
 import { Box, Card, CardContent, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import type { ThreadSummary } from '@chat-app/shared';
 import { extractMessageText } from '../../utils/extractMessageText';
 
@@ -24,6 +25,8 @@ function formatDateTime(iso: string): string {
  * 各カードはスレッドのルートメッセージ本文・送信元チャンネル名・返信件数・最終返信時刻を表示する。
  */
 export default function ThreadsList({ threads }: Props) {
+  const navigate = useNavigate();
+
   if (threads.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
@@ -33,17 +36,41 @@ export default function ThreadsList({ threads }: Props) {
   }
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {threads.map((t) => (
-        <Card key={t.rootMessage.id} variant="outlined" data-testid="thread-card">
-          <CardContent>
-            <Typography variant="caption" color="text.secondary">
-              🧵 #{t.channelName} · {t.rootMessage.username} · 返信 {t.replyCount} 件 ·{' '}
-              {formatDateTime(t.lastReplyAt)}
-            </Typography>
-            <Typography variant="body2">{extractMessageText(t.rootMessage.content)}</Typography>
-          </CardContent>
-        </Card>
-      ))}
+      {threads.map((t) => {
+        // Step 8c: カードクリックでスレッドのルートメッセージへジャンプ
+        const goTo = () =>
+          navigate(`/chat?channel=${t.rootMessage.channelId}#message-${t.rootMessage.id}`);
+        return (
+          <Card
+            key={t.rootMessage.id}
+            variant="outlined"
+            data-testid="thread-card"
+            role="button"
+            tabIndex={0}
+            aria-label={`#${t.channelName} の ${t.rootMessage.username} のスレッドを開く`}
+            onClick={goTo}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                goTo();
+              }
+            }}
+            sx={{
+              cursor: 'pointer',
+              transition: 'background-color 120ms',
+              '&:hover': { bgcolor: 'action.hover' },
+            }}
+          >
+            <CardContent>
+              <Typography variant="caption" color="text.secondary">
+                🧵 #{t.channelName} · {t.rootMessage.username} · 返信 {t.replyCount} 件 ·{' '}
+                {formatDateTime(t.lastReplyAt)}
+              </Typography>
+              <Typography variant="body2">{extractMessageText(t.rootMessage.content)}</Typography>
+            </CardContent>
+          </Card>
+        );
+      })}
     </Box>
   );
 }


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8c。Inbox の Mentions / Threads / Reminders カードをクリック (or Enter キー) で該当チャンネル + メッセージ位置 (`/chat?channel=X#message-Y`) に遷移できるようにする。これまではクリックしても何も起きず、Inbox の動線が片方向だった (TODO #15)。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8c セクション参照。

## 変更内容

### 3 つの Inbox カードに遷移ハンドラ追加
| ソース | navigate 先 |
|---|---|
| `MentionsList` | `/chat?channel=${m.channelId}#message-${m.id}` |
| `ThreadsList` | `/chat?channel=${t.rootMessage.channelId}#message-${t.rootMessage.id}` |
| `RemindersList` | `/chat?channel=${r.message.channelId}#message-${r.messageId}` (`message` がある場合のみ) |

### A11y
全カードに以下を付与:
- `role="button"` + `tabIndex={0}` + `aria-label` (チャンネル名・送信者名等で具体化)
- `onKeyDown` で Enter / Space キー押下時も navigate (`e.preventDefault()` で Space スクロール抑止)

### Hover 視覚フィードバック
```tsx
sx={{
  cursor: 'pointer',
  transition: 'background-color 120ms',
  '&:hover': { bgcolor: 'action.hover' },
}}
```

### Reminders カードの特殊ケース
- **完了ボタンとの動線分離**: `CardActions` 側に `onClick={(e) => e.stopPropagation()}` を付与。完了ボタンクリックがカード遷移を発火しない
- **`message` undefined 時のクリック無効化**: `r.message == null` のとき `onClick` / `onKeyDown` 未設定、`cursor: 'default'`、hover 効果も無効。ジャンプ先が組み立てられないため不必要なエラー回避

### 自動スクロール処理 (流用)
`#message-Y` ハッシュからのメッセージ自動スクロールは **既に `MessageList.tsx:84-93` に実装済**。Step 8c では navigate するだけで動線が成立:
```ts
useEffect(() => {
  if (hasScrolledToHash.current) return;
  const hash = window.location.hash;
  if (!hash.startsWith('#message-')) return;
  const el = document.getElementById(hash.slice(1));
  if (!el) return;
  el.scrollIntoView({ behavior: 'smooth', block: 'center' });
  hasScrolledToHash.current = true;
}, [messages]);
```

`MessageItem` には `id={message-${message.id}}` も付与済 (`MessageItem.tsx:158`)。

### テスト
- `MentionsList.test.tsx` `ThreadsList.test.tsx` `RemindersList.test.tsx` に Step 8c describe (合計 **10 it**) 追加
  - `react-router-dom` を `importActual` パターンで mock し `useNavigate` を `mockNavigate` に差し替え
  - クリック navigate / Enter キー navigate / `role="button"` `tabindex` 属性検証
  - Reminders は完了ボタンクリック時の `stopPropagation` 検証 + `message` undefined 時の navigate 無効化検証
- red → green 確認済

### PROGRESS.md
Step 8c を 🟡 進行中に更新、対象タスク・スコープ外を詳述。保留 TODO #15 を解決済みリストへ移動。

## 影響範囲

### 変更ファイル (7)
- `packages/client/src/components/Inbox/MentionsList.tsx`
- `packages/client/src/components/Inbox/ThreadsList.tsx`
- `packages/client/src/components/Inbox/RemindersList.tsx`
- `packages/client/src/__tests__/MentionsList.test.tsx`
- `packages/client/src/__tests__/ThreadsList.test.tsx`
- `packages/client/src/__tests__/RemindersList.test.tsx`
- `doc/brushup-uiux-plan/PROGRESS.md`

### スコープ外（後続 Step）
- スレッドペイン自動 open (ChatPage 側で `?thread=Y` URL 対応必要、複雑) → 必要であれば 8e で再検討
- Mentions カードクリックで既読化 (API 追加発生) → 据置 (遷移先 ChatPage 側で既読化される既存挙動を維持)

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **104 ファイル / 1513 テスト全パス**)
- [x] バックエンドユニットテストへの影響なし (クライアント側の変更のみ)
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint → クリーン
- [ ] (手動確認) Light / Dark で各カードのクリック・hover フィードバック・キーボード操作・スクロール挙動を確認 → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8c)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8c の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない