### PR TITLE
feat(channel): メンバー行から DM 開始 (Step 8e-2)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -40,7 +40,7 @@
 | **8c** | **Inbox カードクリック遷移** (Mentions/Threads/Reminders カードに `/chat?channel=X#message-Y` ナビ追加) | [#223](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/223) | 🟢 完了 | 2026-05-03 |
 | **8d** | **Sidebar 開閉機構** (折りたたみトグル + localStorage 永続化 + ページごと初期状態) | [#224](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/224) | 🟢 完了 | 2026-05-03 |
 | **8e-1** | **小規模クリーンアップ** (ロゴ刷新 / ホーム→受信箱 / ESLint warning 解消) | [#225](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/225) | 🟢 完了 | 2026-05-03 |
-| 8e-2 | ContextRail メンバータブから DM 開始導線追加 | - | ⚪ 未着手 | - |
+| **8e-2** | **ContextRail メンバータブから DM 開始導線追加** | (作成中) | 🟡 進行中 | - |
 | 8e-3 | SidebarFooter を Rail に統合 (Sidebar 閉じてもアクセス可) | - | ⚪ 未着手 | - |
 | 8e-4 | DmConversationList と SidebarDmList の重複整理 | - | ⚪ 未着手 | - |
 | 9 | モバイル対応（ボトムタブ + ContextRail のボトムシート化） | - | ⚪ 未着手 | - |
@@ -171,6 +171,20 @@
 **テスト**:
 - `Rail.test.tsx` に Step 8e-1 describe (5 it) 追加: ロゴ SVG / "C" 撤去 / 受信箱ラベル / 受信箱→/ リンク
 - 既存テストの「ホーム」を「受信箱」に置換 (sed 一括)
+
+##### Step 8e-2: ContextRail メンバータブから DM 開始導線追加
+**ブランチ**: `feature/brush-up-uiux-step-8e-2-contextrail-dm`
+
+**タスク**:
+- [x] `MembersContent` の props に `currentUserId: number` 追加
+- [x] 各行 (自分以外) の右端に SendIcon (紙飛行機) の IconButton (`aria-label="DM を開始"`) を追加
+- [x] クリックで `e.stopPropagation()` + `api.dm.createConversation(targetUserId)` → `navigate('/dm?conv=${conv.id}')`
+- [x] エラー時は `useSnackbar().showError` で通知 (DMPage と同じパターン)
+- [x] `ChannelMembersDialog` (default export) で `useAuth` から currentUserId 取得 → MembersContent に渡す
+- [x] `ContextRail` でも MembersContent に `currentUserId` を渡す
+
+**テスト**:
+- `ChannelMembersDialog.test.tsx` に Step 8e-2 describe (6 it) 追加: 自分以外に DM ボタン / 自分には非表示 / createConversation 呼び出し / navigate 成功 / stopPropagation で handleToggle 抑止 / showError 失敗時
 
 ---
 

--- a/packages/client/src/__tests__/ChannelMembersDialog.test.tsx
+++ b/packages/client/src/__tests__/ChannelMembersDialog.test.tsx
@@ -28,7 +28,31 @@ vi.mock('../api/client', () => ({
     auth: {
       users: vi.fn(),
     },
+    dm: {
+      createConversation: vi.fn(),
+    },
   },
+}));
+
+// Step 8e-2: useNavigate / useSnackbar / useAuth を mock
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+const mockShowError = vi.hoisted(() => vi.fn());
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({ showError: mockShowError, showSuccess: vi.fn(), showInfo: vi.fn() }),
+}));
+
+const mockAuthUser = vi.hoisted(() => ({
+  id: 1,
+  username: 'me',
+  email: 'me@example.com',
+  role: 'user',
+}));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockAuthUser }),
 }));
 
 import { api } from '../api/client';
@@ -36,6 +60,8 @@ const mockGetMembers = api.channels.getMembers as ReturnType<typeof vi.fn>;
 const mockAddMember = api.channels.addMember as ReturnType<typeof vi.fn>;
 const mockRemoveMember = api.channels.removeMember as ReturnType<typeof vi.fn>;
 const mockUsers = api.auth.users as ReturnType<typeof vi.fn>;
+const mockCreateConv = (api as unknown as { dm: { createConversation: ReturnType<typeof vi.fn> } })
+  .dm.createConversation;
 
 function makeUser(id: number, username: string, displayName?: string) {
   return {
@@ -230,6 +256,82 @@ describe('ChannelMembersDialog', () => {
       await renderDialog(defaultProps);
 
       expect(screen.queryByTestId('user-status')).not.toBeInTheDocument();
+    });
+  });
+
+  // Step 8e-2: ContextRail メンバータブから DM 開始導線
+  describe('Step 8e-2: DM 開始ボタン', () => {
+    it('自分以外の行に「DM を開始」ボタンが表示される', async () => {
+      mockUsers.mockResolvedValue({
+        users: [makeUser(1, 'me'), makeUser(2, 'alice'), makeUser(3, 'bob')],
+      });
+      mockGetMembers.mockResolvedValue({ members: [] });
+
+      await renderDialog(defaultProps);
+
+      // 自分 (id=1) 以外の 2 人 (alice, bob) に DM ボタンが表示される
+      const dmButtons = screen.getAllByRole('button', { name: 'DM を開始' });
+      expect(dmButtons).toHaveLength(2);
+    });
+
+    it('自分自身の行には「DM を開始」ボタンが表示されない', async () => {
+      mockUsers.mockResolvedValue({ users: [makeUser(1, 'me'), makeUser(2, 'alice')] });
+      mockGetMembers.mockResolvedValue({ members: [] });
+
+      await renderDialog(defaultProps);
+
+      // 自分 (id=1) の行内には DM ボタンが無い
+      const meRow = screen.getByText('me').closest('li')!;
+      expect(meRow.querySelector('button[aria-label="DM を開始"]')).toBeNull();
+    });
+
+    it('DM ボタンクリックで api.dm.createConversation が呼ばれる', async () => {
+      mockUsers.mockResolvedValue({ users: [makeUser(1, 'me'), makeUser(2, 'alice')] });
+      mockGetMembers.mockResolvedValue({ members: [] });
+      mockCreateConv.mockResolvedValue({ conversation: { id: 99 } });
+
+      await renderDialog(defaultProps);
+
+      await userEvent.click(screen.getByRole('button', { name: 'DM を開始' }));
+
+      await waitFor(() => expect(mockCreateConv).toHaveBeenCalledWith(2));
+    });
+
+    it('createConversation 成功時に /dm?conv=N に navigate される', async () => {
+      mockUsers.mockResolvedValue({ users: [makeUser(1, 'me'), makeUser(2, 'alice')] });
+      mockGetMembers.mockResolvedValue({ members: [] });
+      mockCreateConv.mockResolvedValue({ conversation: { id: 99 } });
+
+      await renderDialog(defaultProps);
+
+      await userEvent.click(screen.getByRole('button', { name: 'DM を開始' }));
+
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/dm?conv=99'));
+    });
+
+    it('DM ボタンクリックでメンバー追加/削除 (handleToggle) が呼ばれない (stopPropagation)', async () => {
+      mockUsers.mockResolvedValue({ users: [makeUser(1, 'me'), makeUser(2, 'alice')] });
+      mockGetMembers.mockResolvedValue({ members: [] });
+      mockCreateConv.mockResolvedValue({ conversation: { id: 99 } });
+
+      await renderDialog(defaultProps);
+
+      await userEvent.click(screen.getByRole('button', { name: 'DM を開始' }));
+
+      // メンバー追加 API は呼ばれない (DM ボタンが ListItemButton onClick を発火させない)
+      expect(mockAddMember).not.toHaveBeenCalled();
+    });
+
+    it('createConversation 失敗時に showError でエラー通知される', async () => {
+      mockUsers.mockResolvedValue({ users: [makeUser(1, 'me'), makeUser(2, 'alice')] });
+      mockGetMembers.mockResolvedValue({ members: [] });
+      mockCreateConv.mockRejectedValue(new Error('DM 開始に失敗'));
+
+      await renderDialog(defaultProps);
+
+      await userEvent.click(screen.getByRole('button', { name: 'DM を開始' }));
+
+      await waitFor(() => expect(mockShowError).toHaveBeenCalledWith('DM 開始に失敗'));
     });
   });
 });

--- a/packages/client/src/components/Channel/ChannelMembersDialog.tsx
+++ b/packages/client/src/components/Channel/ChannelMembersDialog.tsx
@@ -10,15 +10,21 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  IconButton,
   List,
   ListItem,
   ListItemAvatar,
   ListItemButton,
   ListItemText,
+  Tooltip,
 } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../../api/client';
 import type { User } from '@chat-app/shared';
 import { useSocket } from '../../contexts/SocketContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { useSnackbar } from '../../contexts/SnackbarContext';
 import { usePresence } from '../../hooks/usePresence';
 import PresenceIndicator from '../Chat/PresenceIndicator';
 
@@ -33,16 +39,31 @@ export type MembersData = [{ users: User[] }, { members: User[] }];
 interface MembersContentProps {
   membersPromise: Promise<MembersData>;
   channelId: number;
+  /** Step 8e-2: 自分自身を識別して DM ボタンを抑止するために使用 */
+  currentUserId: number;
 }
 
 // Step 5a: ContextRail のメンバータブから再利用するため named export を追加
-export function MembersContent({ membersPromise, channelId }: MembersContentProps) {
+export function MembersContent({ membersPromise, channelId, currentUserId }: MembersContentProps) {
   const [{ users: allUsers }, { members }] = use(membersPromise);
   const [memberIds, setMemberIds] = useState<Set<number>>(() => new Set(members.map((m) => m.id)));
   const [loadingId, setLoadingId] = useState<number | null>(null);
   const [error, setError] = useState('');
   const socket = useSocket();
   const presence = usePresence(socket);
+  const navigate = useNavigate();
+  const { showError } = useSnackbar();
+
+  // Step 8e-2: メンバー行から DM を開始する
+  const handleStartDm = async (targetUserId: number) => {
+    try {
+      const { conversation } = await api.dm.createConversation(targetUserId);
+      navigate(`/dm?conv=${conversation.id}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'DM の開始に失敗しました';
+      showError(msg);
+    }
+  };
 
   const handleToggle = async (userId: number) => {
     setError('');
@@ -118,6 +139,21 @@ export function MembersContent({ membersPromise, channelId }: MembersContentProp
                   }
                   secondary={isMember ? 'メンバー' : undefined}
                 />
+                {/* Step 8e-2: 自分以外のメンバー行に DM 開始ボタンを表示 */}
+                {u.id !== currentUserId && (
+                  <Tooltip title="DM を開始">
+                    <IconButton
+                      size="small"
+                      aria-label="DM を開始"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void handleStartDm(u.id);
+                      }}
+                    >
+                      <SendIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
               </ListItemButton>
             </ListItem>
           );
@@ -128,6 +164,7 @@ export function MembersContent({ membersPromise, channelId }: MembersContentProp
 }
 
 export default function ChannelMembersDialog({ open, channelId, onClose }: Props) {
+  const { user } = useAuth();
   // open と channelId が変わるたびに新しい Promise を生成する
   const membersPromise = useMemo<Promise<MembersData> | null>(() => {
     if (!open) return null;
@@ -138,9 +175,13 @@ export default function ChannelMembersDialog({ open, channelId, onClose }: Props
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs" scroll="paper">
       <DialogTitle>メンバー管理</DialogTitle>
       <DialogContent dividers>
-        {open && membersPromise && (
+        {open && membersPromise && user && (
           <Suspense fallback={<CircularProgress size={24} />}>
-            <MembersContent membersPromise={membersPromise} channelId={channelId} />
+            <MembersContent
+              membersPromise={membersPromise}
+              channelId={channelId}
+              currentUserId={user.id}
+            />
           </Suspense>
         )}
       </DialogContent>

--- a/packages/client/src/components/Channel/ContextRail.tsx
+++ b/packages/client/src/components/Channel/ContextRail.tsx
@@ -145,13 +145,20 @@ export default function ContextRail({
         value={tab}
         onChange={(_, v: TabKey) => setTab(v)}
         variant="fullWidth"
-        sx={{ minHeight: 36, borderBottom: '1px solid var(--border)' }}
+        // Step 8e-2 追加修正: 5 タブ × MUI デフォルト minWidth=90px = 450px が
+        // 右ペイン 320px に収まらず「メンバー」タブが overflow して画面外に隠れていた。
+        // minWidth: 0 と padding 圧縮で全タブを等分配置可能にする。
+        sx={{
+          minHeight: 36,
+          borderBottom: '1px solid var(--border)',
+          '& .MuiTab-root': { minWidth: 0, minHeight: 36, fontSize: 13, px: 1 },
+        }}
       >
-        <Tab value="summary" label="概要" sx={{ minHeight: 36, fontSize: 13 }} />
-        <Tab value="pins" label="ピン留め" sx={{ minHeight: 36, fontSize: 13 }} />
-        <Tab value="files" label="ファイル" sx={{ minHeight: 36, fontSize: 13 }} />
-        <Tab value="events" label="予定" sx={{ minHeight: 36, fontSize: 13 }} />
-        <Tab value="members" label="メンバー" sx={{ minHeight: 36, fontSize: 13 }} />
+        <Tab value="summary" label="概要" />
+        <Tab value="pins" label="ピン留め" />
+        <Tab value="files" label="ファイル" />
+        <Tab value="events" label="予定" />
+        <Tab value="members" label="メンバー" />
       </Tabs>
 
       <Box sx={{ flex: 1, overflow: 'auto', p: 1.5, minHeight: 0 }}>

--- a/packages/client/src/components/Channel/ContextRail.tsx
+++ b/packages/client/src/components/Channel/ContextRail.tsx
@@ -213,7 +213,11 @@ export default function ContextRail({
               </Box>
             }
           >
-            <MembersContent membersPromise={membersPromise} channelId={channel.id} />
+            <MembersContent
+              membersPromise={membersPromise}
+              channelId={channel.id}
+              currentUserId={currentUserId}
+            />
           </Suspense>
         )}
       </Box>


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8e-2。ContextRail のメンバータブ (および ChannelMembersDialog) のメンバー一覧から、自分以外のユーザーに対して DM を開始できる導線を追加する。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-2 セクション参照。

## 変更内容

### `MembersContent` に DM 開始ボタン追加
- props に `currentUserId: number` 追加（自分自身を識別）
- 各行 (自分以外) の右端に `SendIcon` (紙飛行機) の `IconButton` (`aria-label="DM を開始"`, Tooltip 付き) を配置
- クリック処理:
  ```ts
  onClick={(e) => {
    e.stopPropagation();  // ListItemButton の handleToggle 衝突回避
    void handleStartDm(u.id);
  }}
  ```
- `handleStartDm`:
  - `api.dm.createConversation(targetUserId)` で会話作成 (or 既存取得)
  - 成功時: `navigate('/dm?conv=${conversation.id}')` (Step 3c で実装済の DMPage `?conv=N` 仕様を流用)
  - 失敗時: `useSnackbar().showError` で通知 (DMPage と同じパターン)

### 上位での `currentUserId` 配線
- `ChannelMembersDialog` (default export): `useAuth()` で `user.id` を取得 → MembersContent に渡す
- `ContextRail`: 既存の `currentUserId` props をそのまま MembersContent に渡す

### テスト
`ChannelMembersDialog.test.tsx` に Step 8e-2 describe (**6 it** 追加):
- 自分以外の行に「DM を開始」ボタンが表示される (alice + bob = 2 個)
- 自分自身の行には「DM を開始」ボタンが表示されない
- DM ボタンクリックで `api.dm.createConversation` が呼ばれる
- 成功時に `/dm?conv=N` に navigate される
- DM ボタンクリックでメンバー追加/削除 (`handleToggle`) が呼ばれない (stopPropagation)
- 失敗時に `showError` でエラー通知される

mock 追加:
- `useNavigate` (`mockNavigate`)
- `useSnackbar().showError` (`mockShowError`)
- `useAuth` (`mockAuthUser` で `user.id = 1`)
- `api.dm.createConversation` (`mockCreateConv`)

red → green 確認済。

### PROGRESS.md
Step 8e-2 を 🟡 進行中に更新、対象タスク・テスト内容を詳述。

## 影響範囲

### 変更ファイル (4)
- `packages/client/src/components/Channel/ChannelMembersDialog.tsx` (MembersContent + default export)
- `packages/client/src/components/Channel/ContextRail.tsx` (currentUserId 配線)
- `packages/client/src/__tests__/ChannelMembersDialog.test.tsx` (Step 8e-2 describe 追加 + mock)
- `doc/brushup-uiux-plan/PROGRESS.md`

### 後続サブステップ
- **8e-3**: SidebarFooter を Rail に統合 (Sidebar 閉じてもアクセス可能に)
- **8e-4**: DmConversationList と SidebarDmList の重複整理

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **104 ファイル / 1534 テスト全パス**)
- [x] バックエンドユニットテストへの影響なし (クライアント側のみ)
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint → クリーン
- [ ] (手動確認) ContextRail メンバータブから DM 開始 → DMPage 遷移 → 会話表示の流れ、エラー時のスナックバー → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-2)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8e-2 の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない