### PR TITLE
feat: thread_reads テーブル設計 + ThreadSummary.unreadCount 本実装 (#236)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -2405,5 +2405,44 @@ table "calendar_poll_votes" {
   }
 }
 
+table "thread_reads" {
+  schema  = schema.public
+  comment = "スレッド既読状態（ユーザー × ルートメッセージ / #236）"
+  column "user_id" {
+    null    = false
+    type    = integer
+    comment = "ユーザーID"
+  }
+  column "root_message_id" {
+    null    = false
+    type    = integer
+    comment = "スレッドのルートメッセージID"
+  }
+  column "last_read_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "最終既読日時（この時刻より後の返信が未読）"
+  }
+  primary_key {
+    columns = [column.user_id, column.root_message_id]
+  }
+  foreign_key "fk_thread_reads_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_thread_reads_root_message" {
+    columns     = [column.root_message_id]
+    ref_columns = [table.messages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  index "idx_thread_reads_user_root" {
+    columns = [column.user_id, column.root_message_id]
+  }
+}
+
 schema "public" {
 }

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -439,6 +439,14 @@ export function createTestDatabase() {
       voted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       PRIMARY KEY (candidate_id, user_id)
     );
+
+    -- #236 スレッド既読状態
+    CREATE TABLE IF NOT EXISTS thread_reads (
+      user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+      root_message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+      last_read_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      PRIMARY KEY (user_id, root_message_id)
+    );
   `);
 
   // pg-mem で作った Pool アダプタ
@@ -514,6 +522,7 @@ export function getSharedTestDatabase(): TestDatabase {
  */
 export async function resetTestData(db: TestDatabase): Promise<void> {
   // 外部キー参照の末端から順に削除する
+  await db.execute('DELETE FROM thread_reads', []);
   await db.execute('DELETE FROM tasks', []);
   await db.execute('DELETE FROM saved_views', []);
   await db.execute('DELETE FROM guest_links', []);

--- a/packages/server/src/__tests__/integration/threadsSubscribed.test.ts
+++ b/packages/server/src/__tests__/integration/threadsSubscribed.test.ts
@@ -230,27 +230,106 @@ describe('GET /api/threads/subscribed', () => {
       expect(channelNames).toEqual(expect.arrayContaining(['th-ch7a', 'th-ch7b']));
     });
 
-    // unreadCount の本実装は #236 (thread_reads テーブル設計) にて対応予定。
-    // 現状 0 固定の仕様を passing で残すと、本実装で 0 以外を返すようになったときに
-    // 検出できない (期待値 0 は仕様変更後に偽陽性になる) ため skip する。
-    it.skip('unreadCount は thread_reads 未読数を反映する (issue #236 で本実装)', async () => {
+    // #236: thread_reads 本実装 — 以下のテストで実際の未読件数を検証する
+    it('thread_reads が未登録の場合（一度も既読化していない）unreadCount は他者の返信数と一致する', async () => {
       const { token: aliceToken, userId: aliceId } = await registerUser(
         app,
-        'th_alice8',
-        'th_alice8@example.com',
+        'th_alice_u1',
+        'th_alice_u1@example.com',
       );
-      const { userId: bobId } = await registerUser(app, 'th_bob8', 'th_bob8@example.com');
-      const channelId = await createChannelReq(app, aliceToken, 'th-ch8');
+      const { userId: bobId } = await registerUser(app, 'th_bob_u1', 'th_bob_u1@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch-u1');
 
       const rootId = await insertMessage(channelId, bobId, 'ルート');
-      await insertReply(channelId, aliceId, '返信', rootId, rootId);
+      // alice が返信（購読登録）
+      await insertReply(channelId, aliceId, 'alice の返信', rootId, rootId);
+      // bob がさらに返信（alice から見て未読）
+      await insertReply(channelId, bobId, 'bob の返信', rootId, rootId);
 
       const res = await request(app)
         .get('/api/threads/subscribed')
         .set('Cookie', `token=${aliceToken}`);
 
       expect(res.status).toBe(200);
-      // TODO #236: thread_reads 実装後は実際の未読件数を期待値にする
+      expect(res.body.threads).toHaveLength(1);
+      // alice 自身の返信は除外し、bob の返信1件が未読
+      expect(res.body.threads[0].unreadCount).toBe(1);
+    });
+
+    it('PUT /api/threads/:rootMessageId/read で既読化すると unreadCount が 0 になる', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice_u2',
+        'th_alice_u2@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob_u2', 'th_bob_u2@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch-u2');
+
+      const rootId = await insertMessage(channelId, bobId, 'ルート');
+      await insertReply(channelId, aliceId, 'alice の返信', rootId, rootId);
+      await insertReply(channelId, bobId, 'bob の返信', rootId, rootId);
+
+      // 既読化
+      const readRes = await request(app)
+        .put(`/api/threads/${rootId}/read`)
+        .set('Cookie', `token=${aliceToken}`);
+      expect(readRes.status).toBe(204);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.threads[0].unreadCount).toBe(0);
+    });
+
+    it('既読化後に新しい返信が来ると unreadCount が増える', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice_u3',
+        'th_alice_u3@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob_u3', 'th_bob_u3@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch-u3');
+
+      const rootId = await insertMessage(channelId, bobId, 'ルート');
+      await insertReply(channelId, aliceId, 'alice の返信', rootId, rootId);
+
+      // 一度既読化
+      await request(app).put(`/api/threads/${rootId}/read`).set('Cookie', `token=${aliceToken}`);
+
+      // 既読化後に bob がさらに返信
+      await insertReply(channelId, bobId, '既読後の bob 返信', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      // 既読後の bob 返信1件が未読になる
+      expect(res.body.threads[0].unreadCount).toBe(1);
+    });
+
+    it('自分の返信は unreadCount にカウントされない', async () => {
+      const { token: aliceToken, userId: aliceId } = await registerUser(
+        app,
+        'th_alice_u4',
+        'th_alice_u4@example.com',
+      );
+      const { userId: bobId } = await registerUser(app, 'th_bob_u4', 'th_bob_u4@example.com');
+      const channelId = await createChannelReq(app, aliceToken, 'th-ch-u4');
+
+      const rootId = await insertMessage(channelId, bobId, 'ルート');
+      // alice のみが複数回返信
+      await insertReply(channelId, aliceId, 'alice の返信1', rootId, rootId);
+      await insertReply(channelId, aliceId, 'alice の返信2', rootId, rootId);
+
+      const res = await request(app)
+        .get('/api/threads/subscribed')
+        .set('Cookie', `token=${aliceToken}`);
+
+      expect(res.status).toBe(200);
+      // 自分の返信のみなので unreadCount は 0
       expect(res.body.threads[0].unreadCount).toBe(0);
     });
   });

--- a/packages/server/src/__tests__/unit/threadService.test.ts
+++ b/packages/server/src/__tests__/unit/threadService.test.ts
@@ -1,0 +1,262 @@
+/**
+ * テスト対象: threadService（thread_reads テーブル / unreadCount 計算）
+ * 戦略:
+ *   - pg-mem のインメモリ DB を使用してサービス関数を直接呼び出す
+ *   - thread_reads の UPSERT と unreadCount 計算ロジックを検証する
+ *   - AGENTS.md「テスト設計方針」に従い境界値・エラーケースを網羅する
+ */
+
+import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+
+jest.mock('../../db/database', () => testDb);
+
+import * as threadService from '../../services/threadService';
+
+/** スレッド返信を直接 INSERT してIDを返す */
+async function insertReply(
+  channelId: number,
+  userId: number,
+  content: string,
+  parentMessageId: number,
+  rootMessageId: number,
+  createdAt?: string,
+): Promise<number> {
+  const result = await testDb.execute(
+    createdAt
+      ? `INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id, created_at)
+         VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`
+      : `INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id)
+         VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+    createdAt
+      ? [channelId, userId, content, parentMessageId, rootMessageId, createdAt]
+      : [channelId, userId, content, parentMessageId, rootMessageId],
+  );
+  return result.rows[0].id as number;
+}
+
+describe('threadService - thread_reads / unreadCount', () => {
+  let aliceId: number;
+  let bobId: number;
+  let channelId: number;
+
+  beforeEach(async () => {
+    await resetTestData(testDb);
+
+    const ra = await testDb.execute(
+      'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+      ['ts_alice', 'ts_alice@example.com', 'hash'],
+    );
+    aliceId = ra.rows[0].id as number;
+
+    const rb = await testDb.execute(
+      'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+      ['ts_bob', 'ts_bob@example.com', 'hash'],
+    );
+    bobId = rb.rows[0].id as number;
+
+    const rc = await testDb.execute(
+      'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+      ['ts-ch', aliceId],
+    );
+    channelId = rc.rows[0].id as number;
+
+    await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+      channelId,
+      aliceId,
+    ]);
+    await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+      channelId,
+      bobId,
+    ]);
+  });
+
+  describe('markThreadAsRead - thread_reads の更新', () => {
+    it('スレッドを既読にすると thread_reads に last_read_at が記録される', async () => {
+      const rootId = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート'],
+        )
+      ).rows[0].id as number;
+
+      await threadService.markThreadAsRead(aliceId, rootId);
+
+      const rows = await testDb.execute(
+        'SELECT * FROM thread_reads WHERE user_id = $1 AND root_message_id = $2',
+        [aliceId, rootId],
+      );
+      expect(rows.rowCount).toBe(1);
+      expect(rows.rows[0].last_read_at).toBeTruthy();
+    });
+
+    it('同一スレッドを再度既読にすると last_read_at が更新される（UPSERT）', async () => {
+      const rootId = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート'],
+        )
+      ).rows[0].id as number;
+
+      await threadService.markThreadAsRead(aliceId, rootId);
+      const firstRows = await testDb.execute(
+        'SELECT last_read_at FROM thread_reads WHERE user_id = $1 AND root_message_id = $2',
+        [aliceId, rootId],
+      );
+      const firstReadAt = firstRows.rows[0].last_read_at as Date;
+
+      // 少し後に再度既読化
+      await new Promise((r) => setTimeout(r, 10));
+      await threadService.markThreadAsRead(aliceId, rootId);
+
+      const secondRows = await testDb.execute(
+        'SELECT last_read_at FROM thread_reads WHERE user_id = $1 AND root_message_id = $2',
+        [aliceId, rootId],
+      );
+      const secondReadAt = secondRows.rows[0].last_read_at as Date;
+
+      // レコードは 1 件のまま（重複なし）
+      const countRows = await testDb.execute(
+        'SELECT COUNT(*) as cnt FROM thread_reads WHERE user_id = $1 AND root_message_id = $2',
+        [aliceId, rootId],
+      );
+      expect(Number(countRows.rows[0].cnt)).toBe(1);
+      // last_read_at が更新されている（同じか後の時刻）
+      expect(new Date(secondReadAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(firstReadAt).getTime(),
+      );
+    });
+
+    it('存在しないメッセージIDで既読化しても例外にならず正常終了する', async () => {
+      await expect(threadService.markThreadAsRead(aliceId, 99999)).resolves.not.toThrow();
+    });
+  });
+
+  describe('listSubscribedThreads - unreadCount 計算', () => {
+    it('thread_reads レコードがない場合（一度も既読化していない）は全返信数が unreadCount になる', async () => {
+      const rootId = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート'],
+        )
+      ).rows[0].id as number;
+
+      // alice が返信してスレッド購読
+      await insertReply(channelId, aliceId, 'alice の返信', rootId, rootId);
+      // bob もさらに返信（2件目）
+      await insertReply(channelId, bobId, 'bob の返信', rootId, rootId);
+
+      // thread_reads は未登録（既読化なし）
+      const threads = await threadService.listSubscribedThreads(aliceId);
+
+      expect(threads).toHaveLength(1);
+      // 全返信2件（alice + bob）のうち alice 自身の返信を除く bob の1件が未読
+      expect(threads[0].unreadCount).toBe(1);
+    });
+
+    it('last_read_at 以降の返信のみ unreadCount にカウントされる', async () => {
+      const rootId = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート'],
+        )
+      ).rows[0].id as number;
+
+      // alice が返信してスレッド購読（古い時刻）
+      await insertReply(channelId, aliceId, 'alice の返信', rootId, rootId, '2024-01-01T00:00:00Z');
+      // bob の返信（古い）
+      await insertReply(channelId, bobId, '古い bob 返信', rootId, rootId, '2024-01-01T01:00:00Z');
+
+      // alice が既読化
+      await threadService.markThreadAsRead(aliceId, rootId);
+
+      // 既読化後に bob がさらに返信（新しい）
+      await insertReply(channelId, bobId, '新しい bob 返信', rootId, rootId);
+
+      const threads = await threadService.listSubscribedThreads(aliceId);
+
+      expect(threads).toHaveLength(1);
+      // last_read_at 以降の bob の返信1件だけが未読
+      expect(threads[0].unreadCount).toBe(1);
+    });
+
+    it('全返信を既読化済みの場合 unreadCount が 0 になる', async () => {
+      const rootId = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート'],
+        )
+      ).rows[0].id as number;
+
+      await insertReply(channelId, aliceId, 'alice の返信', rootId, rootId);
+      await insertReply(channelId, bobId, 'bob の返信', rootId, rootId);
+
+      // 全返信が完了してから既読化
+      await threadService.markThreadAsRead(aliceId, rootId);
+
+      const threads = await threadService.listSubscribedThreads(aliceId);
+
+      expect(threads).toHaveLength(1);
+      expect(threads[0].unreadCount).toBe(0);
+    });
+
+    it('自分の返信は unreadCount にカウントしない', async () => {
+      const rootId = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート'],
+        )
+      ).rows[0].id as number;
+
+      // alice のみが返信（自分の返信のみ）
+      await insertReply(channelId, aliceId, 'alice の返信1', rootId, rootId);
+      await insertReply(channelId, aliceId, 'alice の返信2', rootId, rootId);
+
+      // thread_reads 未登録（既読化なし）
+      const threads = await threadService.listSubscribedThreads(aliceId);
+
+      expect(threads).toHaveLength(1);
+      // 自分の返信のみなので unreadCount は 0
+      expect(threads[0].unreadCount).toBe(0);
+    });
+
+    it('複数スレッドそれぞれで unreadCount が独立して計算される', async () => {
+      const root1 = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート1'],
+        )
+      ).rows[0].id as number;
+      const root2 = (
+        await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, bobId, 'ルート2'],
+        )
+      ).rows[0].id as number;
+
+      // alice が両スレッドに返信
+      await insertReply(channelId, aliceId, 'alice r1', root1, root1);
+      await insertReply(channelId, aliceId, 'alice r2', root2, root2);
+
+      // bob はスレッド1に2件、スレッド2に1件追加返信
+      await insertReply(channelId, bobId, 'bob r1-1', root1, root1);
+      await insertReply(channelId, bobId, 'bob r1-2', root1, root1);
+      await insertReply(channelId, bobId, 'bob r2-1', root2, root2);
+
+      // スレッド1だけ既読化
+      await threadService.markThreadAsRead(aliceId, root1);
+
+      const threads = await threadService.listSubscribedThreads(aliceId);
+
+      expect(threads).toHaveLength(2);
+      const t1 = threads.find((t) => t.rootMessage.id === root1)!;
+      const t2 = threads.find((t) => t.rootMessage.id === root2)!;
+
+      // スレッド1は既読化済みなので unreadCount = 0
+      expect(t1.unreadCount).toBe(0);
+      // スレッド2は未読化のまま bob の1件が未読
+      expect(t2.unreadCount).toBe(1);
+    });
+  });
+});

--- a/packages/server/src/routes/threads.ts
+++ b/packages/server/src/routes/threads.ts
@@ -18,4 +18,22 @@ router.get('/subscribed', authenticateToken, async (req, res) => {
   }
 });
 
+/**
+ * PUT /api/threads/:rootMessageId/read
+ * 指定スレッドを既読にする (thread_reads を UPSERT して last_read_at を現在時刻に更新)。
+ */
+router.put('/:rootMessageId/read', authenticateToken, async (req, res) => {
+  const userId = (req as AuthenticatedRequest).userId;
+  const rootMessageId = Number(req.params.rootMessageId);
+  if (isNaN(rootMessageId)) {
+    return res.status(400).json({ error: 'Invalid rootMessageId' });
+  }
+  try {
+    await threadService.markThreadAsRead(userId, rootMessageId);
+    return res.status(204).send();
+  } catch {
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
 export default router;

--- a/packages/server/src/services/threadService.ts
+++ b/packages/server/src/services/threadService.ts
@@ -1,4 +1,4 @@
-import { query } from '../db/database';
+import { query, execute } from '../db/database';
 import type { ThreadSummary } from '@chat-app/shared';
 import * as messageService from './messageService';
 
@@ -7,6 +7,7 @@ interface ThreadAggRow {
   channel_name: string;
   reply_count: string;
   last_reply_at: string;
+  unread_count: string;
 }
 
 /**
@@ -17,7 +18,11 @@ interface ThreadAggRow {
  *   - そのルートメッセージ (root_message_id が指すメッセージ) を集約して返す
  *   - ルートメッセージが論理削除済みの場合は除外する
  *
- * unreadCount は thread_reads テーブルが未設計のため現状 0 固定 (将来本実装予定)。
+ * unreadCount:
+ *   - thread_reads テーブルの last_read_at より後に投稿された他者の返信数
+ *   - thread_reads レコードが存在しない場合は全ての他者返信が未読
+ *   - 自分自身の返信は未読にカウントしない
+ *
  * ソート: lastReplyAt 降順 (スレッド全体の最終返信時刻)。
  */
 export async function listSubscribedThreads(userId: number): Promise<ThreadSummary[]> {
@@ -27,11 +32,20 @@ export async function listSubscribedThreads(userId: number): Promise<ThreadSumma
       r.id AS root_message_id,
       c.name AS channel_name,
       COUNT(all_replies.id)::text AS reply_count,
-      MAX(all_replies.created_at) AS last_reply_at
+      MAX(all_replies.created_at) AS last_reply_at,
+      COUNT(
+        CASE
+          WHEN all_replies.user_id != $1
+            AND (tr.last_read_at IS NULL OR all_replies.created_at > tr.last_read_at)
+          THEN 1
+        END
+      )::text AS unread_count
     FROM messages r
     JOIN channels c ON c.id = r.channel_id
     LEFT JOIN messages all_replies
       ON all_replies.root_message_id = r.id AND all_replies.is_deleted = false
+    LEFT JOIN thread_reads tr
+      ON tr.root_message_id = r.id AND tr.user_id = $1
     WHERE r.is_deleted = false
       AND r.id IN (
         SELECT my_reply.root_message_id
@@ -40,7 +54,7 @@ export async function listSubscribedThreads(userId: number): Promise<ThreadSumma
           AND my_reply.user_id = $1
           AND my_reply.is_deleted = false
       )
-    GROUP BY r.id, c.name
+    GROUP BY r.id, c.name, tr.last_read_at
     ORDER BY MAX(all_replies.created_at) DESC
     `,
     [userId],
@@ -55,8 +69,27 @@ export async function listSubscribedThreads(userId: number): Promise<ThreadSumma
       channelName: row.channel_name,
       replyCount: Number(row.reply_count),
       lastReplyAt: row.last_reply_at,
-      unreadCount: 0, // thread_reads テーブル未設計のため 0 固定
+      unreadCount: Number(row.unread_count),
     });
   }
   return summaries;
+}
+
+/**
+ * スレッドを既読にする。
+ * thread_reads テーブルに UPSERT し last_read_at を現在時刻に更新する。
+ * rootMessageId が存在しない場合は何もしない（冪等に無視する）。
+ */
+export async function markThreadAsRead(userId: number, rootMessageId: number): Promise<void> {
+  // 存在しないメッセージIDの場合は FK 違反を避けて何もしない
+  await execute(
+    `
+    INSERT INTO thread_reads (user_id, root_message_id, last_read_at)
+    SELECT $1::integer, $2::integer, NOW()
+    WHERE EXISTS (SELECT 1 FROM messages WHERE id = $2::integer)
+    ON CONFLICT (user_id, root_message_id)
+    DO UPDATE SET last_read_at = NOW()
+    `,
+    [userId, rootMessageId],
+  );
 }

--- a/packages/shared/src/types/thread.ts
+++ b/packages/shared/src/types/thread.ts
@@ -5,7 +5,8 @@ import type { Message } from './message';
  *
  * 「購読中スレッド」= 自分が返信投稿 (parent_message_id IS NOT NULL かつ user_id = me) した
  * スレッドのルートメッセージ。
- * unreadCount は thread_reads テーブル未設計のため現状 0 固定 (将来本実装予定)。
+ * unreadCount は thread_reads テーブルの last_read_at より後に投稿された他者の返信数。
+ * 自分自身の返信は未読にカウントしない。
  */
 export interface ThreadSummary {
   rootMessage: Message;


### PR DESCRIPTION
## 概要

Inbox の「スレッド」タブで使う `ThreadSummary.unreadCount` が `thread_reads` テーブル未設計のため 0 固定になっていた問題を解消する。`thread_reads` テーブルを新設し、既読管理と未読件数の正確な計算を実装した。

## 変更内容

- **`db/schema.hcl`**: `thread_reads` テーブルを追加（`user_id × root_message_id` 複合主キー、`last_read_at TIMESTAMPTZ`）
- **`atlas schema apply --env local`**: マイグレーション適用済み
- **`threadService.ts`**:
  - `listSubscribedThreads` を改修 — `thread_reads` と LEFT JOIN して `unread_count` を計算。自分の返信は除外し、`last_read_at` 以降の他者返信のみをカウント
  - `markThreadAsRead` を新設 — `thread_reads` に UPSERT して `last_read_at` を現在時刻に更新。存在しないメッセージIDは何もしない
- **`routes/threads.ts`**: `PUT /api/threads/:rootMessageId/read` エンドポイントを追加（204 No Content）
- **`pgTestHelper.ts`**: `thread_reads` テーブルをインメモリ DB スキーマと `resetTestData` に追加
- **`shared/src/types/thread.ts`**: `unreadCount` のコメントを本実装の仕様に更新

## 影響範囲

- `packages/server/src/services/threadService.ts`
- `packages/server/src/routes/threads.ts`
- `packages/server/src/__tests__/__fixtures__/pgTestHelper.ts`
- `packages/server/src/__tests__/integration/threadsSubscribed.test.ts`（既存テスト変更あり — 下記参照）
- `packages/server/src/__tests__/unit/threadService.test.ts`（新規）
- `packages/shared/src/types/thread.ts`
- `db/schema.hcl`

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（変更なし、影響なし）
- [x] バックエンドユニットテストがすべてパスする（65 スイート / 1387 件 全通過）
- [x] ビルドが正常に完了すること

### 既存テストの変更

| ファイル | 変更箇所 | 変更理由 |
|---|---|---|
| `integration/threadsSubscribed.test.ts` | `it.skip('unreadCount は thread_reads 未読数を反映する...')` を削除し、境界テスト4件（`it`）に置き換え | `#236` 本実装にあわせて `it.skip` を有効化 |

## 関連Issue

Fixes #236

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）