### PR TITLE
feat(layout): AppLayout モバイル幅レスポンシブ化 (Step 9a)

### DIFF
--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -240,4 +240,93 @@ describe('AppLayout', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  // Step 9a: モバイル幅 (< 768px) でのレスポンシブ化
+  describe('Step 9a: モバイル幅レスポンシブ化', () => {
+    /**
+     * matchMedia をモックしてモバイル/デスクトップを切り替えるヘルパー。
+     * `(max-width: 767px)` クエリの matches を制御する。
+     */
+    function setViewport(isMobile: boolean) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: vi.fn((query: string) => ({
+          matches: isMobile && query.includes('max-width: 767px'),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+
+    function renderResponsive(opts?: { rightPane?: boolean }) {
+      return render(
+        <MemoryRouter>
+          <AppLayout
+            sidebar={<div data-testid="custom-sidebar">SIDEBAR</div>}
+            rightPane={opts?.rightPane ? <div data-testid="custom-right">RIGHT</div> : undefined}
+          >
+            <div data-testid="custom-main">MAIN</div>
+          </AppLayout>
+        </MemoryRouter>,
+      );
+    }
+
+    it('デスクトップ幅 (>= 768px) で grid が従来の 3 列構造 (64px 240px 1fr) になる', () => {
+      setViewport(false);
+      renderResponsive();
+      const grid = screen.getByTestId('app-layout-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr' });
+    });
+
+    it('モバイル幅 (< 768px) で grid が 1fr (Main 1 列) のみになる', () => {
+      setViewport(true);
+      renderResponsive();
+      const grid = screen.getByTestId('app-layout-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: '1fr' });
+    });
+
+    it('モバイル幅で Rail (nav 要素) が描画されない', () => {
+      setViewport(true);
+      renderResponsive();
+      expect(
+        screen.queryByRole('navigation', { name: 'メインナビゲーション' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅で Sidebar 列 (app-layout-sidebar) が描画されない', () => {
+      setViewport(true);
+      renderResponsive();
+      expect(screen.queryByTestId('app-layout-sidebar')).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅で rightPane を渡しても right 列 (app-layout-right) が描画されない', () => {
+      setViewport(true);
+      renderResponsive({ rightPane: true });
+      expect(screen.queryByTestId('app-layout-right')).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅でも children (Main) は描画される', () => {
+      setViewport(true);
+      renderResponsive();
+      expect(screen.getByTestId('custom-main')).toBeInTheDocument();
+    });
+
+    it('モバイル幅で AppBar (app-layout-mobile-header) が描画される', () => {
+      setViewport(true);
+      renderResponsive();
+      expect(screen.getByTestId('app-layout-mobile-header')).toBeInTheDocument();
+    });
+
+    it('デスクトップ幅で AppBar (app-layout-mobile-header) は描画されない', () => {
+      setViewport(false);
+      renderResponsive();
+      expect(screen.queryByTestId('app-layout-mobile-header')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/client/src/__tests__/setup.ts
+++ b/packages/client/src/__tests__/setup.ts
@@ -6,3 +6,23 @@ import '@testing-library/jest-dom';
 if (typeof window !== 'undefined' && !window.HTMLElement.prototype.scrollIntoView) {
   window.HTMLElement.prototype.scrollIntoView = function () {};
 }
+
+// jsdom は matchMedia を実装していないため、デフォルト mock を入れる (Step 9a)。
+// MUI の useMediaQuery / ThemeContext からの呼び出しでエラーにならないようにする。
+// 個別テストで挙動を変えたい場合は Object.defineProperty(window, 'matchMedia', ...) で上書きする。
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}

--- a/packages/client/src/components/Layout/AppLayout.tsx
+++ b/packages/client/src/components/Layout/AppLayout.tsx
@@ -1,7 +1,10 @@
 import { ReactNode, useEffect, useState } from 'react';
-import { Box, Snackbar, Alert } from '@mui/material';
+import { Box, Snackbar, Alert, useMediaQuery } from '@mui/material';
 import { useSocket } from '../../contexts/SocketContext';
 import Rail from './Rail';
+
+// Step 9a: モバイル幅ブレークポイント (claude-code-prompt.md §7 準拠 / iPad 縦は 3 列維持)
+const MOBILE_QUERY = '(max-width: 767px)';
 
 const RAIL_WIDTH = 64;
 const SIDEBAR_WIDTH = 240;
@@ -44,6 +47,8 @@ export default function AppLayout({
 }: Props) {
   const [reminderNotification, setReminderNotification] = useState<string | null>(null);
   const socket = useSocket();
+  // Step 9a: モバイル判定 (< 768px)。Rail / Sidebar / RightPane を非表示にし、上部に AppBar を出す
+  const isMobile = useMediaQuery(MOBILE_QUERY);
 
   // Step 8d: Sidebar 開閉 state (localStorage 永続化)
   const [persistedSidebarOpen, setPersistedSidebarOpen] = useState<boolean>(() => {
@@ -95,43 +100,69 @@ export default function AppLayout({
 
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+      {/* Step 9a: モバイル幅専用 AppBar (機能は 9b〜9d で順次追加) */}
+      {isMobile && (
+        <Box
+          component="header"
+          data-testid="app-layout-mobile-header"
+          sx={{
+            height: 56,
+            display: 'flex',
+            alignItems: 'center',
+            px: 2,
+            borderBottom: '1px solid var(--border)',
+            background: 'var(--bg-elev)',
+            flexShrink: 0,
+          }}
+        >
+          {/* 9c で左にハンバーガー / 9b で底部ボトムタブ / 9d で右に ContextRail トグルを追加予定 */}
+          <Box sx={{ flexGrow: 1 }} />
+        </Box>
+      )}
+
       <Box
         data-testid="app-layout-grid"
         sx={{
           flex: 1,
           display: 'grid',
-          gridTemplateColumns: rightPane
-            ? `${RAIL_WIDTH}px ${sidebarOpen ? SIDEBAR_WIDTH : 0}px 1fr ${RIGHT_PANE_WIDTH}px`
-            : `${RAIL_WIDTH}px ${sidebarOpen ? SIDEBAR_WIDTH : 0}px 1fr`,
+          gridTemplateColumns: isMobile
+            ? '1fr'
+            : rightPane
+              ? `${RAIL_WIDTH}px ${sidebarOpen ? SIDEBAR_WIDTH : 0}px 1fr ${RIGHT_PANE_WIDTH}px`
+              : `${RAIL_WIDTH}px ${sidebarOpen ? SIDEBAR_WIDTH : 0}px 1fr`,
           overflow: 'hidden',
           minHeight: 0,
         }}
       >
-        <Rail
-          sidebarOpen={sidebarOpen}
-          onToggleSidebar={
-            // Step 8e-5: 強制閉じページではトグルボタン非表示 (Rail 側で onToggleSidebar 未指定なら非表示)
-            forceSidebarClosed ? undefined : () => setPersistedSidebarOpen((v) => !v)
-          }
-        />
+        {!isMobile && (
+          <Rail
+            sidebarOpen={sidebarOpen}
+            onToggleSidebar={
+              // Step 8e-5: 強制閉じページではトグルボタン非表示 (Rail 側で onToggleSidebar 未指定なら非表示)
+              forceSidebarClosed ? undefined : () => setPersistedSidebarOpen((v) => !v)
+            }
+          />
+        )}
 
-        <Box
-          data-testid="app-layout-sidebar"
-          sx={{
-            // Step 8d 修正: display: 'none' は grid auto-placement から除外され、
-            // 後続の Main Box が Sidebar 列 (幅 0) に押し込まれて縮むバグになる。
-            // display: 'flex' を維持して grid セルを占有し続け、列幅 0 + overflow:hidden で視覚的に消す。
-            display: 'flex',
-            flexDirection: 'column',
-            overflow: 'hidden',
-            borderRight: sidebarOpen ? '1px solid var(--border)' : 'none',
-            background: 'var(--surface)',
-            minHeight: 0,
-          }}
-        >
-          {/* Step 8e-3: SidebarFooter は Rail に移動。Sidebar 列は sidebar prop の中身のみ。 */}
-          <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{sidebar}</Box>
-        </Box>
+        {!isMobile && (
+          <Box
+            data-testid="app-layout-sidebar"
+            sx={{
+              // Step 8d 修正: display: 'none' は grid auto-placement から除外され、
+              // 後続の Main Box が Sidebar 列 (幅 0) に押し込まれて縮むバグになる。
+              // display: 'flex' を維持して grid セルを占有し続け、列幅 0 + overflow:hidden で視覚的に消す。
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              borderRight: sidebarOpen ? '1px solid var(--border)' : 'none',
+              background: 'var(--surface)',
+              minHeight: 0,
+            }}
+          >
+            {/* Step 8e-3: SidebarFooter は Rail に移動。Sidebar 列は sidebar prop の中身のみ。 */}
+            <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>{sidebar}</Box>
+          </Box>
+        )}
 
         <Box
           component="main"
@@ -146,7 +177,7 @@ export default function AppLayout({
           {children}
         </Box>
 
-        {rightPane && (
+        {!isMobile && rightPane && (
           <Box
             data-testid="app-layout-right"
             sx={{


### PR DESCRIPTION
## 概要

Step 9 (モバイル対応 / 最終 Step) の **9a: AppLayout レスポンシブ化（基盤）**。

`useMediaQuery('(max-width: 767px)')` でモバイル判定を導入し、モバイル幅では Rail / Sidebar / RightPane を非表示にして Main 1 列のみのレイアウトに切り替える。上部に AppBar の仮枠 (56px) を追加し、後続サブステップ (9b〜9d) でハンバーガー / ボトムタブ / ContextRail トグルを集約する場所を確保する。

iPad 縦 (768px) 以上は従来の 3 列構造を維持する (claude-code-prompt.md §7 準拠、ユーザー合意済)。

## 変更内容

### `packages/client/src/components/Layout/AppLayout.tsx`
- `useMediaQuery('(max-width: 767px)')` で `isMobile` 判定を追加
- モバイル時:
  - `gridTemplateColumns: '1fr'` (Main 1 列のみ)
  - Rail / Sidebar / RightPane の Box を **条件付き非レンダリング**
  - 上部に `app-layout-mobile-header` (高さ 56px、`var(--bg-elev)` 背景) を追加
- デスクトップ時 (>= 768px): 従来の 3 列 / 4 列 grid をそのまま維持

### `packages/client/src/__tests__/setup.ts`
- jsdom には `window.matchMedia` が無いため、デフォルト mock (`matches: false` 固定) を safety net として追加
- 既存テスト (DarkMode.test.tsx 等) で個別に mock している箇所はそのまま動作

### `packages/client/src/__tests__/AppLayout.test.tsx`
- Step 9a describe を追加 (8 it)
- `setViewport(isMobile)` ヘルパーで `matchMedia` を上書きしてビューポート切替

## 影響範囲

- **AppLayout を使う全ページ**: デスクトップ動作は従来通り（既存テスト 1561 件全 pass）
- モバイル幅での表示は **9a 時点ではナビゲーション動線が無い**（PROGRESS.md「動線が存在しない UI は許容」方針に従う、9b/9c/9d で順次解消予定）
- 既存 `defaultSidebarOpen` / `forceSidebarClosed` / `rightPane` の振る舞いはデスクトップ幅でのみ有効化される

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (1561/1561 件)
- [x] バックエンドユニットテストがすべてパスする (本 PR では変更なし)
- [x] ビルドが正常に完了すること (`npm run build` 成功)
- [ ] 手動確認: モバイル幅 (< 768px) でリサイズし AppBar 出現 / Rail/Sidebar 消失をブラウザで確認

## 関連Issue

PROGRESS.md Step 9a (モバイル対応 - AppLayout レスポンシブ化基盤)。Step 9 全体の最終受け入れ基準は claude-code-prompt.md §7 を参照。

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（PROGRESS.md はマージ後に統合ブランチで更新）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)