### PR TITLE
refactor(dm): DmConversationList と SidebarDmList の重複整理 (Step 8e-4)

### DIFF
--- a/doc/brushup-uiux-plan/PROGRESS.md
+++ b/doc/brushup-uiux-plan/PROGRESS.md
@@ -42,7 +42,7 @@
 | **8e-1** | **小規模クリーンアップ** (ロゴ刷新 / ホーム→受信箱 / ESLint warning 解消) | [#225](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/225) | 🟢 完了 | 2026-05-03 |
 | **8e-2** | **ContextRail メンバータブから DM 開始導線追加** | [#226](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/226) | 🟢 完了 | 2026-05-03 |
 | **8e-3** | **SidebarFooter を Rail に統合** (Sidebar 閉じてもアクセス可) | [#227](https://github.com/mokemoke2850/chat-app-for-claudecode-test/pull/227) | 🟢 完了 | 2026-05-03 |
-| 8e-4 | DmConversationList と SidebarDmList の重複整理 | - | ⚪ 未着手 | - |
+| **8e-4** | **DmConversationList と SidebarDmList の重複整理** | (作成中) | 🟡 進行中 | - |
 | 9 | モバイル対応（ボトムタブ + ContextRail のボトムシート化） | - | ⚪ 未着手 | - |
 
 凡例: ⚪ 未着手 / 🟡 進行中 / 🔵 レビュー中 / 🟢 完了 / 🔴 ブロック
@@ -205,6 +205,28 @@
   - `SidebarFooter` を vi.mock で stub 化 (Rail 単体テストの依存連鎖を切る)
 - `AppLayout.test.tsx` に Step 8e-3 describe (2 it) 追加: Sidebar 列にログアウトが含まれない / Rail (nav) 内に存在する
 - `SidebarFooter.test.tsx` の「表示名が表示される」「username が表示される」を「直接表示されない (Tooltip 化)」に書き換え + 「表示名をクリック」を「ステータスボタンをクリック」に文言変更
+
+##### Step 8e-4: DmConversationList と SidebarDmList の重複整理 (案 C)
+**ブランチ**: `feature/brush-up-uiux-step-8e-4-dmlist-dedup`
+
+**タスク**:
+- [x] `useDmConversationsSocket` フック新設 (両者で重複していた `new_dm_message` 購読ロジックを集約)
+  - 単一 updater で lastMessage / updatedAt / unreadCount を同時更新する仕様に改善
+- [x] `DmListRow` コンポーネント新設 (共通行表示、`variant: 'expanded' | 'compact'` で密度・プレビュー有無を切替)
+  - expanded: 32px avatar + presence indicator + lastMessage プレビュー + 時刻 (DMPage 用)
+  - compact: 24px avatar + 名前のみ (Sidebar 用)
+- [x] `DmConversationList.tsx` を wrapper 化 (ヘッダー + Box + DmListRow.expanded を使う)
+- [x] `SidebarDmList.tsx` を wrapper 化 (ヘッダー + Box + DmListRow.compact を使う) + `useAuth` で currentUserId 取得
+- [x] 既存テスト維持: socket 単一 updater 化に伴う `DmConversationList.test.tsx` 期待値修正、`SidebarDmList.test.tsx` に AuthContext mock 追加
+
+**スコープ外**:
+- API (`api.dm.listConversations`) 自体の変更なし
+- DMPage / AppLayout の使用箇所インターフェース互換 (props 変更なし)
+
+**テスト**:
+- 新規 `DmListRow.test.tsx` (9 it): 共通表示 / expanded プレビュー / compact プレビュー無し / isActive selected 状態
+- `DmConversationList.test.tsx`: socket 「2 回呼ばれる」期待を「1 回 (単一 updater)」に修正
+- `SidebarDmList.test.tsx`: AuthContext mock 追加
 
 ---
 

--- a/packages/client/src/__tests__/DmConversationList.test.tsx
+++ b/packages/client/src/__tests__/DmConversationList.test.tsx
@@ -69,8 +69,15 @@ describe('DmConversationList', () => {
   describe('会話一覧表示', () => {
     it('会話一覧が正しく表示される', () => {
       const conversations = [
-        makeConversation({ id: 1, otherUser: { id: 2, username: 'bob', displayName: null, avatarUrl: null } }),
-        makeConversation({ id: 2, userBId: 3, otherUser: { id: 3, username: 'charlie', displayName: null, avatarUrl: null } }),
+        makeConversation({
+          id: 1,
+          otherUser: { id: 2, username: 'bob', displayName: null, avatarUrl: null },
+        }),
+        makeConversation({
+          id: 2,
+          userBId: 3,
+          otherUser: { id: 3, username: 'charlie', displayName: null, avatarUrl: null },
+        }),
       ];
       render(
         <DmConversationList
@@ -102,7 +109,9 @@ describe('DmConversationList', () => {
 
     it('会話相手の displayName がある場合は displayName が表示される', () => {
       const conversations = [
-        makeConversation({ otherUser: { id: 2, username: 'bob', displayName: 'Bob Smith', avatarUrl: null } }),
+        makeConversation({
+          otherUser: { id: 2, username: 'bob', displayName: 'Bob Smith', avatarUrl: null },
+        }),
       ];
       render(
         <DmConversationList
@@ -121,7 +130,11 @@ describe('DmConversationList', () => {
     it('lastMessage がある場合はメッセージプレビューが表示される', () => {
       const conversations = [
         makeConversation({
-          lastMessage: { content: '最新メッセージ', createdAt: '2024-01-01T10:00:00Z', senderId: 2 },
+          lastMessage: {
+            content: '最新メッセージ',
+            createdAt: '2024-01-01T10:00:00Z',
+            senderId: 2,
+          },
         }),
       ];
       render(
@@ -284,7 +297,12 @@ describe('DmConversationList', () => {
   describe('Socket.IO リアルタイム更新', () => {
     it('new_dm_message イベント受信時に非アクティブ会話の unreadCount がインクリメントされる', async () => {
       const onConversationsChange = vi.fn();
-      const initialConversation = makeConversation({ id: 2, userBId: 3, otherUser: { id: 3, username: 'charlie', displayName: null, avatarUrl: null }, unreadCount: 0 });
+      const initialConversation = makeConversation({
+        id: 2,
+        userBId: 3,
+        otherUser: { id: 3, username: 'charlie', displayName: null, avatarUrl: null },
+        unreadCount: 0,
+      });
       render(
         <DmConversationList
           conversations={[initialConversation]}
@@ -301,11 +319,10 @@ describe('DmConversationList', () => {
         emitSocket('new_dm_message', newMsg);
       });
 
-      // unreadCount インクリメントのupdater（1回目）とlastMessage更新のupdater（2回目）が呼ばれる
-      expect(onConversationsChange).toHaveBeenCalledTimes(2);
-      // 1回目のupdaterがunreadCountをインクリメントすることを確認
-      const unreadUpdater = onConversationsChange.mock.calls[0][0];
-      const result = unreadUpdater([initialConversation]);
+      // Step 8e-4: 単一 updater で unreadCount + lastMessage を同時更新する仕様に変更
+      expect(onConversationsChange).toHaveBeenCalledTimes(1);
+      const updater = onConversationsChange.mock.calls[0][0];
+      const result = updater([initialConversation]);
       expect(result[0].unreadCount).toBe(1);
     });
 
@@ -328,11 +345,10 @@ describe('DmConversationList', () => {
         emitSocket('new_dm_message', newMsg);
       });
 
-      // lastMessage 更新のupdaterが呼ばれることを確認（非アクティブ会話なのでunreadCount + lastMessageで2回）
-      expect(onConversationsChange).toHaveBeenCalledTimes(2);
-      // 2回目のupdaterがlastMessageを更新することを確認
-      const lastMessageUpdater = onConversationsChange.mock.calls[1][0];
-      const result = lastMessageUpdater([initialConversation]);
+      // Step 8e-4: 単一 updater で unreadCount + lastMessage を同時更新
+      expect(onConversationsChange).toHaveBeenCalledTimes(1);
+      const updater = onConversationsChange.mock.calls[0][0];
+      const result = updater([initialConversation]);
       expect(result[0].lastMessage).toEqual({
         content: '新しいメッセージ',
         createdAt: newMsg.createdAt,
@@ -342,7 +358,12 @@ describe('DmConversationList', () => {
 
     it('自分が送信したメッセージでは非アクティブ会話でも unreadCount がインクリメントされない', async () => {
       const onConversationsChange = vi.fn();
-      const initialConversation = makeConversation({ id: 2, userBId: 3, otherUser: { id: 3, username: 'charlie', displayName: null, avatarUrl: null }, unreadCount: 0 });
+      const initialConversation = makeConversation({
+        id: 2,
+        userBId: 3,
+        otherUser: { id: 3, username: 'charlie', displayName: null, avatarUrl: null },
+        unreadCount: 0,
+      });
       render(
         <DmConversationList
           conversations={[initialConversation]}

--- a/packages/client/src/__tests__/DmListRow.test.tsx
+++ b/packages/client/src/__tests__/DmListRow.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * components/DM/DmListRow.tsx のユニットテスト (Step 8e-4)
+ *
+ * 純粋表示コンポーネントのため Suspense / API 不要。
+ * variant 別の表示差分 (avatar 径 / lastMessage プレビュー有無) を検証する。
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import type { DmConversationWithDetails } from '@chat-app/shared';
+import DmListRow from '../components/DM/DmListRow';
+
+function makeConversation(
+  overrides: Partial<DmConversationWithDetails> = {},
+): DmConversationWithDetails {
+  return {
+    id: 1,
+    userAId: 1,
+    userBId: 2,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    otherUser: { id: 2, username: 'bob', displayName: null, avatarUrl: null },
+    unreadCount: 0,
+    lastMessage: null,
+    ...overrides,
+  };
+}
+
+describe('DmListRow', () => {
+  describe('共通表示', () => {
+    it('相手の username が表示される', () => {
+      render(<DmListRow conversation={makeConversation()} variant="expanded" onClick={vi.fn()} />);
+      expect(screen.getByText('bob')).toBeInTheDocument();
+    });
+
+    it('displayName があれば displayName が優先される', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation({
+            otherUser: { id: 2, username: 'bob', displayName: '田中花子', avatarUrl: null },
+          })}
+          variant="expanded"
+          onClick={vi.fn()}
+        />,
+      );
+      expect(screen.getByText('田中花子')).toBeInTheDocument();
+    });
+
+    it('unreadCount > 0 のとき未読バッジが表示される', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation({ unreadCount: 3 })}
+          variant="compact"
+          onClick={vi.fn()}
+        />,
+      );
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('クリックで onClick が呼ばれる', async () => {
+      const onClick = vi.fn();
+      render(<DmListRow conversation={makeConversation()} variant="compact" onClick={onClick} />);
+      await userEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('variant=expanded', () => {
+    it('lastMessage プレビューが表示される', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation({
+            lastMessage: {
+              content: 'こんにちは',
+              createdAt: '2024-01-01T00:00:00Z',
+              senderId: 2,
+            },
+          })}
+          variant="expanded"
+          onClick={vi.fn()}
+        />,
+      );
+      expect(screen.getByText('こんにちは')).toBeInTheDocument();
+    });
+
+    it('lastMessage の時刻が表示される', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation({
+            lastMessage: {
+              content: 'msg',
+              createdAt: '2024-06-01T12:34:00Z',
+              senderId: 2,
+            },
+          })}
+          variant="expanded"
+          onClick={vi.fn()}
+        />,
+      );
+      // 月/日が含まれた caption テキストが表示される (詳細フォーマットは locale 依存のため緩く検証)
+      expect(screen.getByText(/6月|Jun|6\/1/)).toBeInTheDocument();
+    });
+
+    it('isActive=true のとき selected 状態になる (Mui-selected クラス)', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation()}
+          variant="expanded"
+          isActive={true}
+          onClick={vi.fn()}
+        />,
+      );
+      const btn = screen.getByRole('button');
+      expect(btn).toHaveClass('Mui-selected');
+    });
+  });
+
+  describe('variant=compact', () => {
+    it('lastMessage プレビューが表示されない', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation({
+            lastMessage: {
+              content: 'compact では非表示',
+              createdAt: '2024-01-01T00:00:00Z',
+              senderId: 2,
+            },
+          })}
+          variant="compact"
+          onClick={vi.fn()}
+        />,
+      );
+      expect(screen.queryByText('compact では非表示')).not.toBeInTheDocument();
+    });
+
+    it('lastMessage の時刻が表示されない', () => {
+      render(
+        <DmListRow
+          conversation={makeConversation({
+            lastMessage: {
+              content: 'msg',
+              createdAt: '2024-06-01T12:34:00Z',
+              senderId: 2,
+            },
+          })}
+          variant="compact"
+          onClick={vi.fn()}
+        />,
+      );
+      // 6月 や 6/1 等の日付フォーマット文字列が表示されない
+      expect(screen.queryByText(/6月|Jun|6\/1/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/SidebarDmList.test.tsx
+++ b/packages/client/src/__tests__/SidebarDmList.test.tsx
@@ -46,6 +46,13 @@ vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => mockSocket,
 }));
 
+// Step 8e-4: SidebarDmList が useAuth で currentUserId を取得するようになったため mock 追加
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 1, username: 'me', email: 'me@example.com', role: 'user' },
+  }),
+}));
+
 function makeConversation(
   overrides: Partial<DmConversationWithDetails> = {},
 ): DmConversationWithDetails {

--- a/packages/client/src/components/DM/DmConversationList.tsx
+++ b/packages/client/src/components/DM/DmConversationList.tsx
@@ -1,31 +1,10 @@
-import { useEffect } from 'react';
-import {
-  Avatar,
-  Badge,
-  Box,
-  IconButton,
-  List,
-  ListItem,
-  ListItemButton,
-  ListItemAvatar,
-  ListItemText,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import { Box, IconButton, List, Tooltip, Typography } from '@mui/material';
 import AddCommentIcon from '@mui/icons-material/AddComment';
 import { useSocket } from '../../contexts/SocketContext';
 import { usePresence } from '../../hooks/usePresence';
-import PresenceIndicator from '../Chat/PresenceIndicator';
-import type { DmConversationWithDetails, DmMessage } from '@chat-app/shared';
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleString('ja-JP', {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
+import { useDmConversationsSocket } from '../../hooks/useDmConversationsSocket';
+import DmListRow from './DmListRow';
+import type { DmConversationWithDetails } from '@chat-app/shared';
 
 export interface DmConversationListProps {
   conversations: DmConversationWithDetails[];
@@ -38,6 +17,11 @@ export interface DmConversationListProps {
   ) => void;
 }
 
+/**
+ * DMPage の左カラム用 DM 一覧 (280px 幅、expanded variant)。
+ * Step 8e-4: 行レンダリングを `DmListRow` に、socket 購読を `useDmConversationsSocket`
+ * に切り出して `SidebarDmList` と共通化。
+ */
 export default function DmConversationList({
   conversations,
   activeConvId,
@@ -49,42 +33,11 @@ export default function DmConversationList({
   const socket = useSocket();
   const presence = usePresence(socket);
 
-  // Socket.IO: new_dm_message イベントで会話一覧を更新
-  useEffect(() => {
-    if (!socket) return;
-
-    const handleNewDmMessage = (msg: DmMessage) => {
-      if (msg.conversationId !== activeConvId && msg.senderId !== currentUserId) {
-        // 非アクティブ会話の未読数更新
-        onConversationsChange((prev) =>
-          prev.map((c) =>
-            c.id === msg.conversationId ? { ...c, unreadCount: c.unreadCount + 1 } : c,
-          ),
-        );
-      }
-      // 会話一覧の最新メッセージを更新
-      onConversationsChange((prev) =>
-        prev.map((c) =>
-          c.id === msg.conversationId
-            ? {
-                ...c,
-                lastMessage: {
-                  content: msg.content,
-                  createdAt: msg.createdAt,
-                  senderId: msg.senderId,
-                },
-                updatedAt: msg.createdAt,
-              }
-            : c,
-        ),
-      );
-    };
-
-    socket.on('new_dm_message', handleNewDmMessage);
-    return () => {
-      socket.off('new_dm_message', handleNewDmMessage);
-    };
-  }, [socket, activeConvId, currentUserId, onConversationsChange]);
+  useDmConversationsSocket({
+    activeConvId,
+    currentUserId,
+    setConversations: onConversationsChange,
+  });
 
   return (
     <Box
@@ -127,57 +80,14 @@ export default function DmConversationList({
         ) : (
           <List disablePadding>
             {conversations.map((conv) => (
-              <ListItem key={conv.id} disablePadding>
-                <ListItemButton
-                  selected={conv.id === activeConvId}
-                  onClick={() => onSelectConversation(conv.id)}
-                >
-                  <ListItemAvatar sx={{ minWidth: 40 }}>
-                    <Badge
-                      badgeContent={conv.unreadCount > 0 ? conv.unreadCount : undefined}
-                      color="error"
-                      max={9}
-                    >
-                      <Box sx={{ position: 'relative', width: 32, height: 32 }}>
-                        <Avatar
-                          src={conv.otherUser.avatarUrl ?? undefined}
-                          sx={{ width: 32, height: 32 }}
-                        >
-                          {conv.otherUser.username[0].toUpperCase()}
-                        </Avatar>
-                        <PresenceIndicator state={presence.get(conv.otherUser.id)} size={9} />
-                      </Box>
-                    </Badge>
-                  </ListItemAvatar>
-                  <ListItemText
-                    primary={
-                      <Typography
-                        variant="body2"
-                        style={{ fontWeight: conv.unreadCount > 0 ? 'bold' : 'normal' }}
-                        noWrap
-                      >
-                        {conv.otherUser.displayName ?? conv.otherUser.username}
-                      </Typography>
-                    }
-                    secondary={
-                      conv.lastMessage ? (
-                        <Typography variant="caption" noWrap color="text.secondary">
-                          {conv.lastMessage.content}
-                        </Typography>
-                      ) : undefined
-                    }
-                  />
-                  {conv.lastMessage && (
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      sx={{ ml: 0.5, flexShrink: 0 }}
-                    >
-                      {formatDate(conv.lastMessage.createdAt)}
-                    </Typography>
-                  )}
-                </ListItemButton>
-              </ListItem>
+              <DmListRow
+                key={conv.id}
+                conversation={conv}
+                variant="expanded"
+                isActive={conv.id === activeConvId}
+                presenceState={presence.get(conv.otherUser.id)}
+                onClick={() => onSelectConversation(conv.id)}
+              />
             ))}
           </List>
         )}

--- a/packages/client/src/components/DM/DmListRow.tsx
+++ b/packages/client/src/components/DM/DmListRow.tsx
@@ -1,0 +1,105 @@
+import {
+  Avatar,
+  Badge,
+  Box,
+  ListItem,
+  ListItemAvatar,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import type { DmConversationWithDetails, PresenceState } from '@chat-app/shared';
+import PresenceIndicator from '../Chat/PresenceIndicator';
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleString('ja-JP', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+interface Props {
+  conversation: DmConversationWithDetails;
+  /**
+   * `expanded`: DMPage 用。32px avatar + presence + lastMessage プレビュー + 時刻
+   * `compact`: Sidebar 用。24px avatar + 名前のみ
+   */
+  variant: 'expanded' | 'compact';
+  isActive?: boolean;
+  presenceState?: PresenceState;
+  onClick: () => void;
+}
+
+/**
+ * Step 8e-4: DmConversationList と SidebarDmList の共通行コンポーネント。
+ * variant で密度・プレビュー有無を切り替える。
+ */
+export default function DmListRow({
+  conversation: conv,
+  variant,
+  isActive = false,
+  presenceState,
+  onClick,
+}: Props) {
+  const isExpanded = variant === 'expanded';
+  const avatarSize = isExpanded ? 32 : 24;
+  const avatarMinWidth = isExpanded ? 40 : 32;
+  const showPreview = isExpanded;
+
+  return (
+    <ListItem disablePadding>
+      <ListItemButton
+        selected={isActive}
+        onClick={onClick}
+        style={isExpanded ? undefined : { minHeight: 28, paddingTop: 0, paddingBottom: 0 }}
+      >
+        <ListItemAvatar sx={{ minWidth: avatarMinWidth }}>
+          <Badge
+            badgeContent={conv.unreadCount > 0 ? conv.unreadCount : undefined}
+            color="error"
+            max={9}
+          >
+            <Box sx={{ position: 'relative', width: avatarSize, height: avatarSize }}>
+              <Avatar
+                src={conv.otherUser.avatarUrl ?? undefined}
+                sx={{
+                  width: avatarSize,
+                  height: avatarSize,
+                  ...(isExpanded ? {} : { fontSize: 12 }),
+                }}
+              >
+                {conv.otherUser.username[0]?.toUpperCase()}
+              </Avatar>
+              {isExpanded && <PresenceIndicator state={presenceState} size={9} />}
+            </Box>
+          </Badge>
+        </ListItemAvatar>
+        <ListItemText
+          primary={
+            <Typography
+              variant="body2"
+              style={{ fontWeight: conv.unreadCount > 0 ? 'bold' : 'normal' }}
+              noWrap
+            >
+              {conv.otherUser.displayName ?? conv.otherUser.username}
+            </Typography>
+          }
+          secondary={
+            showPreview && conv.lastMessage ? (
+              <Typography variant="caption" noWrap color="text.secondary">
+                {conv.lastMessage.content}
+              </Typography>
+            ) : undefined
+          }
+        />
+        {showPreview && conv.lastMessage && (
+          <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5, flexShrink: 0 }}>
+            {formatDate(conv.lastMessage.createdAt)}
+          </Typography>
+        )}
+      </ListItemButton>
+    </ListItem>
+  );
+}

--- a/packages/client/src/components/Layout/SidebarDmList.tsx
+++ b/packages/client/src/components/Layout/SidebarDmList.tsx
@@ -1,23 +1,12 @@
-import { use, useState, useEffect, Suspense } from 'react';
-import {
-  Avatar,
-  Badge,
-  Box,
-  CircularProgress,
-  IconButton,
-  List,
-  ListItem,
-  ListItemAvatar,
-  ListItemButton,
-  ListItemText,
-  Tooltip,
-  Typography,
-} from '@mui/material';
+import { use, useState, Suspense } from 'react';
+import { Box, CircularProgress, IconButton, List, Tooltip, Typography } from '@mui/material';
 import AddCommentIcon from '@mui/icons-material/AddComment';
 import { useNavigate } from 'react-router-dom';
-import type { DmConversationWithDetails, DmMessage } from '@chat-app/shared';
+import type { DmConversationWithDetails } from '@chat-app/shared';
 import { api } from '../../api/client';
-import { useSocket } from '../../contexts/SocketContext';
+import { useAuth } from '../../contexts/AuthContext';
+import { useDmConversationsSocket } from '../../hooks/useDmConversationsSocket';
+import DmListRow from '../DM/DmListRow';
 
 /**
  * Sidebar 列下部に積む DM 会話一覧ブロック (Step 3c)。
@@ -42,41 +31,18 @@ export function resetSidebarDmListCache(): void {
 
 function SidebarDmListContent({
   conversationsPromise,
+  currentUserId,
 }: {
   conversationsPromise: Promise<{ conversations: DmConversationWithDetails[] }>;
+  currentUserId: number;
 }) {
   const { conversations: initial } = use(conversationsPromise);
   const [conversations, setConversations] = useState<DmConversationWithDetails[]>(initial);
   const navigate = useNavigate();
-  const socket = useSocket();
 
-  useEffect(() => {
-    if (!socket) return;
-    const handler = (msg: DmMessage) => {
-      setConversations((prev) =>
-        prev.map((c) =>
-          c.id === msg.conversationId
-            ? {
-                ...c,
-                lastMessage: {
-                  content: msg.content,
-                  createdAt: msg.createdAt,
-                  senderId: msg.senderId,
-                },
-                updatedAt: msg.createdAt,
-                // 相手 (otherUser) からのメッセージのみ未読数を加算
-                // (自分自身が送ったメッセージは relayed back されても加算しない)
-                unreadCount: msg.senderId === c.otherUser.id ? c.unreadCount + 1 : c.unreadCount,
-              }
-            : c,
-        ),
-      );
-    };
-    socket.on('new_dm_message', handler);
-    return () => {
-      socket.off('new_dm_message', handler);
-    };
-  }, [socket]);
+  // Step 8e-4: socket 購読を共通フックに切り出し。
+  // Sidebar はアクティブ会話の概念を持たないため activeConvId は省略 (= 常に未読加算)
+  useDmConversationsSocket({ currentUserId, setConversations });
 
   return (
     <Box
@@ -124,38 +90,12 @@ function SidebarDmListContent({
         ) : (
           <List dense disablePadding>
             {conversations.map((conv) => (
-              <ListItem key={conv.id} disablePadding>
-                <ListItemButton
-                  onClick={() => navigate(`/dm?conv=${conv.id}`)}
-                  style={{ minHeight: 28, paddingTop: 0, paddingBottom: 0 }}
-                >
-                  <ListItemAvatar sx={{ minWidth: 32 }}>
-                    <Badge
-                      badgeContent={conv.unreadCount > 0 ? conv.unreadCount : undefined}
-                      color="error"
-                      max={9}
-                    >
-                      <Avatar
-                        src={conv.otherUser.avatarUrl ?? undefined}
-                        sx={{ width: 24, height: 24, fontSize: 12 }}
-                      >
-                        {conv.otherUser.username[0]?.toUpperCase()}
-                      </Avatar>
-                    </Badge>
-                  </ListItemAvatar>
-                  <ListItemText
-                    primary={
-                      <Typography
-                        variant="body2"
-                        noWrap
-                        style={{ fontWeight: conv.unreadCount > 0 ? 'bold' : 'normal' }}
-                      >
-                        {conv.otherUser.displayName ?? conv.otherUser.username}
-                      </Typography>
-                    }
-                  />
-                </ListItemButton>
-              </ListItem>
+              <DmListRow
+                key={conv.id}
+                conversation={conv}
+                variant="compact"
+                onClick={() => navigate(`/dm?conv=${conv.id}`)}
+              />
             ))}
           </List>
         )}
@@ -166,6 +106,8 @@ function SidebarDmListContent({
 
 export default function SidebarDmList() {
   const [conversationsPromise] = useState(() => getOrCreatePromise());
+  const { user } = useAuth();
+  if (!user) return null;
   return (
     <Suspense
       fallback={
@@ -174,7 +116,7 @@ export default function SidebarDmList() {
         </Box>
       }
     >
-      <SidebarDmListContent conversationsPromise={conversationsPromise} />
+      <SidebarDmListContent conversationsPromise={conversationsPromise} currentUserId={user.id} />
     </Suspense>
   );
 }

--- a/packages/client/src/hooks/useDmConversationsSocket.ts
+++ b/packages/client/src/hooks/useDmConversationsSocket.ts
@@ -1,0 +1,60 @@
+import { useEffect } from 'react';
+import { useSocket } from '../contexts/SocketContext';
+import type { DmConversationWithDetails, DmMessage } from '@chat-app/shared';
+
+interface Options {
+  /**
+   * 現在表示中の会話 ID。一致する会話への新着メッセージは未読数をインクリメントしない。
+   * Sidebar 用 (アクティブ会話の概念なし) のときは undefined / null を渡す。
+   */
+  activeConvId?: number | null;
+  currentUserId: number;
+  setConversations: (
+    updater: (prev: DmConversationWithDetails[]) => DmConversationWithDetails[],
+  ) => void;
+}
+
+/**
+ * Step 8e-4: DmConversationList と SidebarDmList で共通だった
+ * `new_dm_message` socket 購読ロジックを抽出。
+ *
+ * 受信メッセージに対して該当会話の lastMessage / updatedAt を更新し、
+ * アクティブでない & 自分以外からのメッセージなら unreadCount をインクリメントする。
+ */
+export function useDmConversationsSocket({
+  activeConvId,
+  currentUserId,
+  setConversations,
+}: Options): void {
+  const socket = useSocket();
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handler = (msg: DmMessage) => {
+      setConversations((prev) =>
+        prev.map((c) => {
+          if (c.id !== msg.conversationId) return c;
+          const isActive = activeConvId != null && activeConvId === msg.conversationId;
+          const isOwnMessage = msg.senderId === currentUserId;
+          const shouldIncrementUnread = !isActive && !isOwnMessage;
+          return {
+            ...c,
+            lastMessage: {
+              content: msg.content,
+              createdAt: msg.createdAt,
+              senderId: msg.senderId,
+            },
+            updatedAt: msg.createdAt,
+            unreadCount: shouldIncrementUnread ? c.unreadCount + 1 : c.unreadCount,
+          };
+        }),
+      );
+    };
+
+    socket.on('new_dm_message', handler);
+    return () => {
+      socket.off('new_dm_message', handler);
+    };
+  }, [socket, activeConvId, currentUserId, setConversations]);
+}


### PR DESCRIPTION
## 概要

UI/UX ブラッシュアップ Step 8e-4。DMPage 用 `DmConversationList` と Sidebar 用 `SidebarDmList` で重複していた `new_dm_message` socket 購読ロジック・会話行レンダリングを共通化する。Step 7b 確立の責務分離パターンに沿って、フック + 純粋表示コンポーネントに切り出す (案 C)。

詳細は `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-4 セクション参照。

## 変更内容

### 新規 `useDmConversationsSocket` hook
`src/hooks/useDmConversationsSocket.ts` を新設。`new_dm_message` 受信時の lastMessage / updatedAt / unreadCount 更新ロジックを集約。

```ts
useDmConversationsSocket({
  activeConvId,    // optional (Sidebar は null)
  currentUserId,
  setConversations,
});
```

**改善**: 旧実装は `setConversations` を 2 回呼んでいた (unreadCount 更新 + lastMessage 更新)。新実装は **単一 updater で同時更新**。挙動は等価でレンダリング 1 回節約。

### 新規 `DmListRow` コンポーネント
`src/components/DM/DmListRow.tsx` を新設。共通行表示で `variant` prop により 2 種類の密度を切替:

| variant | avatar | presence | lastMessage プレビュー | 時刻 |
|---|---|---|---|---|
| `expanded` (DMPage 用) | 32px | あり | あり | あり |
| `compact` (Sidebar 用) | 24px | なし | なし | なし |

未読バッジ・isActive 反映・displayName 優先表示は両 variant 共通。

### `DmConversationList` を wrapper 化
- 旧: 全 187 行に socket useEffect + 行レンダリング全部
- 新: `useDmConversationsSocket` + `<DmListRow variant="expanded">` を使う wrapper。ヘッダー / 全体 Box / 空状態のみ自前

### `SidebarDmList` を wrapper 化
- 同様に `<DmListRow variant="compact">` を使う wrapper
- `useAuth()` で `user.id` を取得し `useDmConversationsSocket` に渡す (旧実装は currentUserId を持たなかった)

### テスト
- 新規 `DmListRow.test.tsx` (**9 it**): 共通表示 (username / displayName 優先 / 未読バッジ / onClick) / expanded プレビュー + 時刻 + isActive selected / compact プレビュー無し + 時刻無し
- `DmConversationList.test.tsx`: 「2 回 setConversations 呼ばれる」期待値を「1 回 (単一 updater)」に修正 (Step 8e-4 の改善)
- `SidebarDmList.test.tsx`: `useAuth` mock 追加 (currentUserId 必須化に対応)

red → green 確認済。

### PROGRESS.md
Step 8e-4 を 🟡 進行中に更新、対象タスク・テスト内容を詳述。

## 影響範囲

### 変更ファイル (8)
- 新規: `packages/client/src/hooks/useDmConversationsSocket.ts`
- 新規: `packages/client/src/components/DM/DmListRow.tsx`
- 新規: `packages/client/src/__tests__/DmListRow.test.tsx`
- 更新: `packages/client/src/components/DM/DmConversationList.tsx` (187 → wrapper 化)
- 更新: `packages/client/src/components/Layout/SidebarDmList.tsx` (180 → wrapper 化 + useAuth)
- 更新: `packages/client/src/__tests__/DmConversationList.test.tsx` (期待値修正)
- 更新: `packages/client/src/__tests__/SidebarDmList.test.tsx` (AuthContext mock)
- `doc/brushup-uiux-plan/PROGRESS.md`

### 互換性
- DMPage / AppLayout の使用箇所インターフェース互換 (props 変更なし)
- API (`api.dm.listConversations`) 変更なし

### 後続 Step
- **9**: モバイル対応 (最終 Step)

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (`npx vitest run` → **105 ファイル / 1550 テスト全パス**、新規 DmListRow.test.tsx で +9 件)
- [x] バックエンドユニットテストへの影響なし
- [x] TypeScript 型チェック (`npx tsc --noEmit`) → エラーなし
- [x] ESLint → クリーン
- [ ] (手動確認) DMPage 一覧 / Sidebar DM 一覧の見た目維持 + new_dm_message リアルタイム更新 → ユーザー側で実施

## 関連Issue

なし (UI/UX ブラッシュアップ統合計画 `doc/brushup-uiux-plan/PROGRESS.md` の Step 8e-4)

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] PROGRESS.md を Step 8e-4 の進捗に合わせて更新した
- [x] `it.todo` / 空ボディの `it` が残っていない