### PR TITLE
feat(layout): SidebarFooter を Rail に統合 (Step 8e-3)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -41,7 +41,7 @@
 | **8d** | **Sidebar 開閉機構** (折りたたみトグル + localStorage 永続化 + ページごと初期状態) | [#224](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/224) | 🟢 完了 | 2026-05-03 |
 | **8e-1** | **小規模クリーンアップ** (ロゴ刷新 / ホーム→受信箱 / ESLint warning 解消) | [#225](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/225) | 🟢 完了 | 2026-05-03 |
 | **8e-2** | **ContextRail メンバータブから DM 開始導線追加** | [#226](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/226) | 🟢 完了 | 2026-05-03 |
-| 8e-3 | SidebarFooter を Rail に統合 (Sidebar 閉じてもアクセス可) | - | ⚪ 未着手 | - |
+| **8e-3** | **SidebarFooter を Rail に統合** (Sidebar 閉じてもアクセス可) | (作成中) | 🟡 進行中 | - |
 | 8e-4 | DmConversationList と SidebarDmList の重複整理 | - | ⚪ 未着手 | - |
 | 9 | モバイル対応（ボトムタブ + ContextRail のボトムシート化） | - | ⚪ 未着手 | - |
 
@@ -185,6 +185,26 @@
 
 **テスト**:
 - `ChannelMembersDialog.test.tsx` に Step 8e-2 describe (6 it) 追加: 自分以外に DM ボタン / 自分には非表示 / createConversation 呼び出し / navigate 成功 / stopPropagation で handleToggle 抑止 / showError 失敗時
+
+##### Step 8e-3: SidebarFooter を Rail に統合
+**ブランチ**: `feature/brush-up-uiux-step-8e-3-sidebarfooter-rail`
+
+**タスク**:
+- [x] `SidebarFooter.tsx` を縦並び (64px Rail 幅) アイコン群に refactor: ステータス / テーマ / 通知 / プロフィール / ログアウトの 5 アイコン縦並び
+- [x] ユーザー名 (displayName / username) は Rail 上に直接表示せず、ステータスボタンの Tooltip テキストに含める ("alice のステータスを設定")
+- [x] `Rail.tsx` の最下部 (BOTTOM_ITEMS / 管理アイコンの下) に `<SidebarFooter />` を配置
+- [x] `AppLayout.tsx` から `<SidebarFooter />` を撤去 (Sidebar 列は sidebar prop の中身のみ)
+- [x] Sidebar が閉じた状態 (Step 8d) でも Rail 経由でテーマ切替・ログアウト等にアクセス可能に
+
+**スコープ外**:
+- ステータス選択ダイアログ (`StatusEditDialog`) は据置 (既存挙動)
+- Push 通知 supported 判定は既存ロジック流用
+
+**テスト**:
+- `Rail.test.tsx` に Step 8e-3 describe (5 it) 追加: 各種ボタンが Rail 内に存在 / ユーザー名が直接表示されない
+  - `SidebarFooter` を vi.mock で stub 化 (Rail 単体テストの依存連鎖を切る)
+- `AppLayout.test.tsx` に Step 8e-3 describe (2 it) 追加: Sidebar 列にログアウトが含まれない / Rail (nav) 内に存在する
+- `SidebarFooter.test.tsx` の「表示名が表示される」「username が表示される」を「直接表示されない (Tooltip 化)」に書き換え + 「表示名をクリック」を「ステータスボタンをクリック」に文言変更
 
 ---
 

--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -99,7 +99,23 @@ describe('AppLayout', () => {
 
     it('SidebarFooter の代表的な要素（ログアウトボタン）が AppLayout 内に表示される', () => {
       renderLayout();
+      // Step 8e-3 で SidebarFooter は Rail に移動したが、AppLayout 全体としては存在する
       expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument();
+    });
+  });
+
+  // Step 8e-3: Sidebar 列から SidebarFooter を撤去 (Rail に移動)
+  describe('Step 8e-3: SidebarFooter を Sidebar 列から撤去', () => {
+    it('Sidebar 列内にログアウトボタンが含まれない (Rail に移動済)', () => {
+      renderLayout();
+      const sidebarColumn = screen.getByTestId('app-layout-sidebar');
+      expect(sidebarColumn.querySelector('button[aria-label="ログアウト"]')).toBeNull();
+    });
+
+    it('ログアウトボタンは Rail (nav 要素) 内に存在する', () => {
+      renderLayout();
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav.querySelector('button[aria-label="ログアウト"]')).not.toBeNull();
     });
   });
 

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -27,6 +27,19 @@ vi.mock('../hooks/useMentionUnreadCount', () => ({
   useMentionUnreadCount: () => mockMentionUnreadCount,
 }));
 
+// Step 8e-3: SidebarFooter は Rail 内で render されるが、SidebarFooter 自体は
+// SidebarFooter.test.tsx で検証する。Rail テストでは stub にして依存連鎖を切る。
+vi.mock('../components/Layout/SidebarFooter', () => ({
+  default: () => (
+    <div data-testid="sidebar-footer-stub">
+      <button aria-label="ステータスを設定">stub-status</button>
+      <button aria-label="ダークモードに切り替える">stub-theme</button>
+      <button aria-label="プロフィール設定">stub-profile</button>
+      <button aria-label="ログアウト">stub-logout</button>
+    </div>
+  ),
+}));
+
 const mockUser = {
   id: 1,
   username: 'alice',
@@ -300,6 +313,34 @@ describe('Rail', () => {
       renderRail();
       const logo = screen.getByRole('img', { name: 'Chat App ロゴ' });
       expect(logo.querySelector('svg')).toBeInTheDocument();
+    });
+  });
+
+  // Step 8e-3: SidebarFooter を Rail に統合
+  describe('Step 8e-3: SidebarFooter を Rail に統合', () => {
+    it('Rail 内に「ステータスを設定」ボタンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('button', { name: 'ステータスを設定' })).toBeInTheDocument();
+    });
+
+    it('Rail 内に「テーマ切替」ボタンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('button', { name: /モードに切り替える/ })).toBeInTheDocument();
+    });
+
+    it('Rail 内に「プロフィール設定」ボタンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('button', { name: 'プロフィール設定' })).toBeInTheDocument();
+    });
+
+    it('Rail 内に「ログアウト」ボタンが表示される', () => {
+      renderRail();
+      expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument();
+    });
+
+    it('ユーザー名 (alice) は Rail 内に直接表示されない (Tooltip のみ)', () => {
+      renderRail();
+      expect(screen.queryByText('alice')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/client/src/__tests__/SidebarFooter.test.tsx
+++ b/packages/client/src/__tests__/SidebarFooter.test.tsx
@@ -105,15 +105,17 @@ describe('SidebarFooter', () => {
       expect(screen.getByText('🔵')).toBeInTheDocument();
     });
 
-    it('表示名が表示される（displayName が優先）', () => {
+    // Step 8e-3: Rail に統合され 64px 幅になったため、displayName/username は
+    // SidebarFooter 内に直接テキスト表示されず Tooltip 経由でのみ表示される。
+    it('表示名は SidebarFooter 内に直接表示されない (Step 8e-3: Tooltip 化)', () => {
       mockUser.displayName = '田中花子';
       renderFooter();
-      expect(screen.getByText('田中花子')).toBeInTheDocument();
+      expect(screen.queryByText('田中花子')).not.toBeInTheDocument();
     });
 
-    it('displayName が null のとき username が表示される', () => {
+    it('displayName が null のとき username も SidebarFooter 内に直接表示されない (Step 8e-3)', () => {
       renderFooter();
-      expect(screen.getByText('alice')).toBeInTheDocument();
+      expect(screen.queryByText('alice')).not.toBeInTheDocument();
     });
 
     it('テーマ切替ボタン（ダーク/ライト）が表示される', () => {
@@ -146,7 +148,7 @@ describe('SidebarFooter', () => {
   });
 
   describe('動作', () => {
-    it('表示名をクリックするとステータス編集ダイアログが開く', async () => {
+    it('ステータスボタンをクリックするとステータス編集ダイアログが開く', async () => {
       renderFooter();
       const statusButton = screen.getByRole('button', { name: 'ステータスを設定' });
       await userEvent.click(statusButton);

--- a/packages/client/src/components/Layout/AppLayout.tsx
+++ b/packages/client/src/components/Layout/AppLayout.tsx
@@ -2,7 +2,6 @@ import { ReactNode, useEffect, useState } from 'react';
 import { Box, Snackbar, Alert } from '@mui/material';
 import { useSocket } from '../../contexts/SocketContext';
 import Rail from './Rail';
-import SidebarFooter from './SidebarFooter';
 
 const RAIL_WIDTH = 64;
 const SIDEBAR_WIDTH = 240;
@@ -109,8 +108,8 @@ export default function AppLayout({ sidebar, children, rightPane, defaultSidebar
             minHeight: 0,
           }}
         >
+          {/* Step 8e-3: SidebarFooter は Rail に移動。Sidebar 列は sidebar prop の中身のみ。 */}
           <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{sidebar}</Box>
-          <SidebarFooter />
         </Box>
 
         <Box

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -15,6 +15,7 @@ import { NavLink } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useDmUnreadCount } from '../../hooks/useDmUnreadCount';
 import { useMentionUnreadCount } from '../../hooks/useMentionUnreadCount';
+import SidebarFooter from './SidebarFooter';
 
 interface NavItem {
   label: string;
@@ -188,6 +189,9 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
         ))}
         {isAdmin && <RailLink item={ADMIN_ITEM} />}
       </Box>
+
+      {/* Step 8e-3: SidebarFooter (ステータス / テーマ / 通知 / プロフィール / ログアウト) を Rail に統合 */}
+      <SidebarFooter />
     </Box>
   );
 }

--- a/packages/client/src/components/Layout/SidebarFooter.tsx
+++ b/packages/client/src/components/Layout/SidebarFooter.tsx
@@ -22,8 +22,9 @@ import { api } from '../../api/client';
 import StatusEditDialog from '../User/StatusEditDialog';
 
 /**
- * Sidebar 列フッター。Step 2b で AppBar から移譲した
- * ステータス / テーマ切替 / Push 通知 / プロフィール / ログアウト を集約する。
+ * Step 8e-3: Rail (64px 幅) 最下部に組み込まれるフッター。
+ * 縦並びアイコン群: ステータス / テーマ切替 / Push 通知 / プロフィール / ログアウト。
+ * ユーザー名は Tooltip で表示 (幅不足のため Rail 上には直接表示しない)。
  */
 export default function SidebarFooter() {
   const [statusDialogOpen, setStatusDialogOpen] = useState(false);
@@ -34,108 +35,102 @@ export default function SidebarFooter() {
 
   const themeLabel = mode === 'dark' ? 'ライトモードに切り替える' : 'ダークモードに切り替える';
   const notificationLabel = subscribed ? '通知を無効にする' : '通知を有効にする';
+  const userLabel = user?.displayName ?? user?.username ?? '';
+  const statusTooltip = userLabel ? `${userLabel} のステータスを設定` : 'ステータスを設定';
 
   return (
     <>
       <Box
         sx={{
           borderTop: '1px solid var(--border)',
-          px: 1,
-          py: 1,
+          py: 0.5,
           display: 'flex',
           flexDirection: 'column',
-          gap: 0.5,
+          alignItems: 'center',
+          gap: 0.25,
           background: 'var(--bg-elev)',
         }}
       >
-        <Tooltip title="ステータスを設定">
-          <Box
-            component="button"
+        <Tooltip title={statusTooltip} placement="right">
+          <IconButton
+            size="small"
             aria-label="ステータスを設定"
             onClick={() => setStatusDialogOpen(true)}
             sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 0.5,
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              color: 'var(--text)',
-              px: 1,
-              py: 0.5,
+              width: 36,
+              height: 32,
               borderRadius: 'var(--radius-sm)',
-              textAlign: 'left',
-              minWidth: 0,
-              '&:hover': { background: 'var(--surface-hover)' },
+              color: 'var(--text)',
             }}
           >
-            {user?.status?.emoji && (
-              <Typography component="span" sx={{ fontSize: '1rem', lineHeight: 1 }}>
+            {user?.status?.emoji ? (
+              <Typography component="span" sx={{ fontSize: '1.1rem', lineHeight: 1 }}>
                 {user.status.emoji}
               </Typography>
+            ) : (
+              <AccountCircleIcon fontSize="small" />
             )}
-            <Typography
-              variant="body2"
-              sx={{
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-                minWidth: 0,
-              }}
-            >
-              {user?.displayName ?? user?.username}
-            </Typography>
-          </Box>
+          </IconButton>
         </Tooltip>
 
-        <Box sx={{ display: 'flex', gap: 0.5 }}>
-          <Tooltip title={themeLabel}>
-            <IconButton size="small" aria-label={themeLabel} onClick={toggleTheme}>
-              {mode === 'dark' ? (
-                <LightModeIcon fontSize="small" />
-              ) : (
-                <DarkModeIcon fontSize="small" />
-              )}
-            </IconButton>
-          </Tooltip>
+        <Tooltip title={themeLabel} placement="right">
+          <IconButton
+            size="small"
+            aria-label={themeLabel}
+            onClick={toggleTheme}
+            sx={{ width: 36, height: 32 }}
+          >
+            {mode === 'dark' ? (
+              <LightModeIcon fontSize="small" />
+            ) : (
+              <DarkModeIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
 
-          {supported && (
-            <Tooltip title={notificationLabel}>
-              <span>
-                <IconButton
-                  size="small"
-                  aria-label={notificationLabel}
-                  disabled={loading}
-                  onClick={() => void (subscribed ? unsubscribe() : subscribe())}
-                >
-                  {loading ? (
-                    <CircularProgress size={16} />
-                  ) : subscribed ? (
-                    <NotificationsIcon fontSize="small" />
-                  ) : (
-                    <NotificationsOffIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </span>
-            </Tooltip>
-          )}
-
-          <Tooltip title="プロフィール設定">
-            <IconButton
-              size="small"
-              aria-label="プロフィール設定"
-              onClick={() => navigate('/profile')}
-            >
-              <AccountCircleIcon fontSize="small" />
-            </IconButton>
+        {supported && (
+          <Tooltip title={notificationLabel} placement="right">
+            <span>
+              <IconButton
+                size="small"
+                aria-label={notificationLabel}
+                disabled={loading}
+                onClick={() => void (subscribed ? unsubscribe() : subscribe())}
+                sx={{ width: 36, height: 32 }}
+              >
+                {loading ? (
+                  <CircularProgress size={16} />
+                ) : subscribed ? (
+                  <NotificationsIcon fontSize="small" />
+                ) : (
+                  <NotificationsOffIcon fontSize="small" />
+                )}
+              </IconButton>
+            </span>
           </Tooltip>
+        )}
 
-          <Tooltip title="ログアウト">
-            <IconButton size="small" aria-label="ログアウト" onClick={() => void logout()}>
-              <LogoutIcon fontSize="small" />
-            </IconButton>
-          </Tooltip>
-        </Box>
+        <Tooltip title="プロフィール設定" placement="right">
+          <IconButton
+            size="small"
+            aria-label="プロフィール設定"
+            onClick={() => navigate('/profile')}
+            sx={{ width: 36, height: 32 }}
+          >
+            <AccountCircleIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="ログアウト" placement="right">
+          <IconButton
+            size="small"
+            aria-label="ログアウト"
+            onClick={() => void logout()}
+            sx={{ width: 36, height: 32 }}
+          >
+            <LogoutIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
       </Box>
 
       <Snackbar open={!!error} autoHideDuration={6000}>


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8e-3。SidebarFooter (ステータス / テーマ切替 / 通知 / プロフィール / ログアウト) を Rail の最下部に統合し、Sidebar 列から撤去する。Step 8d で Sidebar が閉じた状態でも Rail は常に表示されるため、これらの機能に常時アクセスできるようになる。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-3 セクション参照。

## 変更内容

### `SidebarFooter.tsx` を縦並びアイコン版に refactor
旧: 240px 幅前提の横長レイアウト (ステータス + ユーザー名 + 4 アイコン横並び)
新: 64px Rail 幅前提の縦並び 5 アイコン

- ステータス: emoji 設定済みなら emoji、未設定なら `AccountCircleIcon`
- テーマ切替 / 通知 / プロフィール / ログアウト: それぞれ `IconButton` (36×32px、`placement="right"` の Tooltip 付き)
- ユーザー名表示は撤去 → ステータスボタンの Tooltip テキストに含める (`"alice のステータスを設定"`)
- 各アイコンは `placement="right"` Tooltip でホバー時にラベル表示

### `Rail.tsx` 最下部に統合
```tsx
<Box sx={...}>
  ... TOP_ITEMS ...
  <Divider />
  ... BOTTOM_ITEMS + ADMIN_ITEM ...
  <SidebarFooter />  {/* 新規 */}
</Box>
```

### `AppLayout.tsx` から `<SidebarFooter />` 撤去
Sidebar 列の中身は `sidebar` prop のみに。

### テスト
- `Rail.test.tsx`:
  - `SidebarFooter` を `vi.mock` で stub 化（Rail 単体テストの依存連鎖を切る）
  - Step 8e-3 describe (**5 it** 追加): 各種ボタン (ステータス / テーマ / プロフィール / ログアウト) が Rail 内に存在 / ユーザー名が直接表示されない
- `AppLayout.test.tsx`:
  - Step 8e-3 describe (**2 it** 追加): Sidebar 列にログアウトが含まれない / Rail (nav) 内に存在する
- `SidebarFooter.test.tsx`:
  - 「表示名が表示される (displayName 優先)」「username が表示される」を **「直接表示されない (Tooltip 化)」** に書き換え
  - 「表示名をクリックでダイアログ」を「ステータスボタンをクリックで...」に文言変更（aria-label="ステータスを設定" は据置）

red → green 確認済。

### PROGRESS.md
Step 8e-3 を 🟡 進行中に更新、対象タスク・テスト内容を詳述。

## 影響範囲

### 変更ファイル (7)
- `packages/client/src/components/Layout/SidebarFooter.tsx` (縦並び refactor)
- `packages/client/src/components/Layout/Rail.tsx` (SidebarFooter import + render)
- `packages/client/src/components/Layout/AppLayout.tsx` (SidebarFooter import + render 撤去)
- `packages/client/src/__tests__/Rail.test.tsx` (mock 追加 + Step 8e-3 describe)
- `packages/client/src/__tests__/AppLayout.test.tsx` (Step 8e-3 describe)
- `packages/client/src/__tests__/SidebarFooter.test.tsx` (Tooltip 化に伴うテスト更新)
- `doc/brushup-uiux-plan/PROGRESS.md`

### 後続サブステップ
- **8e-4**: DmConversationList と SidebarDmList の重複整理
- **9**: モバイル対応

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **104 ファイル / 1541 テスト全パス**)
- [x] バックエンドユニットテストへの影響なし (クライアント側のみ)
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint → クリーン
- [ ] (手動確認) Light / Dark で Rail 最下部のアイコン群表示・Tooltip 表示・ステータスダイアログ・テーマ切替・プロフィール遷移・ログアウト動作 → ユーザー側で実施
- [ ] (手動確認) Sidebar 閉じた状態でも Rail 経由でアクセス可能 → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-3)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8e-3 の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない