### PR TITLE
fix: mentions.channel_id=0 レガシーデータで既読化が効かない問題を修正

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,7 +7,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "jest --maxWorkers=50%",
-    "test:watch": "jest --watch --maxWorkers=50%"
+    "test:watch": "jest --watch --maxWorkers=50%",
+    "backfill:mention-channel-id": "ts-node src/scripts/backfillMentionChannelId.ts"
   },
   "dependencies": {
     "@chat-app/shared": "*",

--- a/packages/server/src/__tests__/mention-channel-id-backfill.test.ts
+++ b/packages/server/src/__tests__/mention-channel-id-backfill.test.ts
@@ -1,0 +1,301 @@
+/**
+ * テスト対象: mentions.channel_id=0 レガシーデータの既読化修正
+ * - A. backfillMentionChannelId スクリプト: channel_id=0 のデータを messages から復旧する
+ * - B. markChannelAsRead の修正: messages JOIN ベースのクエリで channel_id=0 でも正しく既読化する
+ * - C. getChannelsForUser の mentionCount: channel_id=0 レガシーデータでも正しくカウントする
+ * 戦略: pg-mem のインメモリ DB でレガシーフィクスチャ（channel_id=0）を直接 INSERT して動作検証する
+ */
+
+import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+
+jest.mock('../db/database', () => testDb);
+
+import { markChannelAsRead, getChannelsForUser } from '../services/channelService';
+import { backfillMentionChannelId } from '../scripts/backfillMentionChannelId';
+
+let userId1: number;
+let userId2: number;
+let channelId: number;
+let channelId2: number;
+
+beforeEach(async () => {
+  await resetTestData(testDb);
+
+  const r1 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['legacy-user1', 'legacy-u1@t.com', 'h'],
+  );
+  userId1 = r1.rows[0].id as number;
+
+  const r2 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['legacy-user2', 'legacy-u2@t.com', 'h'],
+  );
+  userId2 = r2.rows[0].id as number;
+
+  const rc1 = await testDb.execute(
+    'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+    ['legacy-test-channel', userId1],
+  );
+  channelId = rc1.rows[0].id as number;
+
+  const rc2 = await testDb.execute(
+    'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+    ['legacy-other-channel', userId1],
+  );
+  channelId2 = rc2.rows[0].id as number;
+});
+
+describe('backfillMentionChannelId スクリプト', () => {
+  describe('channel_id=0 のレガシーデータ復旧', () => {
+    it('channel_id=0 のメンションレコードを messages.channel_id から正しく更新する', async () => {
+      // メッセージを正しい channel_id で作成
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'hello @user1'],
+      );
+      const msgId = msgRow.rows[0].id as number;
+
+      // channel_id=0 のレガシーメンションを直接INSERT
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+        [msgId, userId1],
+      );
+
+      // バックフィル実行
+      const updatedCount = await backfillMentionChannelId();
+
+      // channel_id が messages.channel_id に更新されていること
+      const mention = await testDb.queryOne<{ channel_id: number }>(
+        'SELECT channel_id FROM mentions WHERE message_id = $1 AND mentioned_user_id = $2',
+        [msgId, userId1],
+      );
+      expect(mention!.channel_id).toBe(channelId);
+      expect(updatedCount).toBe(1);
+    });
+
+    it('channel_id=0 でないレコードは変更しない（正常データを上書きしない）', async () => {
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'hello @user1'],
+      );
+      const msgId = msgRow.rows[0].id as number;
+
+      // channel_id が正常値（channelId2）のメンション（本来と異なるが意図的な値として扱う）
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, false)',
+        [msgId, userId1, channelId2],
+      );
+
+      await backfillMentionChannelId();
+
+      // 正常データは channelId2 のまま変わらない
+      const mention = await testDb.queryOne<{ channel_id: number }>(
+        'SELECT channel_id FROM mentions WHERE message_id = $1 AND mentioned_user_id = $2',
+        [msgId, userId1],
+      );
+      expect(mention!.channel_id).toBe(channelId2);
+    });
+
+    it('複数件の channel_id=0 レコードをまとめて更新できる', async () => {
+      // 3つのメッセージを同一チャンネルに作成
+      for (let i = 0; i < 3; i++) {
+        const r = await testDb.execute(
+          'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+          [channelId, userId2, `msg${i}`],
+        );
+        await testDb.execute(
+          'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+          [r.rows[0].id, userId1],
+        );
+      }
+
+      const updatedCount = await backfillMentionChannelId();
+      expect(updatedCount).toBe(3);
+
+      // 全件が channelId に更新されていること
+      const mentions = await testDb.query<{ channel_id: number }>(
+        'SELECT channel_id FROM mentions WHERE mentioned_user_id = $1',
+        [userId1],
+      );
+      expect(mentions.every((m) => m.channel_id === channelId)).toBe(true);
+    });
+
+    it('channel_id=0 のレコードがない場合は何も変更しない（冪等性）', async () => {
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'hello'],
+      );
+      // 正常な channel_id でメンション作成
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, false)',
+        [msgRow.rows[0].id, userId1, channelId],
+      );
+
+      const updatedCount = await backfillMentionChannelId();
+      expect(updatedCount).toBe(0);
+    });
+  });
+});
+
+describe('markChannelAsRead - channel_id=0 レガシーデータの既読化', () => {
+  describe('messages JOIN ベースの既読化クエリ', () => {
+    it('channel_id=0 のレガシーメンションがチャンネルを開くと既読になる', async () => {
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'hello @user1'],
+      );
+      const msgId = msgRow.rows[0].id as number;
+
+      // channel_id=0 のレガシーメンション
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+        [msgId, userId1],
+      );
+
+      await markChannelAsRead(channelId, userId1);
+
+      const mention = await testDb.queryOne<{ is_read: boolean }>(
+        'SELECT is_read FROM mentions WHERE message_id = $1 AND mentioned_user_id = $2',
+        [msgId, userId1],
+      );
+      expect(mention!.is_read).toBe(true);
+    });
+
+    it('channel_id が正常値のメンションも引き続き既読になる（regression なし）', async () => {
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'hello @user1'],
+      );
+      const msgId = msgRow.rows[0].id as number;
+
+      // 正常な channel_id のメンション
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, false)',
+        [msgId, userId1, channelId],
+      );
+
+      await markChannelAsRead(channelId, userId1);
+
+      const mention = await testDb.queryOne<{ is_read: boolean }>(
+        'SELECT is_read FROM mentions WHERE message_id = $1 AND mentioned_user_id = $2',
+        [msgId, userId1],
+      );
+      expect(mention!.is_read).toBe(true);
+    });
+
+    it('channel_id=0 と正常 channel_id が混在する場合、両方まとめて既読になる', async () => {
+      // メッセージ1: channel_id=0 のレガシーメンション
+      const msg1Row = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'legacy msg'],
+      );
+      const msg1Id = msg1Row.rows[0].id as number;
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+        [msg1Id, userId1],
+      );
+
+      // メッセージ2: 正常 channel_id のメンション
+      const msg2Row = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'normal msg'],
+      );
+      const msg2Id = msg2Row.rows[0].id as number;
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, false)',
+        [msg2Id, userId1, channelId],
+      );
+
+      await markChannelAsRead(channelId, userId1);
+
+      const mentions = await testDb.query<{ is_read: boolean }>(
+        'SELECT is_read FROM mentions WHERE mentioned_user_id = $1',
+        [userId1],
+      );
+      expect(mentions.every((m) => m.is_read)).toBe(true);
+    });
+
+    it('別チャンネルのメンションは既読にならない', async () => {
+      // channelId のメッセージ（channel_id=0 レガシー）
+      const msg1Row = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'ch1 msg'],
+      );
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+        [msg1Row.rows[0].id, userId1],
+      );
+
+      // channelId2 のメッセージ（別チャンネル）
+      const msg2Row = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId2, userId2, 'ch2 msg'],
+      );
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, $3, false)',
+        [msg2Row.rows[0].id, userId1, channelId2],
+      );
+
+      // channelId のみ既読化
+      await markChannelAsRead(channelId, userId1);
+
+      const ch2Mention = await testDb.queryOne<{ is_read: boolean }>(
+        'SELECT is_read FROM mentions WHERE message_id = $1 AND mentioned_user_id = $2',
+        [msg2Row.rows[0].id, userId1],
+      );
+      // channelId2 のメンションは未読のまま
+      expect(ch2Mention!.is_read).toBe(false);
+    });
+  });
+});
+
+describe('getChannelsForUser - channel_id=0 レガシーデータの mentionCount', () => {
+  describe('messages JOIN ベースの mentionCount 集計', () => {
+    it('channel_id=0 のレガシーメンションが mentionCount に含まれる', async () => {
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'legacy mention msg'],
+      );
+      const msgId = msgRow.rows[0].id as number;
+
+      // channel_id=0 のレガシーメンションを挿入
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+        [msgId, userId1],
+      );
+
+      const channels = await getChannelsForUser(userId1);
+      const ch = channels.find((c) => c.id === channelId);
+      expect(ch).toBeDefined();
+      // channel_id=0 のレガシーデータもメンションカウントに含まれること
+      expect(ch!.mentionCount).toBe(1);
+    });
+
+    it('channel_id=0 のレガシーメンションを既読化すると mentionCount が減る', async () => {
+      const msgRow = await testDb.execute(
+        'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3) RETURNING id',
+        [channelId, userId2, 'legacy mention msg'],
+      );
+      const msgId = msgRow.rows[0].id as number;
+
+      await testDb.execute(
+        'INSERT INTO mentions (message_id, mentioned_user_id, channel_id, is_read) VALUES ($1, $2, 0, false)',
+        [msgId, userId1],
+      );
+
+      // 既読前: mentionCount = 1
+      let channels = await getChannelsForUser(userId1);
+      expect(channels.find((c) => c.id === channelId)!.mentionCount).toBe(1);
+
+      // markChannelAsRead で既読化
+      await markChannelAsRead(channelId, userId1);
+
+      // 既読後: mentionCount = 0
+      channels = await getChannelsForUser(userId1);
+      expect(channels.find((c) => c.id === channelId)!.mentionCount).toBe(0);
+    });
+  });
+});

--- a/packages/server/src/scripts/backfillMentionChannelId.ts
+++ b/packages/server/src/scripts/backfillMentionChannelId.ts
@@ -1,0 +1,78 @@
+/**
+ * バックフィルスクリプト: mentions.channel_id=0 のレガシーデータ修復
+ *
+ * 背景:
+ *   channel_id カラムが追加される前に作成された mentions レコードは
+ *   channel_id=0 のままになっており、markChannelAsRead の WHERE 条件に
+ *   マッチせず永久に未読状態になる問題が発生する（Issue #242）。
+ *
+ * 実行方法:
+ *   npx tsx src/scripts/backfillMentionChannelId.ts
+ *
+ * または package.json の scripts に追加後:
+ *   npm run backfill:mention-channel-id --workspace=packages/server
+ *
+ * 冪等性: channel_id=0 のレコードがない場合は何も変更しない。
+ *          複数回実行しても安全。
+ */
+
+import { execute, queryOne } from '../db/database';
+
+/**
+ * mentions.channel_id=0 のレコードを messages.channel_id から復旧する。
+ * テストからも呼び出せるようにエクスポートする。
+ *
+ * @returns 更新件数
+ */
+export async function backfillMentionChannelId(): Promise<number> {
+  // pg-mem の制約でテーブルエイリアスを使わない形式で記述
+  const result = await execute(
+    `UPDATE mentions
+     SET channel_id = messages.channel_id
+     FROM messages
+     WHERE mentions.message_id = messages.id
+       AND mentions.channel_id = 0`,
+  );
+  return result.rowCount;
+}
+
+// スクリプトとして直接実行された場合のみメイン処理を走らせる
+// （テストでインポートしても実行されない）
+if (require.main === module) {
+  void (async () => {
+    console.log('mentions.channel_id=0 のバックフィルを開始します...');
+
+    // 実行前の件数を確認
+    const before = await queryOne<{ count: string }>(
+      'SELECT COUNT(*) AS count FROM mentions WHERE channel_id = 0',
+    );
+    const beforeCount = Number(before?.count ?? 0);
+    console.log(`対象レコード数: ${beforeCount} 件`);
+
+    if (beforeCount === 0) {
+      console.log('対象レコードがありません。処理をスキップします。');
+      process.exit(0);
+    }
+
+    const updatedCount = await backfillMentionChannelId();
+    console.log(`更新完了: ${updatedCount} 件を修復しました。`);
+
+    // 実行後の確認
+    const after = await queryOne<{ count: string }>(
+      'SELECT COUNT(*) AS count FROM mentions WHERE channel_id = 0',
+    );
+    const afterCount = Number(after?.count ?? 0);
+    console.log(`残存 channel_id=0 件数: ${afterCount} 件`);
+
+    if (afterCount > 0) {
+      console.warn(
+        `警告: ${afterCount} 件が更新されませんでした（メッセージが存在しない孤立レコードの可能性）。`,
+      );
+    }
+
+    process.exit(0);
+  })().catch((err) => {
+    console.error('バックフィル中にエラーが発生しました:', err);
+    process.exit(1);
+  });
+}

--- a/packages/server/src/services/channelService.ts
+++ b/packages/server/src/services/channelService.ts
@@ -72,14 +72,17 @@ export async function getChannelsForUser(userId: number): Promise<Channel[]> {
   );
 
   // 各チャンネルのメンション一覧を取得
+  // messages JOIN で channel_id を解決することで、channel_id=0 のレガシーデータ（#242）にも対応する
   const mentionRows = await query<{
     channel_id: number;
     message_id: number;
   }>(
-    `SELECT channel_id, message_id FROM mentions
-     WHERE channel_id IN (${placeholders})
-       AND mentioned_user_id = $${channelIds.length + 1}
-       AND is_read = false`,
+    `SELECT msg.channel_id, mn.message_id
+     FROM mentions mn
+     JOIN messages msg ON msg.id = mn.message_id
+     WHERE msg.channel_id IN (${placeholders})
+       AND mn.mentioned_user_id = $${channelIds.length + 1}
+       AND mn.is_read = false`,
     [...channelIds, userId],
   );
 
@@ -114,8 +117,12 @@ export async function markChannelAsRead(channelId: number, userId: number): Prom
     [userId, channelId, lastMsg?.id ?? null],
   );
 
+  // messages JOIN で channel_id を解決することで、channel_id=0 のレガシーデータ（#242）にも対応する
   await execute(
-    'UPDATE mentions SET is_read = true WHERE channel_id = $1 AND mentioned_user_id = $2 AND is_read = false',
+    `UPDATE mentions SET is_read = true
+     WHERE message_id IN (SELECT id FROM messages WHERE channel_id = $1)
+       AND mentioned_user_id = $2
+       AND is_read = false`,
     [channelId, userId],
   );
 }


### PR DESCRIPTION
## 概要

PR #241 マージ後も nakamura2 (id=2) のホームアイコンのメンション未読バッジが「7」から減らない問題を修正する。

原因は `mentions` テーブルの古いレコードの `channel_id` が `0` になっており、`markChannelAsRead` の `WHERE channel_id = $1` 条件にマッチしないことだった。`getChannelsForUser` の mentionCount 集計クエリも同様の問題を持っていた。

## 変更内容

### A. データ backfill スクリプト（新規）
- `packages/server/src/scripts/backfillMentionChannelId.ts` を追加
- `mentions.channel_id=0` のレコードを `messages.channel_id` から一括復旧する
- 実行方法: `npm run backfill:mention-channel-id --workspace=packages/server`
- 冪等性あり（複数回実行しても安全）

### B. `markChannelAsRead` のクエリ修正
- `WHERE channel_id = $1` → `WHERE message_id IN (SELECT id FROM messages WHERE channel_id = $1)` に変更
- `mentions.channel_id` の値に依存せず、`messages` 経由でチャンネルを判定するため、channel_id=0 のレガシーデータでも正しく既読化される

### C. `getChannelsForUser` の mentionCount 集計クエリ修正
- `SELECT channel_id FROM mentions WHERE channel_id IN (...)` → `messages JOIN` ベースに変更
- channel_id=0 のレガシーデータも mentionCount に含まれるようになる

## 影響範囲

- `packages/server/src/services/channelService.ts`（markChannelAsRead・getChannelsForUser）
- `packages/server/src/scripts/backfillMentionChannelId.ts`（新規）
- `packages/server/package.json`（backfill スクリプトの実行エントリを scripts に追加）
- `packages/server/src/__tests__/mention-channel-id-backfill.test.ts`（新規テスト 10件）

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（変更なし）
- [x] バックエンドユニットテストがすべてパスする（67スイート・1405件）
- [x] ビルドが正常に完了すること

## マージ後の対応（必須）

**本PRマージ後、本番 DB に対してバックフィルスクリプトの実行が必要です。**

```bash
# サーバーのディレクトリで実行
npm run backfill:mention-channel-id --workspace=packages/server
```

実行結果の例:
```
mentions.channel_id=0 のバックフィルを開始します...
対象レコード数: 7 件
更新完了: 7 件を修復しました。
残存 channel_id=0 件数: 0 件
```

バックフィル実行後、nakamura2 がチャンネルを開くと未読バッジが正常に減るようになります。バックフィルを実行しなくても B の修正により今後の既読化操作は正常に動作しますが、既存の channel_id=0 レコードはバックフィルするまで mentionCount に正しく表示されません。

## 関連Issue

Fixes #242

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した