### PR TITLE
feat(layout): ロゴ刷新 + 受信箱ラベル + ESLint warning 解消 (Step 8e-1)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -39,7 +39,10 @@
 | **8b** | **ChatPage 動線確保** (Rail に「チャット」追加 / Inbox/Calendar/TaskBoard の Sidebar に ChannelList / SearchPage onSelect 修正 / URL 更新 / DM 開始導線 / ホームラベル再考) | [#222](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/222) | 🟢 完了 | 2026-05-03 |
 | **8c** | **Inbox カードクリック遷移** (Mentions/Threads/Reminders カードに `/chat?channel=X#message-Y` ナビ追加) | [#223](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/223) | 🟢 完了 | 2026-05-03 |
 | **8d** | **Sidebar 開閉機構** (折りたたみトグル + localStorage 永続化 + ページごと初期状態) | [#224](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/224) | 🟢 完了 | 2026-05-03 |
-| **8e** | **追加 UX 改善** (TODO #4 ロゴ刷新 / ContextRail DM 開始導線確認 等の残課題) | - | ⚪ 未着手 | - |
+| **8e-1** | **小規模クリーンアップ** (ロゴ刷新 / ホーム→受信箱 / ESLint warning 解消) | (作成中) | 🟡 進行中 | - |
+| 8e-2 | ContextRail メンバータブから DM 開始導線追加 | - | ⚪ 未着手 | - |
+| 8e-3 | SidebarFooter を Rail に統合 (Sidebar 閉じてもアクセス可) | - | ⚪ 未着手 | - |
+| 8e-4 | DmConversationList と SidebarDmList の重複整理 | - | ⚪ 未着手 | - |
 | 9 | モバイル対応（ボトムタブ + ContextRail のボトムシート化） | - | ⚪ 未着手 | - |
 
 凡例: ⚪ 未着手 / 🟡 進行中 / 🔵 レビュー中 / 🟢 完了 / 🔴 ブロック
@@ -148,14 +151,26 @@
 - `Rail.test.tsx` に Step 8d describe (4 it) 追加: トグルボタン表示 / aria-label の状態切替 / クリックハンドラ呼び出し
 
 #### Step 8e: 追加 UX 改善（残課題）
-**ブランチ**: `feature/brush-up-uiux-step-8e-misc-ux`（予定）
+8e はスコープが大きいため、サブステップに分割して順次 PR を出す:
+
+- **8e-1** (小規模クリーンアップ): ロゴ刷新 + ホームラベル変更 + ESLint warning 解消
+- **8e-2** (中規模): ContextRail メンバータブから DM 開始導線
+- **8e-3** (大規模): SidebarFooter を Rail に統合 (閉じてもアクセス可能)
+- **8e-4** (中〜大規模): DmConversationList と SidebarDmList の重複整理
+
+##### Step 8e-1: 小規模クリーンアップ
+**ブランチ**: `feature/brush-up-uiux-step-8e-misc-ux`
 
 **タスク**:
-- [ ] 保留 TODO #4 (Rail 最上部のロゴ "C" 暫定デザイン) の最終デザイン決定（E-5）
-- [ ] ContextRail メンバータブから DM 開始導線の確認・実装（E-7）
-- [ ] その他、8a〜8d 進行中に発見された残課題
+- [x] 保留 TODO #4 (Rail ロゴ刷新): "C" の四角を SVG 幾何学パターン C (上部 3 つの円 + 下部三角形) に差し替え
+- [x] Rail のホームラベル「ホーム」→「受信箱」に変更 (Inbox 強調)
+- [x] ESLint warning 解消: InboxPage `[tab, remindersKey]` / SearchPage `[savedViewsKey]` の意図的依存に `// eslint-disable-next-line react-hooks/exhaustive-deps`
+- [x] 既存テスト (Rail.test.tsx 8 箇所 + AppLayout.test.tsx 1 箇所) の "ホーム" → "受信箱" 文字置換
+- [x] InboxPage の `/?channel=X` リダイレクトコメント整理 → 既に明示済みのため作業不要と判断
 
-**注**: Step 8e は 8a〜8d 完了時点での残課題を集約する位置づけ。スコープは着手時に再確認。
+**テスト**:
+- `Rail.test.tsx` に Step 8e-1 describe (5 it) 追加: ロゴ SVG / "C" 撤去 / 受信箱ラベル / 受信箱→/ リンク
+- 既存テストの「ホーム」を「受信箱」に置換 (sed 一括)
 
 ---
 
@@ -185,9 +200,7 @@
 
 ### ⚪ 未解決
 
-| # | 内容 | 解決予定 Step |
-|---|------|---------------|
-| 4 | Rail 最上部のロゴが暫定デザイン（"C" の四角） | Step 8e |
+なし (Step 8e-1 で残保留 TODO #4 解消予定)
 
 ### 🟢 解決済み（参考）
 
@@ -209,6 +222,7 @@
 | 15 | Inbox の Mentions / Threads / Reminders カードがクリックしても遷移しない | Step 8c |
 | 16 | Rail に「チャット」項目が無く、Inbox/Calendar/TaskBoard の Sidebar が空でチャット画面への動線が見えない | Step 8b |
 | 17 | AppLayout の Sidebar が固定幅 (240px) で開閉できず、コンテンツが空のページではデッドスペース | Step 8d |
+| 4 | Rail 最上部のロゴが暫定デザイン（"C" の四角） | Step 8e-1 |
 | 18 | チャンネル切替時に URL が更新されない（ブラウザ戻る不可） | Step 8b |
 | 19 | 新規 DM 開始導線が DMPage 内のみ（Inbox / ChatPage から開始できない） | Step 8b |
 | 20 | SearchPage の Sidebar ChannelList の `onSelect` が空関数でクリック無反応 | Step 8b |

--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -69,7 +69,7 @@ describe('AppLayout', () => {
   describe('Rail との統合', () => {
     it('Rail コンポーネントの代表的なナビ（ホーム）が AppLayout 内に表示される', () => {
       renderLayout();
-      expect(screen.getByRole('link', { name: 'ホーム' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: '受信箱' })).toBeInTheDocument();
     });
 
     it('AppLayout のレイアウト要素が grid 表示で 3 列構造になっている', () => {

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -57,7 +57,7 @@ describe('Rail', () => {
   describe('ナビゲーション項目の表示', () => {
     it('上部にホーム / チャット / DM / カレンダー / タスク / ブックマーク / 検索の 7 つのアイコンが表示される', () => {
       renderRail();
-      expect(screen.getByRole('link', { name: 'ホーム' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: '受信箱' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'チャット' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'DM' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'カレンダー' })).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe('Rail', () => {
   describe('リンク先', () => {
     it('ホームアイコンは / にリンクする', () => {
       renderRail();
-      expect(screen.getByRole('link', { name: 'ホーム' })).toHaveAttribute('href', '/');
+      expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('href', '/');
     });
 
     it('DM アイコンは /dm にリンクする', () => {
@@ -191,12 +191,12 @@ describe('Rail', () => {
 
     it('現在のパスが /tasks のとき、ホームアイコンには aria-current が付与されない', () => {
       renderRail('/tasks');
-      expect(screen.getByRole('link', { name: 'ホーム' })).not.toHaveAttribute('aria-current');
+      expect(screen.getByRole('link', { name: '受信箱' })).not.toHaveAttribute('aria-current');
     });
 
     it('現在のパスが / のとき、ホームアイコンに aria-current="page" が付与される', () => {
       renderRail('/');
-      expect(screen.getByRole('link', { name: 'ホーム' })).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('aria-current', 'page');
     });
   });
 
@@ -205,7 +205,7 @@ describe('Rail', () => {
       mockMentionUnreadCount = 0;
       // ホームアイコン外の他リンクのバッジ "3" 等の干渉を避けるため、現在パスは /chat
       renderRail('/chat');
-      const homeLink = screen.getByRole('link', { name: 'ホーム' });
+      const homeLink = screen.getByRole('link', { name: '受信箱' });
       // バッジが「不可視（0）」状態であること（DOM 上に MuiBadge-invisible が付く）
       expect(homeLink.querySelector('.MuiBadge-invisible')).not.toBeNull();
     });
@@ -226,7 +226,7 @@ describe('Rail', () => {
     it('未読メンションがあるとき、ホームアイコンの aria-label に未読数の情報が含まれる', () => {
       mockMentionUnreadCount = 4;
       renderRail('/chat');
-      const homeLink = screen.getByRole('link', { name: /ホーム.*4.*未読/ });
+      const homeLink = screen.getByRole('link', { name: /受信箱.*4.*未読/ });
       expect(homeLink).toBeInTheDocument();
     });
   });
@@ -275,12 +275,43 @@ describe('Rail', () => {
       expect(chatLink).toHaveAttribute('href', '/chat');
     });
 
-    it('「チャット」項目はホームの直後 (上部 2 番目) に配置されている', () => {
+    it('「チャット」項目は受信箱の直後 (上部 2 番目) に配置されている', () => {
       renderRail();
       const links = screen.getAllByRole('link');
-      // 上部ナビの最初の 2 つはホーム / チャット の順
-      expect(links[0]).toHaveAttribute('aria-label', 'ホーム');
+      // 上部ナビの最初の 2 つは受信箱 / チャット の順
+      expect(links[0]).toHaveAttribute('aria-label', '受信箱');
       expect(links[1]).toHaveAttribute('aria-label', 'チャット');
+    });
+  });
+
+  // Step 8e-1: ロゴ刷新 + ホームラベル変更
+  describe('Step 8e-1: ロゴ刷新 (TODO #4)', () => {
+    it('Rail 最上部にロゴ画像が表示される (aria-label="Chat App ロゴ")', () => {
+      renderRail();
+      expect(screen.getByRole('img', { name: 'Chat App ロゴ' })).toBeInTheDocument();
+    });
+
+    it('"C" の文字テキストが表示されない (旧暫定デザイン撤去)', () => {
+      renderRail();
+      expect(screen.queryByText('C')).not.toBeInTheDocument();
+    });
+
+    it('ロゴに SVG 要素が含まれる (三角形 + 円の幾何学パターン)', () => {
+      renderRail();
+      const logo = screen.getByRole('img', { name: 'Chat App ロゴ' });
+      expect(logo.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+
+  describe('Step 8e-1: ホームラベルを「受信箱」に変更', () => {
+    it('上部ナビ 1 番目のリンク label が「受信箱」になっている', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: '受信箱' })).toBeInTheDocument();
+    });
+
+    it('「受信箱」リンクは / にリンクする', () => {
+      renderRail();
+      expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('href', '/');
     });
   });
 });

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -25,7 +25,8 @@ interface NavItem {
 }
 
 const TOP_ITEMS: NavItem[] = [
-  { label: 'ホーム', to: '/', icon: <HomeOutlinedIcon />, end: true },
+  // Step 8e-1: 「ホーム」を「受信箱」にラベル変更 (Inbox を強調)
+  { label: '受信箱', to: '/', icon: <HomeOutlinedIcon />, end: true },
   // Step 8b: チャットへの直接動線 (保留 TODO #16 解消)
   { label: 'チャット', to: '/chat', icon: <ForumOutlinedIcon /> },
   { label: 'DM', to: '/dm', icon: <MailOutlineIcon /> },
@@ -113,8 +114,9 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
         borderRight: '1px solid var(--border)',
       }}
     >
-      {/* 最上部のロゴ。Step 2b で AppBar から移譲した暫定デザイン
-          (PROGRESS.md 保留 TODO #4 で最終デザインに差し替え予定) */}
+      {/* Step 8e-1: ロゴ刷新 (保留 TODO #4 解消)。
+          幾何学パターン C: 三角形 (吹き出しの先端) + 3 つの円 (人の集合)
+          メッセージング + コミュニティのメタファー。 */}
       <Box
         role="img"
         aria-label="Chat App ロゴ"
@@ -129,14 +131,24 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
-          fontWeight: 700,
-          fontFamily: 'var(--font-sans)',
-          fontSize: 18,
-          letterSpacing: '-0.02em',
           userSelect: 'none',
         }}
       >
-        C
+        <svg
+          viewBox="0 0 24 24"
+          width="22"
+          height="22"
+          fill="currentColor"
+          aria-hidden="true"
+          focusable="false"
+        >
+          {/* 上部に 3 つの円 (人の集合) */}
+          <circle cx="6" cy="7" r="2" />
+          <circle cx="12" cy="6" r="2.4" />
+          <circle cx="18" cy="7" r="2" />
+          {/* 下部に三角形 (吹き出しの先端 / 共有のメタファー) */}
+          <path d="M5 14 L19 14 L12 22 Z" />
+        </svg>
       </Box>
 
       {/* Step 8d: Sidebar 開閉トグル (ロゴ直下) */}

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -137,7 +137,8 @@ export default function InboxPage() {
   const [remindersKey, setRemindersKey] = useState(0);
   const remindersPromise = useMemo(
     () => (tab === 'reminders' || tab === 'all' ? api.reminders.list() : null),
-    // remindersKey も deps に含めて再フェッチをトリガー
+    // remindersKey も deps に含めて再フェッチをトリガー (関数 body では未使用の意図的依存)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [tab, remindersKey],
   );
   const draftsPromise = useMemo(

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -45,6 +45,8 @@ export default function SearchPage() {
 
   // Step 7b: 保存ビュー一覧 promise。削除/作成後に savedViewsKey をインクリメントして再フェッチ
   const [savedViewsKey, setSavedViewsKey] = useState(0);
+  // savedViewsKey は関数 body 未使用だが再フェッチトリガーとして deps に含める意図
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const savedViewsPromise = useMemo(() => api.savedViews.list(), [savedViewsKey]);
 
   // Step 7c-1: SearchFilterPanel 由来のフィルタとチップ由来のフィルタをマージ


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8e-1 (小規模クリーンアップ)。Step 8e は「残課題集約」位置づけのため、サブステップ (8e-1 〜 8e-4) に分割。本 PR は 1 つ目で、保留 TODO #4 (Rail ロゴ暫定デザイン) を解消し、合わせて細かいクリーンアップを実施する。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e セクション参照。

## 変更内容

### Rail ロゴ刷新 (保留 TODO #4 解消)
旧: 暫定の "C" 文字 + 角丸四角
新: 幾何学パターン C (上部 3 つの円 + 下部三角形) の SVG

- 上部の 3 つの円: 人の集合 (コミュニティ) のメタファー
- 下部の三角形: 吹き出しの先端 (メッセージング / 共有) のメタファー
- `currentColor` を使い、既存の `var(--accent)` / `var(--accent-fg)` を活かす配色
- aria-label="Chat App ロゴ" は据置

```tsx
<svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" aria-hidden focusable="false">
  <circle cx="6" cy="7" r="2" />
  <circle cx="12" cy="6" r="2.4" />
  <circle cx="18" cy="7" r="2" />
  <path d="M5 14 L19 14 L12 22 Z" />
</svg>
```

### Rail のホームラベル「ホーム」→「受信箱」
`Rail.tsx` の `TOP_ITEMS` の最初のラベルを変更。InboxPage 内の見出し (Step 6a で「受信箱」) と一致し、Inbox を強調。

### ESLint warning 解消
意図的に再フェッチトリガー用 key を deps に含める 2 箇所に `// eslint-disable-next-line react-hooks/exhaustive-deps` を追加:

- `InboxPage.tsx`: `useMemo(() => ..., [tab, remindersKey])` (`remindersKey` 関数 body 未使用)
- `SearchPage.tsx`: `useMemo(() => api.savedViews.list(), [savedViewsKey])`

挙動は変えず警告のみ撤去。

### テスト
- `Rail.test.tsx` に Step 8e-1 describe (**5 it** 追加):
  - ロゴ画像が `aria-label="Chat App ロゴ"` で表示される
  - "C" の文字テキストが表示されない (旧暫定デザイン撤去)
  - ロゴ内に SVG 要素が含まれる
  - 上部ナビ 1 番目のリンク label が「受信箱」になっている
  - 「受信箱」リンクは / にリンクする
- 既存テスト (`Rail.test.tsx` 8 箇所 + `AppLayout.test.tsx` 1 箇所) の `name: 'ホーム'` を `name: '受信箱'` に sed 一括置換
- red → green 確認済

### スコープ外で作業不要と判断したもの
- **InboxPage の `/?channel=X` リダイレクトコメント整理** → docstring (`InboxPage.tsx:90`) に既に「後方互換」と明示済み、整理不要

### PROGRESS.md
Step 8e をサブステップ (8e-1〜8e-4) に分割するフォーマットに更新。8e-1 を 🟡 進行中に。保留 TODO #4 を解決済みリストへ移動。

## 影響範囲

### 変更ファイル (6)
- `packages/client/src/components/Layout/Rail.tsx` (ロゴ + ラベル)
- `packages/client/src/pages/InboxPage.tsx` (ESLint disable)
- `packages/client/src/pages/SearchPage.tsx` (ESLint disable)
- `packages/client/src/__tests__/Rail.test.tsx` (Step 8e-1 describe + ホーム→受信箱)
- `packages/client/src/__tests__/AppLayout.test.tsx` (ホーム→受信箱)
- `doc/brushup-uiux-plan/PROGRESS.md`

### 後続サブステップ
- **8e-2**: ContextRail メンバータブから DM 開始導線追加
- **8e-3**: SidebarFooter を Rail に統合 (Sidebar 閉じてもアクセス可能に)
- **8e-4**: DmConversationList と SidebarDmList の重複整理

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **104 ファイル / 1528 テスト全パス**)
- [x] バックエンドユニットテストへの影響なし (クライアント側のみ)
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint → **warning 0 件** (前 1 件あったが本 PR で解消)
- [ ] (手動確認) Light / Dark でロゴ表示・受信箱ラベル・既存ナビ動線を確認 → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-1)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8e-1 の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない