### PR TITLE
chore(test): テスト品質向上 (無実体テスト削除 / トートロジー解消 / 重複統合)

### DIFF
--- a/packages/client/src/__tests__/AppLayout.test.tsx
+++ b/packages/client/src/__tests__/AppLayout.test.tsx
@@ -181,16 +181,17 @@ describe('AppLayout', () => {
       );
     }
 
-    it('localStorage に値が無いとき、defaultSidebarOpen={true} なら sidebar が表示される', () => {
+    it('localStorage に値が無いとき、defaultSidebarOpen={true} なら sidebar が表示され grid 列に SIDEBAR_WIDTH(240px) が含まれる', () => {
       renderWith({ defaultSidebarOpen: true });
       expect(screen.getByTestId('sidebar-content')).toBeVisible();
+      const grid = screen.getByTestId('app-layout-grid');
+      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr' });
     });
 
-    it('localStorage に値が無いとき、defaultSidebarOpen={false} なら grid 列の Sidebar 幅が 0px (= 視覚的に非表示)', () => {
+    it('localStorage に値が無いとき、defaultSidebarOpen={false} なら grid 列の Sidebar 幅が 0px になる (Sidebar Box は grid セルを占有し続けて Main の押し出しを防ぐ)', () => {
       renderWith({ defaultSidebarOpen: false });
       const grid = screen.getByTestId('app-layout-grid');
       expect(grid).toHaveStyle({ gridTemplateColumns: '64px 0px 1fr' });
-      // Sidebar Box は grid セルを占有し続ける (Main の押し出しを防ぐ)
       expect(screen.getByTestId('app-layout-sidebar')).toBeInTheDocument();
     });
 
@@ -206,22 +207,10 @@ describe('AppLayout', () => {
       renderWith({ defaultSidebarOpen: false });
       expect(screen.getByTestId('sidebar-content')).toBeVisible();
     });
-
-    it('Sidebar 表示時、grid 列に SIDEBAR_WIDTH(240px) が含まれる', () => {
-      renderWith({ defaultSidebarOpen: true });
-      const grid = screen.getByTestId('app-layout-grid');
-      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr' });
-    });
-
-    it('Sidebar 非表示時、grid 列の Sidebar 部分が 0px になる', () => {
-      renderWith({ defaultSidebarOpen: false });
-      const grid = screen.getByTestId('app-layout-grid');
-      expect(grid).toHaveStyle({ gridTemplateColumns: '64px 0px 1fr' });
-    });
   });
 
-  // Step 8e-5: forceSidebarClosed prop による強制閉じ
-  describe('Step 8e-5: forceSidebarClosed prop', () => {
+  // forceSidebarClosed prop による強制閉じ
+  describe('forceSidebarClosed prop', () => {
     function renderWithForce(props: { forceSidebarClosed?: boolean }) {
       return render(
         <MemoryRouter>

--- a/packages/client/src/__tests__/AuditLogView.test.tsx
+++ b/packages/client/src/__tests__/AuditLogView.test.tsx
@@ -39,17 +39,9 @@ vi.mock('../api/client', () => ({
       deleteChannel: vi.fn(),
       unarchiveChannel: vi.fn(),
       getAuditLogs: vi.fn(),
-      exportAuditLogsUrl: vi.fn(
-        (params?: { actionType?: string; actorUserId?: number; from?: string; to?: string }) => {
-          const q = new URLSearchParams();
-          if (params?.actionType) q.set('action_type', params.actionType);
-          if (params?.actorUserId !== undefined) q.set('actor_user_id', String(params.actorUserId));
-          if (params?.from) q.set('from', params.from);
-          if (params?.to) q.set('to', params.to);
-          const qs = q.toString();
-          return `/api/admin/audit-logs/export${qs ? `?${qs}` : ''}`;
-        },
-      ),
+      // 戻り値は固定 URL とし、実装側がどんな params で呼んだかは
+      // mockExportAuditLogsUrl.mock.calls[0][0] で直接検証する (mock 内 URL 生成ロジックの自己参照を避ける)
+      exportAuditLogsUrl: vi.fn().mockReturnValue('/api/admin/audit-logs/export?stub=1'),
     },
   },
 }));
@@ -79,6 +71,7 @@ const mockedApi = api as unknown as {
     deleteChannel: ReturnType<typeof vi.fn>;
     unarchiveChannel: ReturnType<typeof vi.fn>;
     getAuditLogs: ReturnType<typeof vi.fn>;
+    exportAuditLogsUrl: ReturnType<typeof vi.fn>;
   };
 };
 const mockedUseAuth = useAuth as ReturnType<typeof vi.fn>;
@@ -375,8 +368,9 @@ describe('AuditLogView エクスポートボタン', () => {
       openSpy.mockRestore();
     });
 
-    it('現在の actionType フィルタが URL のクエリパラメータに反映される', async () => {
+    it('現在の actionType フィルタが exportAuditLogsUrl の引数に反映される', async () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      mockedApi.admin.exportAuditLogsUrl.mockClear();
       await renderAuditLogView();
       await waitFor(() => expect(mockedApi.admin.getAuditLogs).toHaveBeenCalled());
 
@@ -389,13 +383,15 @@ describe('AuditLogView エクスポートボタン', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'CSV エクスポート' }));
 
-      const url = openSpy.mock.calls[0][0] as string;
-      expect(url).toContain('action_type=channel.create');
+      expect(mockedApi.admin.exportAuditLogsUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ actionType: 'channel.create' }),
+      );
       openSpy.mockRestore();
     });
 
-    it('現在の from フィルタが URL のクエリパラメータに反映される', async () => {
+    it('現在の from フィルタが exportAuditLogsUrl の引数に反映される', async () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      mockedApi.admin.exportAuditLogsUrl.mockClear();
       await renderAuditLogView();
       await waitFor(() => expect(mockedApi.admin.getAuditLogs).toHaveBeenCalled());
 
@@ -405,13 +401,15 @@ describe('AuditLogView エクスポートボタン', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'CSV エクスポート' }));
 
-      const url = openSpy.mock.calls[0][0] as string;
-      expect(url).toContain('from=2025-01-01');
+      expect(mockedApi.admin.exportAuditLogsUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ from: '2025-01-01' }),
+      );
       openSpy.mockRestore();
     });
 
-    it('現在の to フィルタが URL のクエリパラメータに反映される', async () => {
+    it('現在の to フィルタが exportAuditLogsUrl の引数に反映される', async () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      mockedApi.admin.exportAuditLogsUrl.mockClear();
       await renderAuditLogView();
       await waitFor(() => expect(mockedApi.admin.getAuditLogs).toHaveBeenCalled());
 
@@ -421,21 +419,26 @@ describe('AuditLogView エクスポートボタン', () => {
 
       await userEvent.click(screen.getByRole('button', { name: 'CSV エクスポート' }));
 
-      const url = openSpy.mock.calls[0][0] as string;
-      expect(url).toContain('to=2025-01-31');
+      expect(mockedApi.admin.exportAuditLogsUrl).toHaveBeenCalledWith(
+        expect.objectContaining({ to: '2025-01-31' }),
+      );
       openSpy.mockRestore();
     });
 
-    it('フィルタが未設定の場合はクエリパラメータなしの URL が生成される', async () => {
+    it('フィルタが未設定の場合は exportAuditLogsUrl が空オブジェクトまたはフィルタフィールドなしで呼ばれる', async () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+      mockedApi.admin.exportAuditLogsUrl.mockClear();
       await renderAuditLogView();
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
 
       await userEvent.click(screen.getByRole('button', { name: 'CSV エクスポート' }));
 
-      const url = openSpy.mock.calls[0][0] as string;
-      // フィルタなしなのでクエリパラメータなし
-      expect(url).toBe('/api/admin/audit-logs/export');
+      expect(mockedApi.admin.exportAuditLogsUrl).toHaveBeenCalledTimes(1);
+      const params = mockedApi.admin.exportAuditLogsUrl.mock.calls[0][0] ?? {};
+      expect(params.actionType).toBeUndefined();
+      expect(params.actorUserId).toBeUndefined();
+      expect(params.from).toBeUndefined();
+      expect(params.to).toBeUndefined();
       openSpy.mockRestore();
     });
   });

--- a/packages/client/src/__tests__/ChannelItem.test.tsx
+++ b/packages/client/src/__tests__/ChannelItem.test.tsx
@@ -635,35 +635,33 @@ describe('ChannelItem', () => {
   // ─────────────────────────────────────────────────────────
 
   describe('バッジ右マージン調整', () => {
-    it('ホバー時のみバッジに mr スタイルが適用される（アイコンとの重なりを回避）', () => {
-      const { container } = render(
+    // MUI sx prop の marginRight は Emotion CSS class に変換され jsdom では値検証不可。
+    // 代わりに「ホバー / 非ホバーで Badge 要素の className が異なる (= sx で別 class が出る)」
+    // ことを確認し、実装が isHovered に応じてスタイル切替している事実を間接保護する。
+    it('ホバー / 非ホバーで Badge 要素に異なる className が割り当てられる (sx 切替の保護)', () => {
+      const { container: hoveredC } = render(
         <ChannelItem
           {...defaultProps}
           channel={makeChannel({ unreadCount: 3 })}
           isHovered={true}
         />,
       );
-      const badge = container.querySelector('.MuiBadge-root') as HTMLElement | null;
-      expect(badge).not.toBeNull();
-      expect(badge!.style.marginRight).not.toBe('0px');
-    });
-
-    it('非ホバー時はバッジの mr は 0 になる', () => {
-      const { container } = render(
+      const { container: idleC } = render(
         <ChannelItem
           {...defaultProps}
           channel={makeChannel({ unreadCount: 3 })}
           isHovered={false}
         />,
       );
-      const badge = container.querySelector('.MuiBadge-root') as HTMLElement | null;
-      if (badge) {
-        expect(badge.style.marginRight).toBe('');
-      }
+      const hovered = hoveredC.querySelector('.MuiBadge-root') as HTMLElement;
+      const idle = idleC.querySelector('.MuiBadge-root') as HTMLElement;
+      expect(hovered).not.toBeNull();
+      expect(idle).not.toBeNull();
+      expect(hovered.className).not.toBe(idle.className);
     });
   });
 
-  describe('行コンパクト化 (Step 3b)', () => {
+  describe('行コンパクト化', () => {
     it('ListItemButton の minHeight が 28px に設定されている', () => {
       render(<ChannelItem {...defaultProps} channel={makeChannel({ name: 'general' })} />);
       const button = screen.getByText('# general').closest('[role="button"]') as HTMLElement;
@@ -684,11 +682,6 @@ describe('ChannelItem', () => {
     it('isPinned=false のとき、行内にピン留めアイコンが表示されない', () => {
       render(<ChannelItem {...defaultProps} channel={makeChannel()} isPinned={false} />);
       expect(screen.queryByLabelText('ピン留め済み')).not.toBeInTheDocument();
-    });
-
-    it('既存の "# {name}" テキスト表示は維持される (regression)', () => {
-      render(<ChannelItem {...defaultProps} channel={makeChannel({ name: 'general' })} />);
-      expect(screen.getByText('# general')).toBeInTheDocument();
     });
   });
 });

--- a/packages/client/src/__tests__/MentionsList.test.tsx
+++ b/packages/client/src/__tests__/MentionsList.test.tsx
@@ -101,7 +101,7 @@ describe('MentionsList (Step 6b)', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7#message-42');
     });
 
-    it('カードに role="button" / cursor: pointer が設定されている', () => {
+    it('カードに role="button" / tabindex="0" が設定されている (キーボード操作可能)', () => {
       render(
         <MemoryRouter>
           <MentionsList messages={[makeSearchResult()]} />

--- a/packages/client/src/__tests__/MessageItem.test.tsx
+++ b/packages/client/src/__tests__/MessageItem.test.tsx
@@ -326,41 +326,19 @@ describe('MessageItem', () => {
         />,
       );
 
-      await userEvent.hover(screen.getByTestId('user-avatar'));
-
-      await waitFor(() => {
-        // id（ポップアップのみに表示される）
-        expect(screen.getByText(`ID: ${dummyUsers[0].id}`)).toBeInTheDocument();
-        // 表示名（ヘッダーとポップアップ両方に出るため複数存在することを確認）
-        expect(screen.getAllByText('Alice Smith').length).toBeGreaterThanOrEqual(1);
-        // メールアドレス（ポップアップのみに表示される）
-        expect(screen.getByText(dummyUsers[0].email)).toBeInTheDocument();
-        // 勤務地（ポップアップのみに表示される）
-        expect(screen.getByText('東京')).toBeInTheDocument();
-      });
-    });
-
-    it('アバターにホバーするとその人の displayName・location を含むプロフィールポップアップが表示される', async () => {
-      const usersWithProfile = [
-        { ...dummyUsers[0], displayName: 'Alice Smith', location: '東京' },
-        { ...dummyUsers[1], displayName: null, location: null },
-      ];
-      render(
-        <MessageItem
-          message={makeMessage({ userId: 1 })}
-          currentUserId={2}
-          users={usersWithProfile}
-        />,
-      );
-
-      // ホバー前は location が表示されていない
+      // ホバー前はポップアップ専用情報 (location) が表示されていない
       expect(screen.queryByText('東京')).not.toBeInTheDocument();
 
-      // アバターにホバーする
       await userEvent.hover(screen.getByTestId('user-avatar'));
 
-      // ポップアップに displayName・location が表示される
       await waitFor(() => {
+        // id (ポップアップのみに表示される)
+        expect(screen.getByText(`ID: ${dummyUsers[0].id}`)).toBeInTheDocument();
+        // 表示名 (ヘッダーとポップアップ両方に出るため複数存在することを確認)
+        expect(screen.getAllByText('Alice Smith').length).toBeGreaterThanOrEqual(1);
+        // メールアドレス (ポップアップのみに表示される)
+        expect(screen.getByText(dummyUsers[0].email)).toBeInTheDocument();
+        // 勤務地 (ポップアップのみに表示される)
         expect(screen.getByText('東京')).toBeInTheDocument();
       });
     });
@@ -608,12 +586,6 @@ describe('MessageItem', () => {
         await waitFor(() => {
           expect(showError).toHaveBeenCalledWith('タグ名は 50 文字以内にしてください');
         });
-      });
-    });
-
-    describe('CASCADE 削除との整合', () => {
-      it('メッセージが削除済み (isDeleted=true) のときタグチップは表示されない', () => {
-        // TODO
       });
     });
   });

--- a/packages/client/src/__tests__/MobileBottomNav.test.tsx
+++ b/packages/client/src/__tests__/MobileBottomNav.test.tsx
@@ -89,8 +89,27 @@ describe('MobileBottomNav', () => {
     expect(within(dmLink).getByText('5')).toBeInTheDocument();
   });
 
-  it('現在パスが "/" のとき受信箱タブが aria-current="page" になる', () => {
-    renderNav('/');
-    expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('aria-current', 'page');
+  describe('aria-current (アクティブタブ表示)', () => {
+    it('現在パスが "/" のとき受信箱タブのみが aria-current="page" になる', () => {
+      renderNav('/');
+      expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('link', { name: 'チャット' })).not.toHaveAttribute('aria-current');
+      expect(screen.getByRole('link', { name: 'DM' })).not.toHaveAttribute('aria-current');
+    });
+
+    it('現在パスが "/chat" のときチャットタブが aria-current="page" になり、受信箱は前方一致でも active にならない (受信箱は完全一致のため)', () => {
+      renderNav('/chat');
+      expect(screen.getByRole('link', { name: 'チャット' })).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+      expect(screen.getByRole('link', { name: '受信箱' })).not.toHaveAttribute('aria-current');
+    });
+
+    it('現在パスが "/dm" のとき DM タブが aria-current="page" になる', () => {
+      renderNav('/dm');
+      expect(screen.getByRole('link', { name: 'DM' })).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('link', { name: '受信箱' })).not.toHaveAttribute('aria-current');
+    });
   });
 });

--- a/packages/client/src/__tests__/ProfilePage.test.tsx
+++ b/packages/client/src/__tests__/ProfilePage.test.tsx
@@ -190,90 +190,15 @@ describe('ProfilePage', () => {
   });
 
   describe('パスワード変更', () => {
+    // パスワード変更フォームの詳細なバリデーション・API 呼び出し・成功 / 失敗フィードバックは
+    // ProfilePage.changePassword.test.tsx で網羅。ここではフォームが ProfilePage に
+    // 統合されていることのみ確認する。
     it('現在のパスワード・新しいパスワード・確認パスワードの3フィールドが表示される', async () => {
       render(<ProfilePage />);
 
       expect(screen.getByLabelText('現在のパスワード')).toBeInTheDocument();
       expect(screen.getByLabelText('新しいパスワード')).toBeInTheDocument();
       expect(screen.getByLabelText('新しいパスワード（確認）')).toBeInTheDocument();
-    });
-
-    it('新しいパスワードと確認パスワードが一致しない場合はエラーが表示される', async () => {
-      render(<ProfilePage />);
-
-      await userEvent.type(screen.getByLabelText('現在のパスワード'), 'currentPass1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード'), 'newPassword1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード（確認）'), 'differentPass1');
-      await userEvent.click(screen.getByRole('button', { name: /パスワードを変更/i }));
-
-      await waitFor(() => {
-        expect(screen.getByText('新しいパスワードが一致しません')).toBeInTheDocument();
-      });
-      expect(mockChangePassword).not.toHaveBeenCalled();
-    });
-
-    it('新しいパスワードが8文字未満の場合はエラーが表示される', async () => {
-      render(<ProfilePage />);
-
-      await userEvent.type(screen.getByLabelText('現在のパスワード'), 'currentPass1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード'), 'short');
-      await userEvent.type(screen.getByLabelText('新しいパスワード（確認）'), 'short');
-      await userEvent.click(screen.getByRole('button', { name: /パスワードを変更/i }));
-
-      await waitFor(() => {
-        expect(
-          screen.getByText('新しいパスワードは8文字以上で入力してください'),
-        ).toBeInTheDocument();
-      });
-      expect(mockChangePassword).not.toHaveBeenCalled();
-    });
-
-    it('バリデーション通過後、api.auth.changePassword が正しいパラメータで呼ばれる', async () => {
-      mockChangePassword.mockResolvedValueOnce({ message: 'Password changed' });
-      render(<ProfilePage />);
-
-      await userEvent.type(screen.getByLabelText('現在のパスワード'), 'currentPass1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード'), 'newPassword1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード（確認）'), 'newPassword1');
-      await userEvent.click(screen.getByRole('button', { name: /パスワードを変更/i }));
-
-      await waitFor(() => {
-        expect(mockChangePassword).toHaveBeenCalledWith({
-          currentPassword: 'currentPass1',
-          newPassword: 'newPassword1',
-          confirmPassword: 'newPassword1',
-        });
-      });
-    });
-
-    it('パスワード変更成功後、フォームがリセットされスナックバーで成功メッセージが表示される', async () => {
-      mockChangePassword.mockResolvedValueOnce({ message: 'Password changed' });
-      render(<ProfilePage />);
-
-      await userEvent.type(screen.getByLabelText('現在のパスワード'), 'currentPass1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード'), 'newPassword1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード（確認）'), 'newPassword1');
-      await userEvent.click(screen.getByRole('button', { name: /パスワードを変更/i }));
-
-      await waitFor(() => {
-        expect(mockShowSuccess).toHaveBeenCalledWith('パスワードを変更しました');
-      });
-      // フォームがリセットされる
-      expect((screen.getByLabelText('現在のパスワード') as HTMLInputElement).value).toBe('');
-    });
-
-    it('API エラー時にスナックバーでエラーメッセージが表示される', async () => {
-      mockChangePassword.mockRejectedValueOnce(new Error('現在のパスワードが正しくありません'));
-      render(<ProfilePage />);
-
-      await userEvent.type(screen.getByLabelText('現在のパスワード'), 'wrongPass1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード'), 'newPassword1');
-      await userEvent.type(screen.getByLabelText('新しいパスワード（確認）'), 'newPassword1');
-      await userEvent.click(screen.getByRole('button', { name: /パスワードを変更/i }));
-
-      await waitFor(() => {
-        expect(mockShowError).toHaveBeenCalledWith('現在のパスワードが正しくありません');
-      });
     });
   });
 

--- a/packages/client/src/__tests__/QuoteReply.test.tsx
+++ b/packages/client/src/__tests__/QuoteReply.test.tsx
@@ -175,53 +175,16 @@ describe('RichEditor — 引用元情報の表示', () => {
         users={dummyUsers}
       />,
     );
-    expect(screen.getByTestId('quoted-content')).toBeInTheDocument();
+    expect(screen.getByTestId('quoted-content')).toHaveTextContent('Plain text content');
   });
 
-  it('引用プレビューの「×」ボタンをクリックすると引用がクリアされる', async () => {
-    // このテストはクライアントの状態管理を確認するため、
-    // ChatPage 側での onClearQuote ハンドラが正しく動作することを確認する。
-    // ここではモックされた RichEditor の Cancel ボタン（onCancel）で代替確認する。
-    // MessageItem の編集モードで RichEditor を表示し、キャンセルボタンが機能することを確認
-    render(
-      <MessageItem
-        message={makeMessage({ userId: 1, isDeleted: false })}
-        currentUserId={1}
-        users={dummyUsers}
-      />,
-    );
-    // Edit ボタンをクリックして RichEditor を表示
-    await userEvent.click(screen.getByRole('button', { name: /edit/i }), {
-      pointerEventsCheck: 0,
-    });
-    expect(screen.getByTestId('rich-editor')).toBeInTheDocument();
-    // Cancel ボタンをクリックしてエディタを閉じる（RichEditorスタブの中のボタンを探す）
-    const richEditor = screen.getByTestId('rich-editor');
-    const cancelBtn = richEditor.querySelector('button');
-    expect(cancelBtn).toBeInTheDocument();
-    await userEvent.click(cancelBtn!);
-    expect(screen.queryByTestId('rich-editor')).not.toBeInTheDocument();
-  });
+  // 「×」ボタンによる引用クリアの実挙動は ChatPage 側の onClearQuote を経由するため
+  // ChatPage 統合テストで検証する (ここでは MessageItem 単体スコープに留める)
 });
 
-describe('ChatPage / MessageList — 引用返信の投稿と表示', () => {
-  it('引用返信を送信するとソケットに quotedMessageId を含むデータが送られる', () => {
-    // このテストはソケットのemitに quotedMessageId が含まれることを確認する。
-    // socket.on('send_message') のハンドラ側でデータ検証する形のため、
-    // ここではモックSocketのemitが呼ばれたことと引数を確認する
-    const quotedMessageId = 5;
-    mockSocket.emit('send_message', {
-      channelId: 1,
-      content: '{"ops":[{"insert":"Reply\n"}]}',
-      mentionedUserIds: [],
-      attachmentIds: [],
-      quotedMessageId,
-    });
-    expect(mockSocket.emit).toHaveBeenCalledWith(
-      'send_message',
-      expect.objectContaining({ quotedMessageId }),
-    );
-  });
+describe('MessageList — 引用返信の投稿と表示', () => {
+  // socket.emit を経由する送信パスは ChatPage 統合テストで検証する
+  // (ここでテストすると mockSocket.emit を直接呼んで mockSocket.emit を検証する自己参照になる)
 
   it('引用元と返信内容がセットでメッセージ一覧に表示される', () => {
     const quotedMessage = {
@@ -245,31 +208,8 @@ describe('ChatPage / MessageList — 引用返信の投稿と表示', () => {
     );
     // 引用プレビューと返信内容の両方が表示される
     expect(screen.getByTestId('quoted-message-preview')).toBeInTheDocument();
-    expect(screen.getByText('Reply')).toBeInTheDocument();
-  });
-
-  it('引用元メッセージのサマリー（送信者・内容の冒頭）が返信メッセージ内に表示される', () => {
-    const quotedMessage = {
-      id: 30,
-      content: JSON.stringify({ ops: [{ insert: 'Summary content\n' }] }),
-      username: 'alice',
-      createdAt: '2024-06-01T10:00:00Z',
-    };
-    render(
-      <MessageItem
-        message={makeMessage({
-          id: 31,
-          userId: 2,
-          quotedMessageId: 30,
-          quotedMessage,
-        })}
-        currentUserId={2}
-        users={dummyUsers}
-      />,
-    );
-    // 送信者名が表示される
     expect(screen.getByTestId('quoted-username')).toHaveTextContent('alice');
-    // 内容のサマリーが表示される
-    expect(screen.getByTestId('quoted-content')).toBeInTheDocument();
+    expect(screen.getByTestId('quoted-content')).toHaveTextContent('Original');
+    expect(screen.getByText('Reply')).toBeInTheDocument();
   });
 });

--- a/packages/client/src/__tests__/Rail.test.tsx
+++ b/packages/client/src/__tests__/Rail.test.tsx
@@ -96,40 +96,17 @@ describe('Rail', () => {
   });
 
   describe('リンク先', () => {
-    it('ホームアイコンは / にリンクする', () => {
+    it.each([
+      { label: '受信箱', href: '/' },
+      { label: 'DM', href: '/dm' },
+      { label: 'カレンダー', href: '/calendar' },
+      { label: 'タスク', href: '/tasks' },
+      { label: 'ブックマーク', href: '/bookmarks' },
+      { label: 'テンプレート', href: '/templates' },
+      { label: '検索', href: '/search' },
+    ])('$label アイコンは $href にリンクする', ({ label, href }) => {
       renderRail();
-      expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('href', '/');
-    });
-
-    it('DM アイコンは /dm にリンクする', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: 'DM' })).toHaveAttribute('href', '/dm');
-    });
-
-    it('カレンダーアイコンは /calendar にリンクする', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: 'カレンダー' })).toHaveAttribute('href', '/calendar');
-    });
-
-    it('タスクアイコンは /tasks にリンクする', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: 'タスク' })).toHaveAttribute('href', '/tasks');
-    });
-
-    it('ブックマークアイコンは /bookmarks にリンクする', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: 'ブックマーク' })).toHaveAttribute(
-        'href',
-        '/bookmarks',
-      );
-    });
-
-    it('テンプレートアイコンは /templates にリンクする', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: 'テンプレート' })).toHaveAttribute(
-        'href',
-        '/templates',
-      );
+      expect(screen.getByRole('link', { name: label })).toHaveAttribute('href', href);
     });
 
     it('admin ロール時、管理アイコンは /admin にリンクする', () => {
@@ -138,20 +115,10 @@ describe('Rail', () => {
     });
   });
 
-  describe('ロゴと検索アイコン (Step 2b で追加 / Step 7a で有効化)', () => {
+  describe('ロゴ', () => {
     it('最上部に Chat App ロゴ要素が表示される', () => {
       renderRail();
       expect(screen.getByRole('img', { name: 'Chat App ロゴ' })).toBeInTheDocument();
-    });
-
-    it('上部ナビに検索アイコン (aria-label="検索") が表示される', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: '検索' })).toBeInTheDocument();
-    });
-
-    it('検索アイコンは /search にリンクする (Step 7a で disabled 解除)', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: '検索' })).toHaveAttribute('href', '/search');
     });
   });
 
@@ -297,27 +264,8 @@ describe('Rail', () => {
     });
   });
 
-  // Step 8e-1: ロゴ刷新 + ホームラベル変更
-  describe('Step 8e-1: ロゴ刷新 (TODO #4)', () => {
-    it('Rail 最上部にロゴ画像が表示される (aria-label="Chat App ロゴ")', () => {
-      renderRail();
-      expect(screen.getByRole('img', { name: 'Chat App ロゴ' })).toBeInTheDocument();
-    });
-
-    it('"C" の文字テキストが表示されない (旧暫定デザイン撤去)', () => {
-      renderRail();
-      expect(screen.queryByText('C')).not.toBeInTheDocument();
-    });
-
-    it('ロゴに SVG 要素が含まれる (三角形 + 円の幾何学パターン)', () => {
-      renderRail();
-      const logo = screen.getByRole('img', { name: 'Chat App ロゴ' });
-      expect(logo.querySelector('svg')).toBeInTheDocument();
-    });
-  });
-
-  // Step 8e-3: SidebarFooter を Rail に統合
-  describe('Step 8e-3: SidebarFooter を Rail に統合', () => {
+  // SidebarFooter (ステータス / テーマ / 通知 / プロフィール / ログアウト) は Rail に統合
+  describe('SidebarFooter 統合', () => {
     it('Rail 内に「ステータスを設定」ボタンが表示される', () => {
       renderRail();
       expect(screen.getByRole('button', { name: 'ステータスを設定' })).toBeInTheDocument();
@@ -341,18 +289,6 @@ describe('Rail', () => {
     it('ユーザー名 (alice) は Rail 内に直接表示されない (Tooltip のみ)', () => {
       renderRail();
       expect(screen.queryByText('alice')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Step 8e-1: ホームラベルを「受信箱」に変更', () => {
-    it('上部ナビ 1 番目のリンク label が「受信箱」になっている', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: '受信箱' })).toBeInTheDocument();
-    });
-
-    it('「受信箱」リンクは / にリンクする', () => {
-      renderRail();
-      expect(screen.getByRole('link', { name: '受信箱' })).toHaveAttribute('href', '/');
     });
   });
 });

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -200,20 +200,12 @@ function renderSearch() {
   );
 }
 
-describe('SearchPage (Step 7a)', () => {
+describe('SearchPage', () => {
   describe('描画', () => {
-    it('検索クエリ入力欄が表示される', () => {
+    it('検索クエリ入力欄 / SearchFilterPanel / SearchResults が初期描画される', () => {
       renderSearch();
       expect(screen.getByLabelText('メッセージ検索')).toBeInTheDocument();
-    });
-
-    it('SearchFilterPanel が表示される', () => {
-      renderSearch();
       expect(screen.getByTestId('mock-search-filter-panel')).toBeInTheDocument();
-    });
-
-    it('SearchResults が表示される', () => {
-      renderSearch();
       expect(screen.getByTestId('mock-search-results')).toBeInTheDocument();
     });
   });

--- a/packages/client/src/__tests__/SidebarDmList.test.tsx
+++ b/packages/client/src/__tests__/SidebarDmList.test.tsx
@@ -181,37 +181,9 @@ describe('SidebarDmList', () => {
   });
 
   describe('Socket リアルタイム更新', () => {
-    it('new_dm_message を受信すると、対象会話の lastMessage が更新される', async () => {
-      mockListConversations.mockResolvedValue({
-        conversations: [
-          makeConversation({
-            id: 1,
-            otherUser: { id: 2, username: 'bob', displayName: null, avatarUrl: null },
-            lastMessage: null,
-          }),
-        ],
-      });
-      await renderSidebarDmList();
-
-      // socket.on で捕捉した new_dm_message ハンドラを呼ぶ
-      await act(async () => {
-        capturedHandlers['new_dm_message']?.({
-          id: 100,
-          conversationId: 1,
-          senderId: 2,
-          senderUsername: 'bob',
-          senderAvatarUrl: null,
-          content: 'こんにちは',
-          isRead: false,
-          createdAt: '2024-02-01T10:00:00Z',
-        });
-      });
-
-      // 行内に最終メッセージが表示される（プレビューがある実装の場合）
-      // 実装側で lastMessage を保持する state 更新が起きていることを確認するため、
-      // 別の検証方法として「会話一覧の DOM 要素数が 1 のまま」 + state 更新による再レンダー後の bob 名表示
-      expect(screen.getByText('bob')).toBeInTheDocument();
-    });
+    // SidebarDmList は compact variant で lastMessage プレビューを描画しないため、
+    // socket → state 更新パスの検証は下記 unreadCount +1 ケースで一括して行う。
+    // (DmConversationList 側 (expanded variant) で lastMessage 表示は別途検証済み)
 
     it('非アクティブ会話の new_dm_message で unreadCount が +1 される', async () => {
       mockListConversations.mockResolvedValue({

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -488,18 +488,8 @@ describe('TaskBoardPage', () => {
       expect(useDroppable).toHaveBeenCalledWith(expect.objectContaining({ id: 'done' }));
     });
 
-    it('タスクを別の列にドラッグするとステータス変更 API（PUT /tasks/order）が呼ばれる', async () => {
-      // DnD は jsdom で直接テスト困難なため、このテストは API 存在確認に留める
-      expect(mockTasksUpdateOrder).toBeDefined();
-    });
-
-    it('同一列内でドラッグするとカード順序変更 API が呼ばれる', async () => {
-      expect(mockTasksUpdateOrder).toBeDefined();
-    });
-
-    it('API 失敗時はカードの状態が元に戻る（楽観的更新のロールバック）', async () => {
-      expect(mockTasksUpdateOrder).toBeDefined();
-    });
+    // DnD の実挙動 (列間遷移 / 同一列順序変更 / 楽観的更新ロールバック) は jsdom では再現困難
+    // なため E2E (Playwright) で検証する。useDroppable の登録確認 (上記) でユニット側の責務は完了。
   });
 
   describe('タスク削除', () => {

--- a/packages/client/src/__tests__/TemplatesPage.test.tsx
+++ b/packages/client/src/__tests__/TemplatesPage.test.tsx
@@ -68,6 +68,15 @@ const mockTemplates = [
     createdAt: '',
     updatedAt: '',
   },
+  {
+    id: 3,
+    userId: 1,
+    title: 'お礼テンプレート',
+    body: 'ありがとうございます。',
+    position: 2,
+    createdAt: '',
+    updatedAt: '',
+  },
 ];
 
 async function renderPage() {
@@ -251,30 +260,50 @@ describe('TemplatesPage', () => {
   });
 
   describe('並び替え', () => {
-    it('↑ボタンを押すと対象テンプレートの position が1つ前に移動し reorder API が呼ばれる', async () => {
+    // 3 要素テンプレート [1, 2, 3] で「真ん中の 2 を↑」と「先頭の 1 を↓」が異なる結果になることで
+    // 各ボタンが独立して機能していることを検証する (2 要素配列だと両者の結果が同一になり区別不能)
+    it('真ん中要素の ↑ ボタンを押すと、その要素が 1 つ前に入れ替わって reorder API に渡される', async () => {
       const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
-      // 2番目のテンプレートの ↑ボタンをクリック（index 1 が最初の enabled なボタン）
+      // 真ん中 (index=1, id=2) の ↑ ボタンをクリック → [2, 1, 3]
       const upButtons = screen.getAllByRole('button', { name: '上に移動' });
       await user.click(upButtons[1]);
 
       expect(mockApi.templates.reorder).toHaveBeenCalledWith([
         mockTemplates[1].id,
         mockTemplates[0].id,
+        mockTemplates[2].id,
       ]);
     });
 
-    it('↓ボタンを押すと対象テンプレートの position が1つ後に移動し reorder API が呼ばれる', async () => {
+    it('先頭要素の ↓ ボタンを押すと、その要素が 1 つ後に入れ替わって reorder API に渡される', async () => {
       const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
       await renderPage();
 
+      // 先頭 (index=0, id=1) の ↓ ボタンをクリック → [2, 1, 3]
+      // ※ ↑↓ の挙動が同じになる ⇔ 2 要素配列のときのみ。3 要素以上で意味が分かれる
       const downButtons = screen.getAllByRole('button', { name: '下に移動' });
       await user.click(downButtons[0]);
 
       expect(mockApi.templates.reorder).toHaveBeenCalledWith([
         mockTemplates[1].id,
         mockTemplates[0].id,
+        mockTemplates[2].id,
+      ]);
+    });
+
+    it('真ん中要素の ↓ ボタンで [1, 2, 3] → [1, 3, 2] になる (↑↓ で結果が異なる例)', async () => {
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+      await renderPage();
+
+      const downButtons = screen.getAllByRole('button', { name: '下に移動' });
+      await user.click(downButtons[1]);
+
+      expect(mockApi.templates.reorder).toHaveBeenCalledWith([
+        mockTemplates[0].id,
+        mockTemplates[2].id,
+        mockTemplates[1].id,
       ]);
     });
 

--- a/packages/client/src/__tests__/ThreadsList.test.tsx
+++ b/packages/client/src/__tests__/ThreadsList.test.tsx
@@ -122,7 +122,7 @@ describe('ThreadsList (Step 6c)', () => {
       expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=5#message-99');
     });
 
-    it('カードに role="button" / cursor: pointer が設定されている', () => {
+    it('カードに role="button" / tabindex="0" が設定されている (キーボード操作可能)', () => {
       render(
         <MemoryRouter>
           <ThreadsList threads={[makeThread()]} />

--- a/packages/server/src/__tests__/integration/threadsSubscribed.test.ts
+++ b/packages/server/src/__tests__/integration/threadsSubscribed.test.ts
@@ -230,7 +230,10 @@ describe('GET /api/threads/subscribed', () => {
       expect(channelNames).toEqual(expect.arrayContaining(['th-ch7a', 'th-ch7b']));
     });
 
-    it('unreadCount は本 Step では 0 固定で返る', async () => {
+    // unreadCount の本実装は #236 (thread_reads テーブル設計) にて対応予定。
+    // 現状 0 固定の仕様を passing で残すと、本実装で 0 以外を返すようになったときに
+    // 検出できない (期待値 0 は仕様変更後に偽陽性になる) ため skip する。
+    it.skip('unreadCount は thread_reads 未読数を反映する (issue #236 で本実装)', async () => {
       const { token: aliceToken, userId: aliceId } = await registerUser(
         app,
         'th_alice8',
@@ -247,6 +250,7 @@ describe('GET /api/threads/subscribed', () => {
         .set('Cookie', `token=${aliceToken}`);
 
       expect(res.status).toBe(200);
+      // TODO #236: thread_reads 実装後は実際の未読件数を期待値にする
       expect(res.body.threads[0].unreadCount).toBe(0);
     });
   });


### PR DESCRIPTION
## 概要

最終 PR (\`feature/brush-up-uiux\` → \`main\`) 前のテスト品質向上。サブエージェント (\`feature-dev:code-reviewer\` 4 並列) による Step 1〜9 全テスト 50 ファイルのレビュー結果を反映した。

### 観点
1. **テスト不足**: 無実体テスト (空 it / 設定だけで検証なし)
2. **トートロジー**: 実装をそのまま検証 (mock を自分で呼んで自分を検証 / mock 内ロジック自身を検証)
3. **意味の重複**: 同じ振る舞いを複数 it で検証

## 変更内容

### Critical (確実に修正すべき)
- \`MessageItem.test.tsx\`: TODO のみの空 it 「CASCADE 削除 / タグチップ非表示」を削除
- \`TaskBoardPage.test.tsx\`: DnD の \`expect(mockTasksUpdateOrder).toBeDefined()\` のみの 3 件削除 (DnD 実挙動は jsdom で再現困難、E2E に委譲)
- \`AuditLogView.test.tsx\`: \`vi.mock\` 内で URL 生成ロジックを再実装し自身を検証していた自己参照トートロジーを修正。固定値 mock + \`exportAuditLogsUrl\` の引数検証に変更
- \`SidebarDmList.test.tsx\`: テスト名と検証内容が乖離 (lastMessage 表示しない compact variant なのに lastMessage 検証) → 削除し下の unreadCount テストに集約

### Important (重複統合 + 強化)
- \`AppLayout.test.tsx\`: 「defaultSidebarOpen + 値あり/なし」の重複 2 セット統合
- \`Rail.test.tsx\`: ホーム/受信箱/検索アイコンの重複 4 件削除、リンク先テストを \`it.each\` 化
- \`ChannelItem.test.tsx\`: バッジ \`mr\` スタイル検証が空文字でも pass する問題を className 比較に変更 (sx prop は jsdom で値検証困難な既知罠)、regression 重複削除
- \`QuoteReply.test.tsx\`: \`mockSocket.emit\` 自己参照トートロジー削除、「×ボタン引用クリア」代替確認になっていたテスト削除、表示確認の重複 2 件を 1 件に統合
- \`MessageItem.test.tsx\`: アバターホバーポップアップの重複 2 it を 1 件に統合 + ホバー前非表示確認追加
- \`ProfilePage.test.tsx\` / \`ProfilePage.changePassword.test.tsx\`: パスワード変更系の重複 5 ケースを changePassword に集約、ProfilePage 側はフィールド存在確認のみに
- \`SearchPage.test.tsx\`: 描画スタブ存在確認 3 件 (検索欄/FilterPanel/Results) を 1 件に統合
- \`TemplatesPage.test.tsx\`: ↑↓ 並び替えが 2 要素配列で同一結果になる問題を 3 要素拡張で解決、「真ん中↓ → [1,3,2]」テスト追加で挙動の差を明示
- \`MentionsList.test.tsx\` / \`ThreadsList.test.tsx\`: テスト名「cursor: pointer」言及があるがスタイル未検証 → 「role=button / tabindex=0 (キーボード操作可能)」にリライト
- \`MobileBottomNav.test.tsx\`: \`aria-current\` 検証が 1 ケースのみ → チャットアクティブ + 非 active タブが \`aria-current\` 持たないことを追加検証

### サーバ側
- \`threadsSubscribed.test.ts\`: \`unreadCount\` 0 固定検証を \`it.skip\` 化 (#236 で本実装予定)。passing で残すと本実装後に偽陽性になるため

## 数値

| 種別 | 件数 |
|---|---|
| 変更ファイル | 15 / 50 |
| 削除 / 統合 it | 約 12 |
| 強化・リライト it | 約 10 |
| 関連 issue 作成 | #236 (thread_reads 本実装) |

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (1570/1570 件)
- [x] バックエンドユニットテストがすべてパスする (1375/1376 件、1 件は意図的 skip)
- [x] ビルドが正常に完了すること (\`npm run build\` 成功)

## 関連Issue

- #236 (thread_reads テーブル設計 + ThreadSummary.unreadCount 本実装) — 本 PR で skip 化したテストの再有効化先

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント更新は不要 (テストのみ)
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない (skip は #236 を参照)

🤖 Generated with [Claude Code](https://claude.com/claude-code)