### PR TITLE
fix: ホームアイコンのメンション未読バッジが既読化後も更新されない問題を修正

### DIFF
--- a/packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx
+++ b/packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx
@@ -1,17 +1,15 @@
 /**
- * テスト対象: hooks/useMentionUnreadCount.ts (Step 6d / 保留 TODO #5)
+ * テスト対象: hooks/useMentionUnreadCount.ts (Rail のホームアイコン メンション未読バッジ用集計フック)
  *
- * Rail のホームアイコン (Inbox) に出すメンション未読数バッジ用集計フック。
- * Step 6b で追加した `api.messages.search('', { mentionedToMe: true, unreadOnly: true })`
- * を再利用して count を取得する。
+ * 修正 Issue #240: 依存配列が [] のため初回マウント時の値で固定されていた問題を修正。
  *
  * 戦略:
  *   - api.messages.search をモックして件数を制御する
- *   - 現在パスが Inbox (ホーム `/`) のときは count を 0 に潰す（自分が見ている画面に
- *     バッジを出すと冗長になるため）
+ *   - SocketContext をモックして mention_updated イベントを任意のタイミングで発火させる
+ *   - MemoryRouter で initialEntries を切り替え、現在パスによる挙動を検証する
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import type { ReactNode } from 'react';
@@ -27,6 +25,19 @@ vi.mock('../../api/client', () => ({
   },
 }));
 
+type MentionUpdatedHandler = (data: { channelId: number; mentionCount: number }) => void;
+
+const mockSocket = {
+  on: vi.fn<(event: string, handler: MentionUpdatedHandler) => void>(),
+  off: vi.fn<(event: string, handler: MentionUpdatedHandler) => void>(),
+};
+
+let socketReturnValue: typeof mockSocket | null = mockSocket;
+
+vi.mock('../../contexts/SocketContext', () => ({
+  useSocket: () => socketReturnValue,
+}));
+
 function wrapperFactory(initialPath: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return <MemoryRouter initialEntries={[initialPath]}>{children}</MemoryRouter>;
@@ -35,50 +46,167 @@ function wrapperFactory(initialPath: string) {
 
 beforeEach(() => {
   mockSearch.mockReset();
+  mockSocket.on.mockReset();
+  mockSocket.off.mockReset();
+  socketReturnValue = mockSocket;
 });
 
-describe('useMentionUnreadCount (Step 6d)', () => {
-  it('初回マウント時に api.messages.search を mentionedToMe / unreadOnly フィルタで呼ぶ', async () => {
-    mockSearch.mockResolvedValue({ messages: [] });
-    renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
-    await waitFor(() => {
-      expect(mockSearch).toHaveBeenCalledWith('', { mentionedToMe: true, unreadOnly: true });
+describe('useMentionUnreadCount', () => {
+  describe('初期取得', () => {
+    it('初回マウント時に api.messages.search を mentionedToMe / unreadOnly フィルタで呼ぶ', async () => {
+      mockSearch.mockResolvedValue({ messages: [] });
+      renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalledWith('', { mentionedToMe: true, unreadOnly: true });
+      });
+    });
+
+    it('レスポンスの messages.length をカウントとして返す', async () => {
+      mockSearch.mockResolvedValue({
+        messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      });
+      const { result } = renderHook(() => useMentionUnreadCount(), {
+        wrapper: wrapperFactory('/chat'),
+      });
+      await waitFor(() => {
+        expect(result.current).toBe(3);
+      });
+    });
+
+    it('API が失敗した場合は 0 を返す（throw しない）', async () => {
+      mockSearch.mockRejectedValue(new Error('network error'));
+      const { result } = renderHook(() => useMentionUnreadCount(), {
+        wrapper: wrapperFactory('/chat'),
+      });
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalled();
+      });
+      expect(result.current).toBe(0);
     });
   });
 
-  it('レスポンスの messages.length をカウントとして返す', async () => {
-    mockSearch.mockResolvedValue({
-      messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+  describe('Socket 受信による再フェッチ', () => {
+    it('mention_updated イベントを受信すると api.messages.search が再フェッチされる', async () => {
+      mockSearch.mockResolvedValue({ messages: [] });
+      renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('mention_updated', expect.any(Function));
+      });
+
+      const handler = mockSocket.on.mock.calls.find(([e]) => e === 'mention_updated')?.[1];
+      expect(handler).toBeDefined();
+
+      const beforeCount = mockSearch.mock.calls.length;
+      act(() => {
+        handler!({ channelId: 1, mentionCount: 2 });
+      });
+
+      await waitFor(() => {
+        expect(mockSearch.mock.calls.length).toBeGreaterThan(beforeCount);
+      });
     });
-    const { result } = renderHook(() => useMentionUnreadCount(), {
-      wrapper: wrapperFactory('/chat'),
+
+    it('再フェッチ後の件数が count に反映される', async () => {
+      // 初回は 1 件、再フェッチ後は 3 件
+      mockSearch
+        .mockResolvedValueOnce({ messages: [{ id: 1 }] })
+        .mockResolvedValueOnce({ messages: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+
+      const { result } = renderHook(() => useMentionUnreadCount(), {
+        wrapper: wrapperFactory('/chat'),
+      });
+
+      await waitFor(() => {
+        expect(result.current).toBe(1);
+      });
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('mention_updated', expect.any(Function));
+      });
+
+      const handler = mockSocket.on.mock.calls.find(([e]) => e === 'mention_updated')?.[1];
+      act(() => {
+        handler!({ channelId: 1, mentionCount: 3 });
+      });
+
+      await waitFor(() => {
+        expect(result.current).toBe(3);
+      });
     });
-    await waitFor(() => {
-      expect(result.current).toBe(3);
+
+    it('mention_updated を複数回受信するたびに再フェッチが走る', async () => {
+      mockSearch.mockResolvedValue({ messages: [] });
+      renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
+
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('mention_updated', expect.any(Function));
+      });
+
+      const handler = mockSocket.on.mock.calls.find(([e]) => e === 'mention_updated')?.[1];
+      expect(handler).toBeDefined();
+
+      act(() => {
+        handler!({ channelId: 1, mentionCount: 1 });
+      });
+      act(() => {
+        handler!({ channelId: 2, mentionCount: 2 });
+      });
+
+      // 初回 + 2 回 = 合計 3 回以上のフェッチが走る
+      await waitFor(() => {
+        expect(mockSearch.mock.calls.length).toBeGreaterThanOrEqual(3);
+      });
+    });
+
+    it('socket が null のとき mention_updated の購読は行わない', async () => {
+      socketReturnValue = null;
+      mockSearch.mockResolvedValue({ messages: [] });
+      renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalled();
+      });
+      expect(mockSocket.on).not.toHaveBeenCalled();
+    });
+
+    it('unmount 時に mention_updated の購読が解除される', async () => {
+      mockSearch.mockResolvedValue({ messages: [] });
+      const { unmount } = renderHook(() => useMentionUnreadCount(), {
+        wrapper: wrapperFactory('/chat'),
+      });
+      await waitFor(() => {
+        expect(mockSocket.on).toHaveBeenCalledWith('mention_updated', expect.any(Function));
+      });
+      unmount();
+      expect(mockSocket.off).toHaveBeenCalledWith('mention_updated', expect.any(Function));
     });
   });
 
-  it('現在パスが / (Inbox) のときは 0 を返す（内部 state は保持）', async () => {
-    mockSearch.mockResolvedValue({ messages: [{ id: 1 }, { id: 2 }] });
-    const { result } = renderHook(() => useMentionUnreadCount(), {
-      wrapper: wrapperFactory('/'),
+  describe('現在パスによる挙動', () => {
+    it('現在パスが / (Inbox) のときは 0 を返す（内部 state は保持される）', async () => {
+      mockSearch.mockResolvedValue({
+        messages: [{ id: 1 }, { id: 2 }],
+      });
+      const { result } = renderHook(() => useMentionUnreadCount(), {
+        wrapper: wrapperFactory('/'),
+      });
+      // API は呼ばれるが、location が '/' のため count は 0
+      await waitFor(() => {
+        expect(mockSearch).toHaveBeenCalled();
+      });
+      expect(result.current).toBe(0);
     });
-    // API は呼ばれるが、location が '/' のため count は 0
-    await waitFor(() => {
-      expect(mockSearch).toHaveBeenCalled();
-    });
-    expect(result.current).toBe(0);
-  });
 
-  it('API が失敗した場合は 0 を返す（throw しない）', async () => {
-    mockSearch.mockRejectedValue(new Error('boom'));
-    const { result } = renderHook(() => useMentionUnreadCount(), {
-      wrapper: wrapperFactory('/chat'),
+    it('現在パスが /chat など / 以外のときは集計値を返す', async () => {
+      mockSearch.mockResolvedValue({
+        messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      });
+      const { result } = renderHook(() => useMentionUnreadCount(), {
+        wrapper: wrapperFactory('/chat'),
+      });
+      await waitFor(() => {
+        expect(result.current).toBe(3);
+      });
     });
-    // 失敗後も throw せず 0 のまま
-    await waitFor(() => {
-      expect(mockSearch).toHaveBeenCalled();
-    });
-    expect(result.current).toBe(0);
   });
 });

--- a/packages/client/src/hooks/useMentionUnreadCount.ts
+++ b/packages/client/src/hooks/useMentionUnreadCount.ts
@@ -1,16 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { api } from '../api/client';
+import { useSocket } from '../contexts/SocketContext';
 
 /**
  * Rail のホームアイコン (Inbox) に出すメンション未読バッジ用の集計フック。
  *
  * - `api.messages.search('', { mentionedToMe: true, unreadOnly: true })` で件数を取得
+ * - Socket イベント `mention_updated` を購読し、受信のたびに再フェッチして最新件数を反映する
  * - 現在パスが Inbox (`/`) のときは 0 を返す (見ている画面のバッジは冗長になるため)
  * - API 失敗時は 0 を返す (throw しない)
  */
 export function useMentionUnreadCount(): number {
   const [count, setCount] = useState(0);
+  const socket = useSocket();
   const location = useLocation();
 
   useEffect(() => {
@@ -28,6 +31,26 @@ export function useMentionUnreadCount(): number {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handler = () => {
+      api.messages
+        .search('', { mentionedToMe: true, unreadOnly: true })
+        .then(({ messages }) => {
+          setCount(messages.length);
+        })
+        .catch(() => {
+          // 取得失敗時は現在値を維持
+        });
+    };
+
+    socket.on('mention_updated', handler);
+    return () => {
+      socket.off('mention_updated', handler);
+    };
+  }, [socket]);
 
   if (location.pathname === '/') return 0;
   return count;

--- a/packages/server/src/__tests__/channel-read-emit.test.ts
+++ b/packages/server/src/__tests__/channel-read-emit.test.ts
@@ -1,0 +1,102 @@
+/**
+ * テスト対象: POST /api/channels/:id/read（markAsRead コントローラー）の Socket.IO 配信
+ *
+ * 修正 Issue #240: markChannelAsRead 成功時に対象ユーザーへ mention_updated を emit する。
+ *
+ * 戦略:
+ *   - pg-mem のインメモリ DB を使用
+ *   - getSocketServer を jest.mock で差し替え、mention_updated emit を検証する
+ *   - supertest で HTTP リクエストを発行し、204 レスポンスと Socket emit を確認する
+ */
+
+import { createTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+jest.mock('../db/database', () => testDb);
+
+// Socket.IO サーバーモック
+const mockEmit = jest.fn();
+const mockSocketTo = jest.fn().mockReturnValue({ emit: mockEmit });
+const mockSocketServer = { to: mockSocketTo };
+
+jest.mock('../socket', () => ({
+  getSocketServer: jest.fn(() => mockSocketServer),
+}));
+
+import request from 'supertest';
+import { createApp } from '../app';
+import { registerUser, createChannelReq } from './__fixtures__/testHelpers';
+import { createMessage } from '../services/messageService';
+
+const app = createApp();
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  mockSocketTo.mockReturnValue({ emit: mockEmit });
+  await resetTestData(testDb);
+});
+
+describe('POST /api/channels/:id/read — Socket.IO mention_updated 配信', () => {
+  it('既読化成功時に user:${userId} ルームへ mention_updated が emit される', async () => {
+    const { token, userId } = await registerUser(app, 'read_emit1', 'read_emit1@t.com');
+    const channelId = await createChannelReq(app, token, 'read-emit-ch1');
+
+    // メンションメッセージを作成してから既読化する
+    await createMessage(channelId, userId, 'hello @read_emit1', [userId]);
+
+    const res = await request(app)
+      .post(`/api/channels/${channelId}/read`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(204);
+
+    // user:{userId} ルームへ emit されたこと
+    expect(mockSocketTo).toHaveBeenCalledWith(`user:${userId}`);
+    expect(mockEmit).toHaveBeenCalledWith(
+      'mention_updated',
+      expect.objectContaining({ channelId }),
+    );
+  });
+
+  it('既読化後の mention_updated の mentionCount は 0 になる', async () => {
+    const { token, userId } = await registerUser(app, 'read_emit2', 'read_emit2@t.com');
+    const channelId = await createChannelReq(app, token, 'read-emit-ch2');
+
+    // メンションメッセージを作成
+    await createMessage(channelId, userId, 'hello @me', [userId]);
+
+    await request(app).post(`/api/channels/${channelId}/read`).set('Cookie', `token=${token}`);
+
+    const emitCall = mockEmit.mock.calls.find(([event]: [string]) => event === 'mention_updated');
+    expect(emitCall).toBeDefined();
+    const payload = emitCall![1] as { channelId: number; mentionCount: number };
+    expect(payload.mentionCount).toBe(0);
+  });
+
+  it('メンションがない状態で既読化した場合も mentionCount: 0 で mention_updated が emit される', async () => {
+    const { token, userId } = await registerUser(app, 'read_emit3', 'read_emit3@t.com');
+    const channelId = await createChannelReq(app, token, 'read-emit-ch3');
+
+    // メンションなし（通常メッセージのみ）
+    const res = await request(app)
+      .post(`/api/channels/${channelId}/read`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(204);
+    // クライアントが再フェッチのトリガとして使うため、mentionCount: 0 でも emit する
+    expect(mockSocketTo).toHaveBeenCalledWith(`user:${userId}`);
+    expect(mockEmit).toHaveBeenCalledWith('mention_updated', {
+      channelId,
+      mentionCount: 0,
+    });
+  });
+
+  it('存在しないチャンネルへの既読化リクエストは 404 を返し emit しない', async () => {
+    const { token } = await registerUser(app, 'read_emit4', 'read_emit4@t.com');
+
+    const res = await request(app).post('/api/channels/99999/read').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(404);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/__tests__/socket-handler.test.ts
+++ b/packages/server/src/__tests__/socket-handler.test.ts
@@ -599,6 +599,160 @@ describe('Socket.IO ハンドラ', () => {
       });
     });
 
+    describe('edit_message イベント — メンション通知', () => {
+      const MENTIONED_USER_ID = 99;
+      const fakeEditedWithMention = {
+        id: 5,
+        channelId: 10,
+        content: 'edited @user',
+        userId: TEST_USER_ID,
+        username: TEST_USERNAME,
+        isEdited: true,
+        isDeleted: false,
+        createdAt: '',
+        updatedAt: '',
+        reactions: [],
+        mentions: [MENTIONED_USER_ID],
+        attachments: [],
+        parentMessageId: null,
+        rootMessageId: null,
+        quotedMessageId: null,
+      };
+
+      it('編集で新たにメンションを追加すると対象ユーザーに mention_updated が emit される', async () => {
+        mockedMessageService.editMessage.mockResolvedValue(fakeEditedWithMention as any);
+        mockedPushService.sendPushToUser.mockResolvedValue(undefined as any);
+        mockedChannelService.getChannelsForUser.mockResolvedValue([
+          {
+            id: 10,
+            name: 'general',
+            description: null,
+            topic: null,
+            createdBy: 1,
+            isPrivate: false,
+            postingPermission: 'everyone',
+            createdAt: '',
+            unreadCount: 0,
+            mentionCount: 1,
+          },
+        ]);
+
+        const socket = createMockSocket();
+        socket.data.userId = TEST_USER_ID;
+        socket.data.username = TEST_USERNAME;
+
+        const handlers: Record<string, (...args: unknown[]) => void> = {};
+        socket.on.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+          handlers[event] = cb;
+        });
+
+        const io = createMockIo();
+        registerMessageHandlers(io as any, socket as any);
+
+        handlers['edit_message']?.({
+          messageId: 5,
+          content: 'edited @user',
+          mentionedUserIds: [MENTIONED_USER_ID],
+        });
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(io.to).toHaveBeenCalledWith(`user:${MENTIONED_USER_ID}`);
+        expect(io.emit).toHaveBeenCalledWith('mention_updated', {
+          channelId: 10,
+          mentionCount: 1,
+        });
+      });
+
+      it('編集者自身へのメンションは mention_updated が emit されない', async () => {
+        const fakeEditedSelfMention = {
+          ...fakeEditedWithMention,
+          mentions: [TEST_USER_ID],
+        };
+        mockedMessageService.editMessage.mockResolvedValue(fakeEditedSelfMention as any);
+
+        const socket = createMockSocket();
+        socket.data.userId = TEST_USER_ID;
+        socket.data.username = TEST_USERNAME;
+
+        const handlers: Record<string, (...args: unknown[]) => void> = {};
+        socket.on.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+          handlers[event] = cb;
+        });
+
+        const io = createMockIo();
+        registerMessageHandlers(io as any, socket as any);
+
+        handlers['edit_message']?.({
+          messageId: 5,
+          content: 'edited @me',
+          mentionedUserIds: [TEST_USER_ID],
+        });
+        await new Promise((r) => setTimeout(r, 10));
+
+        // user:{TEST_USER_ID} への mention_updated は emit されない
+        const mentionUpdatedCalls = (io.emit as jest.Mock).mock.calls.filter(
+          ([event]: [string]) => event === 'mention_updated',
+        );
+        expect(mentionUpdatedCalls).toHaveLength(0);
+      });
+
+      it('通知レベルが muted のチャンネルでは mention_updated が emit されない', async () => {
+        mockedMessageService.editMessage.mockResolvedValue(fakeEditedWithMention as any);
+        mockedNotificationService.getLevel.mockResolvedValue('muted');
+
+        const socket = createMockSocket();
+        socket.data.userId = TEST_USER_ID;
+        socket.data.username = TEST_USERNAME;
+
+        const handlers: Record<string, (...args: unknown[]) => void> = {};
+        socket.on.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+          handlers[event] = cb;
+        });
+
+        const io = createMockIo();
+        registerMessageHandlers(io as any, socket as any);
+
+        handlers['edit_message']?.({
+          messageId: 5,
+          content: 'edited @user',
+          mentionedUserIds: [MENTIONED_USER_ID],
+        });
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(io.emit).not.toHaveBeenCalledWith('mention_updated', expect.anything());
+      });
+
+      it('mentionedUserIds が空の場合は mention_updated が emit されない', async () => {
+        const fakeEditedNoMention = {
+          ...fakeEditedWithMention,
+          mentions: [],
+          content: 'edited without mention',
+        };
+        mockedMessageService.editMessage.mockResolvedValue(fakeEditedNoMention as any);
+
+        const socket = createMockSocket();
+        socket.data.userId = TEST_USER_ID;
+        socket.data.username = TEST_USERNAME;
+
+        const handlers: Record<string, (...args: unknown[]) => void> = {};
+        socket.on.mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+          handlers[event] = cb;
+        });
+
+        const io = createMockIo();
+        registerMessageHandlers(io as any, socket as any);
+
+        handlers['edit_message']?.({
+          messageId: 5,
+          content: 'edited without mention',
+          mentionedUserIds: [],
+        });
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(io.emit).not.toHaveBeenCalledWith('mention_updated', expect.anything());
+      });
+    });
+
     describe('delete_message イベント', () => {
       it('delete_messageを受信するとchannel全員にmessage_deletedをemitする', async () => {
         const fakeMsg = { id: 5, channelId: 10, content: 'bye', userId: TEST_USER_ID };

--- a/packages/server/src/controllers/channelController.ts
+++ b/packages/server/src/controllers/channelController.ts
@@ -173,12 +173,26 @@ export async function updateTopic(req: Request, res: Response, next: NextFunctio
 export async function markAsRead(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const channelId = Number(req.params.id);
+    const userId = (req as AuthenticatedRequest).userId;
     const channel = await channelService.getChannelById(channelId);
     if (!channel) {
       res.status(404).json({ error: 'Channel not found' });
       return;
     }
-    await channelService.markChannelAsRead(channelId, (req as AuthenticatedRequest).userId);
+    await channelService.markChannelAsRead(channelId, userId);
+
+    // 既読化後のメンション未読数を取得し、対象ユーザーに mention_updated を通知する。
+    // Rail のホームアイコンバッジをリアルタイムに更新するために使用する（Issue #240）。
+    const channels = await channelService.getChannelsForUser(userId);
+    const updatedChannel = channels.find((c) => c.id === channelId);
+    if (updatedChannel !== undefined) {
+      const io = getSocketServer();
+      io?.to(`user:${userId}`).emit('mention_updated', {
+        channelId,
+        mentionCount: updatedChannel.mentionCount ?? 0,
+      });
+    }
+
     res.status(204).send();
   } catch (err) {
     next(err);

--- a/packages/server/src/socket/messageHandler.ts
+++ b/packages/server/src/socket/messageHandler.ts
@@ -118,6 +118,30 @@ export function registerMessageHandlers(io: ChatServer, socket: ChatSocket): voi
           data.attachmentIds,
         );
         io.to(`channel:${message.channelId}`).emit('message_edited', message);
+
+        // 編集でメンションが追加された場合、send_message と同じパターンで通知する
+        if (data.mentionedUserIds && data.mentionedUserIds.length > 0) {
+          for (const mentionedUserId of data.mentionedUserIds) {
+            if (mentionedUserId !== userId) {
+              // 通知レベルチェック: muted なら mention_updated も送らない（send_message と同仕様）
+              const level = await channelNotificationService.getLevel(
+                mentionedUserId,
+                message.channelId,
+              );
+
+              if (level !== 'muted') {
+                const mentionedChannels = await channelService.getChannelsForUser(mentionedUserId);
+                const ch = mentionedChannels.find((c) => c.id === message.channelId);
+                if (ch !== undefined) {
+                  io.to(`user:${mentionedUserId}`).emit('mention_updated', {
+                    channelId: message.channelId,
+                    mentionCount: ch.mentionCount ?? 0,
+                  });
+                }
+              }
+            }
+          }
+        }
       } catch {
         socket.emit('error', 'Failed to edit message');
       }


### PR DESCRIPTION
## 概要

Rail のホームアイコンに表示されるメンション未読バッジが、初回マウント時の値で固定されたまま更新されない問題を修正する。

根本原因は \`useMentionUnreadCount\` の \`useEffect\` 依存配列が空（\`[]\`）で初回1回しかフェッチしないこと。Rail コンポーネントは常駐でアンマウントされないため、再フェッチが発生しなかった。

## 変更内容

### クライアント側 (\`packages/client/src/hooks/useMentionUnreadCount.ts\`)
- \`useSocket()\` を注入し、\`mention_updated\` Socket イベントを購読する
- イベント受信のたびに \`api.messages.search\` を再フェッチし、最新のメンション未読数をカウントに反映する
- \`useDmUnreadCount\` と同じパターンで実装（既存コードに合わせた最小変更）

### サーバー側 — 既読化時 emit (\`packages/server/src/controllers/channelController.ts\`)
- \`markAsRead\` コントローラーで既読化成功後に \`getChannelsForUser\` で最新 \`mentionCount\` を取得し、\`user:{userId}\` ルームへ \`mention_updated\` を emit する
- 既存の \`archiveChannel\` での \`getSocketServer()\` 使用パターンに倣った実装

### サーバー側 — メッセージ編集時 emit (\`packages/server/src/socket/messageHandler.ts\`)
- \`edit_message\` ハンドラで編集によりメンションが追加された場合、\`send_message\` と同じパターンで \`mention_updated\` を emit する
- 通知レベル \`muted\` のチャンネルは除外（\`send_message\` との仕様一貫性）
- 編集者自身へのメンションは emit しない

### テスト追加
- \`packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx\`: Socket 購読・再フェッチ・購読解除・null socket 処理を網羅（既存テストを修正し 10 件に拡充）
- \`packages/server/src/__tests__/channel-read-emit.test.ts\`: \`POST /api/channels/:id/read\` 後の \`mention_updated\` emit を検証（新規 4 件）
- \`packages/server/src/__tests__/socket-handler.test.ts\`: \`edit_message\` イベントのメンション通知 4 件を追加（編集者自身除外・muted 除外・空リスト除外を含む）

## 影響範囲

- \`packages/client/src/hooks/useMentionUnreadCount.ts\`
- \`packages/server/src/controllers/channelController.ts\`
- \`packages/server/src/socket/messageHandler.ts\`
- テストファイル 3 件

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（1576 件）
- [x] バックエンドユニットテストがすべてパスする（1395 件）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #240

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した