### PR TITLE
feat(layout): モバイル AppBar (検索 + 3 点メニュー) + BottomNav 5 タブ (Step 9b)

### DIFF
--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -241,6 +241,90 @@ describe('AppLayout', () => {
     });
   });
 
+  // Step 9b: モバイル幅 AppBar (検索アイコン + 3 点メニュー) と BottomNav 描画
+  describe('Step 9b: モバイル AppBar / BottomNav', () => {
+    function setViewportMobile(isMobile: boolean) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: vi.fn((query: string) => ({
+          matches: isMobile && query.includes('max-width: 767px'),
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+
+    function renderForViewport(role: 'user' | 'admin' = 'user') {
+      mockUser.role = role;
+      return render(
+        <MemoryRouter>
+          <AppLayout sidebar={<div />}>
+            <div />
+          </AppLayout>
+        </MemoryRouter>,
+      );
+    }
+
+    it('モバイル幅で AppBar 内に検索アイコンボタン (aria-label="検索") が表示される', () => {
+      setViewportMobile(true);
+      renderForViewport();
+      expect(screen.getByRole('button', { name: '検索' })).toBeInTheDocument();
+    });
+
+    it('モバイル幅で AppBar 内に 3 点メニューボタン (aria-label="メニュー") が表示される', () => {
+      setViewportMobile(true);
+      renderForViewport();
+      expect(screen.getByRole('button', { name: 'メニュー' })).toBeInTheDocument();
+    });
+
+    it('3 点メニュークリックで「ブックマーク」「テンプレート」項目が表示される', async () => {
+      setViewportMobile(true);
+      renderForViewport();
+      await screen.getByRole('button', { name: 'メニュー' }).click();
+      expect(screen.getByRole('menuitem', { name: /ブックマーク/ })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /テンプレート/ })).toBeInTheDocument();
+    });
+
+    it('admin ロールのとき 3 点メニューに「管理」項目が表示される', async () => {
+      setViewportMobile(true);
+      renderForViewport('admin');
+      await screen.getByRole('button', { name: 'メニュー' }).click();
+      expect(screen.getByRole('menuitem', { name: /管理/ })).toBeInTheDocument();
+    });
+
+    it('一般ユーザーのとき 3 点メニューに「管理」項目は表示されない', async () => {
+      setViewportMobile(true);
+      renderForViewport('user');
+      await screen.getByRole('button', { name: 'メニュー' }).click();
+      expect(screen.queryByRole('menuitem', { name: /管理/ })).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅で MobileBottomNav (data-testid="mobile-bottom-nav") が描画される', () => {
+      setViewportMobile(true);
+      renderForViewport();
+      expect(screen.getByTestId('mobile-bottom-nav')).toBeInTheDocument();
+    });
+
+    it('デスクトップ幅で MobileBottomNav は描画されない', () => {
+      setViewportMobile(false);
+      renderForViewport();
+      expect(screen.queryByTestId('mobile-bottom-nav')).not.toBeInTheDocument();
+    });
+
+    it('デスクトップ幅で AppBar の検索アイコン / 3 点メニューも描画されない (既存挙動維持)', () => {
+      setViewportMobile(false);
+      renderForViewport();
+      expect(screen.queryByRole('button', { name: '検索' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'メニュー' })).not.toBeInTheDocument();
+    });
+  });
+
   // Step 9a: モバイル幅 (< 768px) でのレスポンシブ化
   describe('Step 9a: モバイル幅レスポンシブ化', () => {
     /**

--- a/packages/client/src/__tests__/MobileBottomNav.test.tsx
+++ b/packages/client/src/__tests__/MobileBottomNav.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * components/Layout/MobileBottomNav.tsx のユニットテスト
+ *
+ * テスト対象: モバイル幅 (< 768px) 時に画面下部に固定表示される 5 タブナビ
+ * 戦略:
+ *   - useDmUnreadCount / useMentionUnreadCount をモックする (既存 Rail.test.tsx と同じ方針)
+ *   - react-router-dom は実体を使い MemoryRouter でラップする (NavLink を使うため)
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import MobileBottomNav from '../components/Layout/MobileBottomNav';
+
+const mockDmUnread = vi.fn(() => 0);
+const mockMentionUnread = vi.fn(() => 0);
+
+vi.mock('../hooks/useDmUnreadCount', () => ({
+  useDmUnreadCount: () => mockDmUnread(),
+}));
+vi.mock('../hooks/useMentionUnreadCount', () => ({
+  useMentionUnreadCount: () => mockMentionUnread(),
+}));
+
+function renderNav(initialPath: string = '/') {
+  mockDmUnread.mockReturnValue(0);
+  mockMentionUnread.mockReturnValue(0);
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <MobileBottomNav />
+    </MemoryRouter>,
+  );
+}
+
+describe('MobileBottomNav', () => {
+  it('5 タブ (受信箱 / チャット / DM / カレンダー / タスク) すべてが表示される', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: '受信箱' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'チャット' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'DM' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'カレンダー' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'タスク' })).toBeInTheDocument();
+  });
+
+  it('受信箱タブのリンク先が "/" である', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('href', '/');
+  });
+
+  it('チャットタブのリンク先が "/chat" である', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'チャット' })).toHaveAttribute('href', '/chat');
+  });
+
+  it('DM タブのリンク先が "/dm" である', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'DM' })).toHaveAttribute('href', '/dm');
+  });
+
+  it('カレンダータブのリンク先が "/calendar" である', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'カレンダー' })).toHaveAttribute('href', '/calendar');
+  });
+
+  it('タスクタブのリンク先が "/tasks" である', () => {
+    renderNav();
+    expect(screen.getByRole('link', { name: 'タスク' })).toHaveAttribute('href', '/tasks');
+  });
+
+  it('受信箱タブにメンション未読バッジ (mentionUnreadCount > 0) が表示される', () => {
+    mockMentionUnread.mockReturnValue(3);
+    render(
+      <MemoryRouter initialEntries={['/chat']}>
+        <MobileBottomNav />
+      </MemoryRouter>,
+    );
+    const inboxLink = screen.getByRole('link', { name: '受信箱' });
+    expect(within(inboxLink).getByText('3')).toBeInTheDocument();
+  });
+
+  it('DM タブに DM 未読バッジ (dmUnreadCount > 0) が表示される', () => {
+    mockDmUnread.mockReturnValue(5);
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <MobileBottomNav />
+      </MemoryRouter>,
+    );
+    const dmLink = screen.getByRole('link', { name: 'DM' });
+    expect(within(dmLink).getByText('5')).toBeInTheDocument();
+  });
+
+  it('現在パスが "/" のとき受信箱タブが aria-current="page" になる', () => {
+    renderNav('/');
+    expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/packages/client/src/components/Layout/AppLayout.tsx
+++ b/packages/client/src/components/Layout/AppLayout.tsx
@@ -1,7 +1,26 @@
 import { ReactNode, useEffect, useState } from 'react';
-import { Box, Snackbar, Alert, useMediaQuery } from '@mui/material';
+import {
+  Box,
+  Snackbar,
+  Alert,
+  useMediaQuery,
+  IconButton,
+  Tooltip,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+} from '@mui/material';
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import BookmarkBorderOutlinedIcon from '@mui/icons-material/BookmarkBorderOutlined';
+import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
+import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettingsOutlined';
+import { NavLink, useNavigate } from 'react-router-dom';
 import { useSocket } from '../../contexts/SocketContext';
+import { useAuth } from '../../contexts/AuthContext';
 import Rail from './Rail';
+import MobileBottomNav from './MobileBottomNav';
 
 // Step 9a: モバイル幅ブレークポイント (claude-code-prompt.md §7 準拠 / iPad 縦は 3 列維持)
 const MOBILE_QUERY = '(max-width: 767px)';
@@ -49,6 +68,16 @@ export default function AppLayout({
   const socket = useSocket();
   // Step 9a: モバイル判定 (< 768px)。Rail / Sidebar / RightPane を非表示にし、上部に AppBar を出す
   const isMobile = useMediaQuery(MOBILE_QUERY);
+  const navigate = useNavigate();
+  // Step 9b: モバイル AppBar の 3 点メニュー (低頻度ナビ項目)
+  const { user } = useAuth();
+  const [moreMenuAnchor, setMoreMenuAnchor] = useState<null | HTMLElement>(null);
+  const moreMenuOpen = Boolean(moreMenuAnchor);
+  const handleMoreMenuClose = () => setMoreMenuAnchor(null);
+  const handleMoreMenuNavigate = (to: string) => {
+    handleMoreMenuClose();
+    navigate(to);
+  };
 
   // Step 8d: Sidebar 開閉 state (localStorage 永続化)
   const [persistedSidebarOpen, setPersistedSidebarOpen] = useState<boolean>(() => {
@@ -100,7 +129,7 @@ export default function AppLayout({
 
   return (
     <Box sx={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      {/* Step 9a: モバイル幅専用 AppBar (機能は 9b〜9d で順次追加) */}
+      {/* Step 9a/9b: モバイル幅専用 AppBar (9c でハンバーガー / 9d で ContextRail トグル追加予定) */}
       {isMobile && (
         <Box
           component="header"
@@ -109,14 +138,93 @@ export default function AppLayout({
             height: 56,
             display: 'flex',
             alignItems: 'center',
+            gap: 1,
             px: 2,
             borderBottom: '1px solid var(--border)',
             background: 'var(--bg-elev)',
             flexShrink: 0,
           }}
         >
-          {/* 9c で左にハンバーガー / 9b で底部ボトムタブ / 9d で右に ContextRail トグルを追加予定 */}
+          {/* Step 9b: 左 — アプリロゴ (タップで `/` 遷移) */}
+          <Box
+            component={NavLink}
+            to="/"
+            aria-label="ホーム"
+            sx={{
+              width: 36,
+              height: 36,
+              borderRadius: 'var(--radius-md)',
+              background: 'var(--accent)',
+              color: 'var(--accent-fg)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              textDecoration: 'none',
+              flexShrink: 0,
+            }}
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="22"
+              height="22"
+              fill="currentColor"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <circle cx="6" cy="7" r="2" />
+              <circle cx="12" cy="6" r="2.4" />
+              <circle cx="18" cy="7" r="2" />
+              <path d="M5 14 L19 14 L12 22 Z" />
+            </svg>
+          </Box>
+
           <Box sx={{ flexGrow: 1 }} />
+
+          {/* Step 9b: 右 — 検索アイコン (`/search` へ遷移) */}
+          <Tooltip title="検索">
+            <IconButton
+              size="small"
+              aria-label="検索"
+              onClick={() => navigate('/search')}
+              sx={{ color: 'var(--text-muted)' }}
+            >
+              <SearchOutlinedIcon />
+            </IconButton>
+          </Tooltip>
+
+          {/* Step 9b: 右 — 3 点メニュー (低頻度ナビ項目: ブックマーク / テンプレート / 管理) */}
+          <Tooltip title="メニュー">
+            <IconButton
+              size="small"
+              aria-label="メニュー"
+              onClick={(e) => setMoreMenuAnchor(e.currentTarget)}
+              sx={{ color: 'var(--text-muted)' }}
+            >
+              <MoreVertIcon />
+            </IconButton>
+          </Tooltip>
+          <Menu anchorEl={moreMenuAnchor} open={moreMenuOpen} onClose={handleMoreMenuClose}>
+            <MenuItem onClick={() => handleMoreMenuNavigate('/bookmarks')}>
+              <ListItemIcon>
+                <BookmarkBorderOutlinedIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>ブックマーク</ListItemText>
+            </MenuItem>
+            <MenuItem onClick={() => handleMoreMenuNavigate('/templates')}>
+              <ListItemIcon>
+                <ArticleOutlinedIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>テンプレート</ListItemText>
+            </MenuItem>
+            {user?.role === 'admin' && (
+              <MenuItem onClick={() => handleMoreMenuNavigate('/admin')}>
+                <ListItemIcon>
+                  <AdminPanelSettingsOutlinedIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>管理</ListItemText>
+              </MenuItem>
+            )}
+          </Menu>
         </Box>
       )}
 
@@ -172,6 +280,8 @@ export default function AppLayout({
             flexDirection: 'column',
             overflow: 'hidden',
             minWidth: 0,
+            // Step 9b: モバイル時は底部 56px の BottomNav に被らないよう padding-bottom 確保
+            ...(isMobile ? { pb: '56px' } : {}),
           }}
         >
           {children}
@@ -191,6 +301,9 @@ export default function AppLayout({
           </Box>
         )}
       </Box>
+
+      {/* Step 9b: モバイル幅で底部 5 タブナビ */}
+      {isMobile && <MobileBottomNav />}
 
       <Snackbar
         open={!!reminderNotification}

--- a/packages/client/src/components/Layout/MobileBottomNav.tsx
+++ b/packages/client/src/components/Layout/MobileBottomNav.tsx
@@ -1,0 +1,116 @@
+/**
+ * Step 9b: モバイル幅 (< 768px) 時に画面下部に固定表示する 5 タブナビ。
+ *
+ * AppLayout から `isMobile` 判定で条件付きレンダリングされる。
+ * ナビ項目は受信箱 / チャット / DM / カレンダー / タスク の 5 つに絞り、
+ * ブックマーク / テンプレート / 管理は AppBar 右の 3 点メニュー、
+ * 検索は AppBar 右の検索アイコンに分離する。
+ */
+
+import { ReactNode } from 'react';
+import { Badge, BottomNavigation, BottomNavigationAction, Box } from '@mui/material';
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
+import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
+import MailOutlineIcon from '@mui/icons-material/MailOutline';
+import CalendarMonthOutlinedIcon from '@mui/icons-material/CalendarMonthOutlined';
+import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
+import { NavLink, useLocation } from 'react-router-dom';
+import { useDmUnreadCount } from '../../hooks/useDmUnreadCount';
+import { useMentionUnreadCount } from '../../hooks/useMentionUnreadCount';
+
+interface NavItem {
+  label: string;
+  to: string;
+  icon: ReactNode;
+  /** ルートパス "/" の部分一致を防ぐため (NavLink の end prop に渡す) */
+  end?: boolean;
+}
+
+const ITEMS: NavItem[] = [
+  { label: '受信箱', to: '/', icon: <HomeOutlinedIcon />, end: true },
+  { label: 'チャット', to: '/chat', icon: <ForumOutlinedIcon /> },
+  { label: 'DM', to: '/dm', icon: <MailOutlineIcon /> },
+  { label: 'カレンダー', to: '/calendar', icon: <CalendarMonthOutlinedIcon /> },
+  { label: 'タスク', to: '/tasks', icon: <AssignmentOutlinedIcon /> },
+];
+
+/**
+ * 現在 path に応じてアクティブ index を返す。
+ * 受信箱は完全一致 (`end`)、それ以外は前方一致で判定。
+ */
+function getActiveIndex(pathname: string): number {
+  // 完全一致するアイテムを優先
+  for (let i = 0; i < ITEMS.length; i++) {
+    if (ITEMS[i].end && pathname === ITEMS[i].to) return i;
+  }
+  // 前方一致 (より長い path を優先するため逆順走査)
+  for (let i = ITEMS.length - 1; i >= 0; i--) {
+    if (!ITEMS[i].end && pathname.startsWith(ITEMS[i].to)) return i;
+  }
+  return -1;
+}
+
+export default function MobileBottomNav() {
+  const { pathname } = useLocation();
+  const dmUnreadCount = useDmUnreadCount();
+  const mentionUnreadCount = useMentionUnreadCount();
+
+  const activeIndex = getActiveIndex(pathname);
+
+  return (
+    <Box
+      data-testid="mobile-bottom-nav"
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: (theme) => theme.zIndex.appBar,
+        borderTop: '1px solid var(--border)',
+        background: 'var(--bg-elev)',
+      }}
+    >
+      <BottomNavigation
+        value={activeIndex}
+        showLabels
+        sx={{ background: 'transparent', height: 56 }}
+      >
+        {ITEMS.map((item, idx) => {
+          const isActive = idx === activeIndex;
+          let badgeCount = 0;
+          if (item.to === '/dm') badgeCount = dmUnreadCount;
+          else if (item.to === '/') badgeCount = mentionUnreadCount;
+
+          const iconWithBadge =
+            badgeCount > 0 ? (
+              <Badge badgeContent={badgeCount} max={9} color="error">
+                {item.icon}
+              </Badge>
+            ) : (
+              item.icon
+            );
+
+          return (
+            <BottomNavigationAction
+              key={item.to}
+              component={NavLink}
+              to={item.to}
+              end={item.end}
+              label={item.label}
+              icon={iconWithBadge}
+              aria-label={item.label}
+              aria-current={isActive ? 'page' : undefined}
+              sx={{
+                minWidth: 0,
+                color: 'var(--text-muted)',
+                '&.Mui-selected, &[aria-current="page"]': {
+                  color: 'var(--accent)',
+                },
+              }}
+            />
+          );
+        })}
+      </BottomNavigation>
+    </Box>
+  );
+}


### PR DESCRIPTION
## 概要

Step 9 (モバイル対応 / 最終 Step) の **9b: Rail → ボトムタブバー**。

モバイル幅 (`< 768px`) 時に、Rail のナビ項目を底部 5 タブの `BottomNavigation` に切替。低頻度ナビ項目 (ブックマーク / テンプレート / 管理) は AppBar 右の 3 点メニューに移譲、検索は AppBar 右の検索アイコンに分離。

ユーザー合意 (2026-05-03):
- ボトムタブ 5 項目: 受信箱 / チャット / DM / カレンダー / タスク (案 B)
- 低頻度項目: 3 点メニュー経由 (案 Y)

## 変更内容

### 新規 `packages/client/src/components/Layout/MobileBottomNav.tsx`
- MUI `BottomNavigation` + `BottomNavigationAction` で 5 タブ
- `useLocation` で aria-current="page" 設定 (受信箱は `/` 完全一致、それ以外は前方一致)
- `useDmUnreadCount` / `useMentionUnreadCount` で未読バッジ表示
- `position: fixed; bottom: 0` で全画面下固定 (`zIndex: theme.zIndex.appBar`)

### `packages/client/src/components/Layout/AppLayout.tsx`
- Step 9a で追加した AppBar 仮枠に機能追加:
  - **左**: アプリロゴ (Rail と同じ SVG、タップで `/` 遷移)
  - **右**: 検索アイコン (`SearchOutlinedIcon`) → `navigate('/search')`
  - **右**: 3 点メニュー (`MoreVertIcon`) → ブックマーク / テンプレート / 管理 (admin ロールのみ)
- モバイル時 Main 領域に `pb: '56px'` を確保 (BottomNav に被らない)
- モバイル時に `<MobileBottomNav />` を最下部にレンダリング

### テスト
- 新規 `MobileBottomNav.test.tsx` (9 it):
  5 タブ表示 / リンク先 / 未読バッジ / aria-current 検証
- `AppLayout.test.tsx` に Step 9b describe (8 it):
  モバイル/デスクトップ切替 / 3 点メニュー項目 / admin 権限分岐 / BottomNav 描画

## 影響範囲

- AppLayout を使う全ページ (モバイル幅でのみ追加表示)
- デスクトップ幅 (>= 768px) では従来の 3 列表示・Rail を維持 (既存挙動完全に保持)
- Rail.tsx は変更なし (モバイル時に 9a で非表示にするだけ)

## 動作確認・テスト結果

### Playwright 実機検証

| 幅 | 表示確認内容 |
|---|---|
| **375px (モバイル)** | AppBar (ロゴ + 検索 + 3 点メニュー) / 5 タブ BottomNav 表示 / 3 点メニューに「ブックマーク」「テンプレート」表示 (一般ユーザーで「管理」非表示) |
| **1280px (デスクトップ)** | 従来の Rail + Sidebar + Main 3 列表示維持 / AppBar / BottomNav 非表示 |

### チェックリスト

- [x] フロントエンドユニットテストがすべてパスする (1578/1578 件、新規 17 件含む)
- [x] バックエンドユニットテストがすべてパスする (本 PR では変更なし)
- [x] ビルドが正常に完了すること (\`npm run build\` 成功)
- [x] (手動確認) Playwright で モバイル 375px / デスクトップ 1280px 両方の表示確認済

## 関連Issue

PROGRESS.md Step 9b (モバイル対応 — Rail → ボトムタブバー)。

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（PROGRESS.md 等）の更新が必要な場合、それらも修正した（マージ後に統合ブランチで実施）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)