### PR TITLE
fix: モバイル幅での DM / タスク / カレンダー画面レイアウト崩れを修正

### DIFF
--- a/packages/client/src/__tests__/MobileLayout.test.tsx
+++ b/packages/client/src/__tests__/MobileLayout.test.tsx
@@ -1,0 +1,531 @@
+/**
+ * テスト対象: モバイル幅 (max-width: 767px) でのレイアウト分岐
+ *   - DMPage (packages/client/src/pages/DMPage.tsx)
+ *   - TaskBoardPage (packages/client/src/pages/TaskBoardPage.tsx)
+ *   - CalendarPage (packages/client/src/pages/CalendarPage.tsx)
+ *   - ChannelFilterPanel (packages/client/src/components/Calendar/ChannelFilterPanel.tsx)
+ *   - DmConversationList (packages/client/src/components/DM/DmConversationList.tsx)
+ *
+ * 戦略:
+ *   - window.matchMedia をモックして isMobile フラグの ON/OFF を制御する
+ *   - "レイアウト分岐ロジック" "条件付きレンダリング" "遷移挙動" を検証する
+ *   - スタイル値そのものや aria 属性だけのテストは書かない(AGENTS.md 方針)
+ *   - api/client・SocketContext はスタブ化して対象コンポーネントに集中する
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import type { DmConversationWithDetails } from '@chat-app/shared';
+
+// ---------------------------------------------------------------------------
+// window.matchMedia モック (モバイル/デスクトップ切り替え用)
+// ---------------------------------------------------------------------------
+
+function setMobile(v: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: v && query.includes('max-width: 767px'),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 共通スタブ
+// ---------------------------------------------------------------------------
+
+vi.mock('../contexts/SocketContext', () => ({
+  useSocket: () => null,
+}));
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: 1, username: 'alice', displayName: null, avatarUrl: null, role: 'user' },
+    logout: vi.fn(),
+    updateUser: vi.fn(),
+  }),
+}));
+
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({ showError: vi.fn(), showSuccess: vi.fn() }),
+}));
+
+vi.mock('../contexts/ThemeContext', () => ({
+  useTheme: () => ({ mode: 'light', toggleTheme: vi.fn() }),
+}));
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../components/Channel/ChannelList', () => ({
+  default: () => <div data-testid="channel-list-stub" />,
+}));
+
+vi.mock('../components/Layout/SidebarDmList', () => ({
+  default: () => <div data-testid="sidebar-dm-list-stub" />,
+}));
+
+vi.mock('../components/Layout/MobileBottomNav', () => ({
+  default: () => <nav data-testid="mobile-bottom-nav" />,
+}));
+
+vi.mock('../components/Layout/Rail', () => ({
+  default: () => <div data-testid="rail-stub" />,
+}));
+
+vi.mock('../components/Layout/SidebarFooter', () => ({
+  default: () => <div data-testid="sidebar-footer-stub" />,
+}));
+
+vi.mock('../hooks/usePushNotifications', () => ({
+  usePushNotifications: () => ({
+    supported: false,
+    subscribed: false,
+    loading: false,
+    error: null,
+    subscribe: vi.fn(),
+    unsubscribe: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// DM 関連スタブ
+// ---------------------------------------------------------------------------
+
+const makeConv = (id = 1): DmConversationWithDetails => ({
+  id,
+  userAId: 1,
+  userBId: 2,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  otherUser: { id: 2, username: 'bob', displayName: null, avatarUrl: null },
+  unreadCount: 0,
+  lastMessage: null,
+});
+
+vi.mock('../components/DM/MessageArea', () => ({
+  default: () => <div data-testid="message-area-stub" />,
+}));
+
+vi.mock('../components/DM/NewDmDialog', () => ({
+  default: () => null,
+}));
+
+vi.mock('../hooks/usePresence', () => ({
+  usePresence: () => new Map(),
+}));
+
+vi.mock('../hooks/useDmConversationsSocket', () => ({
+  useDmConversationsSocket: () => undefined,
+}));
+
+// ---------------------------------------------------------------------------
+// Task 関連スタブ
+// ---------------------------------------------------------------------------
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCorners: vi.fn(),
+  PointerSensor: class {},
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn((...args: unknown[]) => args),
+  useDroppable: vi.fn(() => ({ setNodeRef: vi.fn(), isOver: false })),
+}));
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  verticalListSortingStrategy: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+  arrayMove: vi.fn(),
+}));
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: vi.fn(() => '') } },
+}));
+
+vi.mock('../components/Task/CreateTaskDialog', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/Task/EditTaskDialog', () => ({
+  default: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Calendar 関連スタブ
+// ---------------------------------------------------------------------------
+
+vi.mock('../components/Calendar/CalendarHeader', () => ({
+  CalendarHeader: () => <div data-testid="calendar-header-stub" />,
+}));
+
+vi.mock('../components/Calendar/MonthView', () => ({
+  MonthView: () => <div data-testid="month-view-stub" />,
+}));
+
+vi.mock('../components/Calendar/WeekView', () => ({
+  WeekView: () => <div data-testid="week-view-stub" />,
+}));
+
+vi.mock('../components/Calendar/AgendaView', () => ({
+  AgendaView: () => <div data-testid="agenda-view-stub" />,
+}));
+
+vi.mock('../components/Calendar/EventDetailDrawer', () => ({
+  EventDetailDrawer: () => null,
+}));
+
+vi.mock('../components/Calendar/EventDialog', () => ({
+  EventDialog: () => null,
+}));
+
+vi.mock('../components/Calendar/PollListDrawer', () => ({
+  PollListDrawer: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+// api/client モック
+// ---------------------------------------------------------------------------
+
+vi.mock('../api/client', () => ({
+  api: {
+    dm: {
+      listConversations: vi.fn().mockResolvedValue({ conversations: [] }),
+      getMessages: vi.fn().mockResolvedValue({ messages: [] }),
+      markAsRead: vi.fn().mockResolvedValue(undefined),
+      createConversation: vi.fn(),
+    },
+    auth: {
+      users: vi.fn().mockResolvedValue({ users: [] }),
+    },
+    tasks: {
+      list: vi.fn().mockResolvedValue({ tasks: [] }),
+      update: vi.fn(),
+      delete: vi.fn(),
+      updateOrder: vi.fn(),
+    },
+    channels: {
+      list: vi.fn().mockResolvedValue({ channels: [] }),
+    },
+    messages: {
+      search: vi.fn().mockResolvedValue({ messages: [] }),
+    },
+    calendar: {
+      events: {
+        list: vi.fn().mockResolvedValue({ events: [] }),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// インポート (vi.mock の後に必ず記述)
+// ---------------------------------------------------------------------------
+
+import { api } from '../api/client';
+import DMPage, { resetDmConversationsCache } from '../pages/DMPage';
+import TaskBoardPage from '../pages/TaskBoardPage';
+import CalendarPage from '../pages/CalendarPage';
+import DmConversationList from '../components/DM/DmConversationList';
+import { ChannelFilterPanel } from '../components/Calendar/ChannelFilterPanel';
+
+const mockDmApi = api.dm as unknown as {
+  listConversations: ReturnType<typeof vi.fn>;
+  getMessages: ReturnType<typeof vi.fn>;
+  markAsRead: ReturnType<typeof vi.fn>;
+};
+
+// ---------------------------------------------------------------------------
+// beforeEach
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetDmConversationsCache();
+  setMobile(false);
+  mockDmApi.listConversations.mockResolvedValue({ conversations: [] });
+  mockDmApi.getMessages.mockResolvedValue({ messages: [] });
+  mockDmApi.markAsRead.mockResolvedValue(undefined);
+  (api.tasks.list as ReturnType<typeof vi.fn>).mockResolvedValue({ tasks: [] });
+  (api.channels.list as ReturnType<typeof vi.fn>).mockResolvedValue({ channels: [] });
+  (api.auth.users as ReturnType<typeof vi.fn>).mockResolvedValue({ users: [] });
+  (api.calendar.events.list as ReturnType<typeof vi.fn>).mockResolvedValue({ events: [] });
+  localStorage.clear();
+});
+
+// ===========================================================================
+// DM画面 モバイルレイアウト
+// ===========================================================================
+
+describe('DMPage: モバイルレイアウト', () => {
+  async function renderDMPage(isMobile = false) {
+    setMobile(isMobile);
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <DMPage
+            users={[{ id: 1, username: 'alice', displayName: null, avatarUrl: null }] as never}
+          />
+        </MemoryRouter>,
+      );
+    });
+  }
+
+  describe('デスクトップ時の基本動作 (モバイル分岐のベースライン確認)', () => {
+    it('デスクトップ幅では会話一覧と右ペインが横並びで表示される', async () => {
+      mockDmApi.listConversations.mockResolvedValue({ conversations: [makeConv()] });
+      await renderDMPage(false);
+      // 「ダイレクトメッセージ」はページヘッダーと DmConversationList 内部の2箇所に存在する
+      expect(screen.getAllByText('ダイレクトメッセージ').length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('bob')).toBeInTheDocument();
+      expect(screen.getByText('会話を選択してください')).toBeInTheDocument();
+    });
+  });
+
+  describe('モバイル時: 一覧 → 会話の階層ナビゲーション', () => {
+    it('モバイル幅かつ会話未選択時は会話一覧だけが表示され、メッセージエリアは非表示になる', async () => {
+      mockDmApi.listConversations.mockResolvedValue({ conversations: [makeConv()] });
+      await renderDMPage(true);
+      expect(screen.getByText('bob')).toBeInTheDocument();
+      expect(screen.queryByText('会話を選択してください')).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅で会話をタップするとメッセージエリアが表示され、一覧は非表示になる', async () => {
+      mockDmApi.listConversations.mockResolvedValue({ conversations: [makeConv()] });
+      await renderDMPage(true);
+      await userEvent.click(screen.getByText('bob'));
+      await waitFor(() => {
+        expect(screen.getByTestId('message-area-stub')).toBeInTheDocument();
+      });
+      // 会話選択後は DmConversationList ごと DOM から消える
+      expect(screen.queryByTestId('dm-conversation-list')).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅のメッセージ表示中に戻るボタンを押すと一覧に戻る', async () => {
+      mockDmApi.listConversations.mockResolvedValue({ conversations: [makeConv()] });
+      await renderDMPage(true);
+      await userEvent.click(screen.getByText('bob'));
+      await waitFor(() => {
+        expect(screen.getByTestId('message-area-stub')).toBeInTheDocument();
+      });
+      await userEvent.click(screen.getByRole('button', { name: '一覧に戻る' }));
+      await waitFor(() => {
+        expect(screen.getByText('bob')).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('message-area-stub')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('DmConversationList: モバイル時の幅制御', () => {
+    it('モバイル幅では DmConversationList が fullWidth 表示になる', () => {
+      render(
+        <MemoryRouter>
+          <DmConversationList
+            conversations={[makeConv()]}
+            activeConvId={null}
+            currentUserId={1}
+            isMobile={true}
+            onSelectConversation={vi.fn()}
+            onNewDm={vi.fn()}
+            onConversationsChange={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+      const listBox = screen.getByTestId('dm-conversation-list');
+      expect(listBox).toHaveStyle({ width: '100%' });
+    });
+
+    it('デスクトップ幅では DmConversationList が固定幅 (280px) で表示される', () => {
+      render(
+        <MemoryRouter>
+          <DmConversationList
+            conversations={[makeConv()]}
+            activeConvId={null}
+            currentUserId={1}
+            isMobile={false}
+            onSelectConversation={vi.fn()}
+            onNewDm={vi.fn()}
+            onConversationsChange={vi.fn()}
+          />
+        </MemoryRouter>,
+      );
+      const listBox = screen.getByTestId('dm-conversation-list');
+      expect(listBox).toHaveStyle({ width: '280px' });
+    });
+  });
+});
+
+// ===========================================================================
+// タスク画面 モバイルレイアウト
+// ===========================================================================
+
+describe('TaskBoardPage: モバイルレイアウト', () => {
+  async function renderTaskPage(isMobile = false) {
+    setMobile(isMobile);
+    await act(async () => {
+      render(
+        <MemoryRouter>
+          <TaskBoardPage />
+        </MemoryRouter>,
+      );
+    });
+  }
+
+  describe('ツールバーのレスポンシブ対応', () => {
+    it('モバイル幅ではツールバーが縦方向にスタックして表示される', async () => {
+      await renderTaskPage(true);
+      const toolbar = screen.getByTestId('task-toolbar');
+      expect(toolbar).toHaveStyle({ flexDirection: 'column' });
+    });
+
+    it('モバイル幅ではチャンネル絞り込みセレクトが全幅で表示される', async () => {
+      await renderTaskPage(true);
+      const filterForm = screen.getByTestId('task-channel-filter');
+      expect(filterForm).toHaveStyle({ width: '100%' });
+    });
+
+    it('デスクトップ幅ではツールバーが横一列で表示される', async () => {
+      await renderTaskPage(false);
+      const toolbar = screen.getByTestId('task-toolbar');
+      expect(toolbar).toHaveStyle({ flexDirection: 'row' });
+    });
+  });
+
+  describe('カンバン列の横スクロール', () => {
+    it('モバイル幅でもカンバン列コンテナが overflowX: auto でスクロール可能になっている', async () => {
+      await renderTaskPage(true);
+      const kanbanContainer = screen.getByTestId('kanban-container');
+      expect(kanbanContainer).toHaveStyle({ overflowX: 'auto' });
+    });
+
+    it('カンバン列は minWidth が確保されており、モバイル幅でも潰れない', async () => {
+      await renderTaskPage(true);
+      const columns = screen.getAllByTestId(/^column-/);
+      expect(columns.length).toBeGreaterThan(0);
+      for (const col of columns) {
+        const style = window.getComputedStyle(col);
+        const minWidth = parseInt(style.minWidth || '0', 10);
+        expect(minWidth).toBeGreaterThanOrEqual(260);
+      }
+    });
+  });
+});
+
+// ===========================================================================
+// カレンダー画面 モバイルレイアウト
+// ===========================================================================
+
+describe('CalendarPage: モバイルレイアウト', () => {
+  async function renderCalendarPage(isMobile = false) {
+    setMobile(isMobile);
+    let result!: ReturnType<typeof render>;
+    await act(async () => {
+      result = render(
+        <MemoryRouter>
+          <CalendarPage />
+        </MemoryRouter>,
+      );
+    });
+    return result;
+  }
+
+  describe('ChannelFilterPanel の表示制御', () => {
+    it('モバイル幅では ChannelFilterPanel が通常の左ペイン列に表示されない', async () => {
+      await renderCalendarPage(true);
+      expect(screen.queryByTestId('channel-filter-panel')).not.toBeInTheDocument();
+    });
+
+    it('モバイル幅でフィルターボタンをタップすると ChannelFilterPanel が Drawer として開く', async () => {
+      await renderCalendarPage(true);
+      const filterBtn = screen.getByRole('button', { name: /フィルター/ });
+      await userEvent.click(filterBtn);
+      await waitFor(() => {
+        expect(screen.getByTestId('channel-filter-panel')).toBeInTheDocument();
+      });
+    });
+
+    it('モバイル幅で Drawer を閉じると ChannelFilterPanel が非表示になる', async () => {
+      await renderCalendarPage(true);
+      const filterBtn = screen.getByRole('button', { name: /フィルター/ });
+      await userEvent.click(filterBtn);
+      await waitFor(() => {
+        expect(screen.getByTestId('channel-filter-panel')).toBeInTheDocument();
+      });
+      const closeBtn = screen.getByRole('button', { name: '閉じる' });
+      await userEvent.click(closeBtn);
+      await waitFor(() => {
+        expect(screen.queryByTestId('channel-filter-panel')).not.toBeInTheDocument();
+      });
+    });
+
+    it('デスクトップ幅では ChannelFilterPanel が左ペインとして通常表示される', async () => {
+      await renderCalendarPage(false);
+      expect(screen.getByTestId('channel-filter-panel')).toBeInTheDocument();
+    });
+  });
+
+  describe('カレンダーグリッドの幅確保', () => {
+    it('モバイル幅では CalendarContent のメインエリアが全幅 (100%) で表示される', async () => {
+      await renderCalendarPage(true);
+      expect(screen.getByTestId('month-view-stub')).toBeInTheDocument();
+      const calendarMain = screen.getByTestId('calendar-main-area');
+      expect(calendarMain).toHaveStyle({ width: '100%' });
+    });
+  });
+});
+
+// ===========================================================================
+// ChannelFilterPanel: 単体テスト
+// ===========================================================================
+
+describe('ChannelFilterPanel', () => {
+  const baseProps = {
+    channels: [],
+    channelColors: new Map<number, string>(),
+    channelFilter: new Set<number>(),
+    onToggleChannel: vi.fn(),
+    events: [],
+    today: new Date('2024-01-15'),
+    onEventClick: vi.fn(),
+  };
+
+  it('isDrawer=true のとき幅制限なしで表示される (Drawer 内用レイアウト)', () => {
+    render(
+      <MemoryRouter>
+        <ChannelFilterPanel {...baseProps} isDrawer={true} />
+      </MemoryRouter>,
+    );
+    const panel = screen.getByTestId('channel-filter-panel');
+    expect(panel).not.toHaveStyle({ width: '220px' });
+  });
+
+  it('isDrawer=false または省略時は従来の 220px 幅の左ペインとして表示される', () => {
+    render(
+      <MemoryRouter>
+        <ChannelFilterPanel {...baseProps} isDrawer={false} />
+      </MemoryRouter>,
+    );
+    const panel = screen.getByTestId('channel-filter-panel');
+    expect(panel).toHaveStyle({ width: '220px' });
+  });
+});

--- a/packages/client/src/components/Calendar/ChannelFilterPanel.tsx
+++ b/packages/client/src/components/Calendar/ChannelFilterPanel.tsx
@@ -13,6 +13,8 @@ interface Props {
   events: CalendarEvent[];
   today: Date;
   onEventClick: (event: CalendarEvent) => void;
+  /** Drawer 内で使用する場合 true。幅制限を外す */
+  isDrawer?: boolean;
 }
 
 export function ChannelFilterPanel({
@@ -23,6 +25,7 @@ export function ChannelFilterPanel({
   events,
   today,
   onEventClick,
+  isDrawer = false,
 }: Props) {
   const todayEvents = events
     .filter((e) => sameDay(new Date(e.startsAt), today))
@@ -30,10 +33,11 @@ export function ChannelFilterPanel({
 
   return (
     <Box
+      data-testid="channel-filter-panel"
       sx={{
-        width: 220,
+        width: isDrawer ? undefined : 220,
         flexShrink: 0,
-        borderRight: 1,
+        borderRight: isDrawer ? 'none' : 1,
         borderColor: 'divider',
         p: 2,
         overflow: 'auto',

--- a/packages/client/src/components/DM/DmConversationList.tsx
+++ b/packages/client/src/components/DM/DmConversationList.tsx
@@ -10,6 +10,8 @@ export interface DmConversationListProps {
   conversations: DmConversationWithDetails[];
   activeConvId: number | null;
   currentUserId: number;
+  /** モバイル幅の場合 true。幅が 100% になる */
+  isMobile?: boolean;
   onSelectConversation: (convId: number) => void;
   onNewDm: () => void;
   onConversationsChange: (
@@ -18,7 +20,7 @@ export interface DmConversationListProps {
 }
 
 /**
- * DMPage の左カラム用 DM 一覧 (280px 幅、expanded variant)。
+ * DMPage の左カラム用 DM 一覧 (デスクトップ: 280px 幅、モバイル: 全幅、expanded variant)。
  * 行レンダリングは `DmListRow`、socket 購読は `useDmConversationsSocket` で
  * `SidebarDmList` と共通化している。
  */
@@ -26,6 +28,7 @@ export default function DmConversationList({
   conversations,
   activeConvId,
   currentUserId,
+  isMobile = false,
   onSelectConversation,
   onNewDm,
   onConversationsChange,
@@ -41,10 +44,11 @@ export default function DmConversationList({
 
   return (
     <Box
+      data-testid="dm-conversation-list"
       sx={{
-        width: 280,
+        width: isMobile ? '100%' : 280,
         flexShrink: 0,
-        borderRight: 1,
+        borderRight: isMobile ? 'none' : 1,
         borderColor: 'divider',
         display: 'flex',
         flexDirection: 'column',

--- a/packages/client/src/pages/CalendarPage.tsx
+++ b/packages/client/src/pages/CalendarPage.tsx
@@ -3,7 +3,9 @@
 
 import { Suspense, use, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, CircularProgress, Drawer, IconButton, Tooltip, useMediaQuery } from '@mui/material';
+import FilterListIcon from '@mui/icons-material/FilterList';
+import CloseIcon from '@mui/icons-material/Close';
 
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
@@ -81,6 +83,8 @@ function CalendarContent({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogDate, setDialogDate] = useState<Date | null>(null);
   const [editingEvent, setEditingEvent] = useState<CalendarEvent | null>(null);
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+  const isMobile = useMediaQuery('(max-width: 767px)');
 
   const channelColors = useMemo(() => {
     const m = new Map<number, string>();
@@ -136,16 +140,87 @@ function CalendarContent({
   return (
     <>
       <Box sx={{ flexGrow: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
-        <ChannelFilterPanel
-          channels={channels}
-          channelColors={channelColors}
-          channelFilter={effectiveFilter}
-          onToggleChannel={handleToggleChannel}
-          events={filteredEvents}
-          today={today}
-          onEventClick={handleEventClick}
-        />
-        <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+        {/* デスクトップ: 左ペインとして常時表示 / モバイル: Drawer 経由 */}
+        {!isMobile && (
+          <ChannelFilterPanel
+            channels={channels}
+            channelColors={channelColors}
+            channelFilter={effectiveFilter}
+            onToggleChannel={handleToggleChannel}
+            events={filteredEvents}
+            today={today}
+            onEventClick={handleEventClick}
+          />
+        )}
+
+        {/* モバイル: フィルター Drawer */}
+        {isMobile && (
+          <Drawer
+            anchor="left"
+            open={filterDrawerOpen}
+            onClose={() => setFilterDrawerOpen(false)}
+            PaperProps={{ sx: { width: 280 } }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+                px: 1,
+                py: 0.5,
+                borderBottom: '1px solid var(--border)',
+              }}
+            >
+              <IconButton
+                size="small"
+                aria-label="閉じる"
+                onClick={() => setFilterDrawerOpen(false)}
+              >
+                <CloseIcon />
+              </IconButton>
+            </Box>
+            <ChannelFilterPanel
+              channels={channels}
+              channelColors={channelColors}
+              channelFilter={effectiveFilter}
+              onToggleChannel={handleToggleChannel}
+              events={filteredEvents}
+              today={today}
+              onEventClick={(e) => {
+                handleEventClick(e);
+                setFilterDrawerOpen(false);
+              }}
+              isDrawer={true}
+            />
+          </Drawer>
+        )}
+
+        {/* カレンダーメインエリア */}
+        <Box
+          data-testid="calendar-main-area"
+          sx={{
+            flexGrow: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            minWidth: 0,
+            width: isMobile ? '100%' : undefined,
+          }}
+        >
+          {/* モバイル: フィルターボタン */}
+          {isMobile && (
+            <Box sx={{ px: 1, py: 0.5, flexShrink: 0 }}>
+              <Tooltip title="フィルター">
+                <IconButton
+                  size="small"
+                  aria-label="フィルターを開く"
+                  onClick={() => setFilterDrawerOpen(true)}
+                >
+                  <FilterListIcon />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          )}
+
           {view === 'month' && (
             <MonthView
               cursor={cursor}

--- a/packages/client/src/pages/DMPage.tsx
+++ b/packages/client/src/pages/DMPage.tsx
@@ -1,6 +1,7 @@
 import { use, useState, useEffect, useMemo, Suspense } from 'react';
-import { Box, Typography, CircularProgress, Paper } from '@mui/material';
+import { Box, Typography, CircularProgress, Paper, IconButton, useMediaQuery } from '@mui/material';
 import ChatIcon from '@mui/icons-material/Chat';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useSearchParams } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
 import { api } from '../api/client';
@@ -16,6 +17,8 @@ import type {
 import MessageArea from '../components/DM/MessageArea';
 import NewDmDialog from '../components/DM/NewDmDialog';
 import DmConversationList from '../components/DM/DmConversationList';
+
+const MOBILE_QUERY = '(max-width: 767px)';
 
 // ---------------------------------------------------------------------------
 // Promise キャッシュ（React 19 concurrent モード多重初期化対策）
@@ -56,6 +59,7 @@ function DMPageContent({ conversationsPromise, users, currentUserId }: DMPageCon
   const [newDmOpen, setNewDmOpen] = useState(false);
   const socket = useSocket();
   const { showError } = useSnackbar();
+  const isMobile = useMediaQuery(MOBILE_QUERY);
 
   const activeConversation = useMemo(
     () => conversations.find((c) => c.id === activeConvId) ?? null,
@@ -158,61 +162,109 @@ function DMPageContent({ conversationsPromise, users, currentUserId }: DMPageCon
     void handleSelectConversation(conversation.id);
   };
 
+  // モバイル: 一覧表示中かメッセージ表示中かを activeConvId で判定
+  // デスクトップ: 両方同時に表示
+  const showList = !isMobile || activeConvId === null;
+  const showMessage = !isMobile || activeConvId !== null;
+
   return (
     <Box sx={{ display: 'flex', height: '100%', overflow: 'hidden' }}>
-      {/* DM会話一覧サイドバー */}
-      <DmConversationList
-        conversations={conversations}
-        activeConvId={activeConvId}
-        currentUserId={currentUserId}
-        onSelectConversation={(convId) => void handleSelectConversation(convId)}
-        onNewDm={() => setNewDmOpen(true)}
-        onConversationsChange={setConversations}
-      />
+      {/* DM会話一覧サイドバー（モバイル: 会話未選択時のみ表示） */}
+      {showList && (
+        <DmConversationList
+          conversations={conversations}
+          activeConvId={activeConvId}
+          currentUserId={currentUserId}
+          isMobile={isMobile}
+          onSelectConversation={(convId) => void handleSelectConversation(convId)}
+          onNewDm={() => setNewDmOpen(true)}
+          onConversationsChange={setConversations}
+        />
+      )}
 
-      {/* メッセージエリア */}
-      <Box sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-        {activeConversation ? (
-          loadingMessages ? (
+      {/* メッセージエリア（モバイル: 会話選択時のみ表示） */}
+      {showMessage && (
+        <Box
+          sx={{
+            flexGrow: 1,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+            minWidth: 0,
+          }}
+        >
+          {/* モバイル: 戻るボタンヘッダー */}
+          {isMobile && activeConvId !== null && (
             <Box
               sx={{
                 display: 'flex',
-                justifyContent: 'center',
                 alignItems: 'center',
-                height: '100%',
+                gap: 1,
+                px: 1,
+                py: 0.5,
+                borderBottom: '1px solid var(--border)',
+                background: 'var(--bg-elev)',
+                flexShrink: 0,
               }}
             >
-              <CircularProgress />
+              <IconButton
+                size="small"
+                aria-label="一覧に戻る"
+                onClick={() => setActiveConvId(null)}
+              >
+                <ArrowBackIcon />
+              </IconButton>
+              <Typography variant="subtitle2" fontWeight="bold">
+                {activeConversation?.otherUser.displayName ??
+                  activeConversation?.otherUser.username ??
+                  ''}
+              </Typography>
             </Box>
+          )}
+
+          {activeConversation ? (
+            loadingMessages ? (
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  height: '100%',
+                }}
+              >
+                <CircularProgress />
+              </Box>
+            ) : (
+              <MessageArea
+                conversation={activeConversation}
+                currentUserId={currentUserId}
+                onSend={handleSend}
+                messages={messages}
+                typingUserId={typingUserId}
+              />
+            )
           ) : (
-            <MessageArea
-              conversation={activeConversation}
-              currentUserId={currentUserId}
-              onSend={handleSend}
-              messages={messages}
-              typingUserId={typingUserId}
-            />
-          )
-        ) : (
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              justifyContent: 'center',
-              height: '100%',
-              color: 'text.secondary',
-              gap: 1,
-            }}
-          >
-            <ChatIcon sx={{ fontSize: 64, opacity: 0.3 }} />
-            <Typography variant="h6">会話を選択してください</Typography>
-            <Typography variant="body2">
-              左のリストから相手を選ぶか、新規DMを開始しましょう
-            </Typography>
-          </Box>
-        )}
-      </Box>
+            // デスクトップのみ: 会話未選択時プレースホルダー（モバイルは showMessage=false で非表示）
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                height: '100%',
+                color: 'text.secondary',
+                gap: 1,
+              }}
+            >
+              <ChatIcon sx={{ fontSize: 64, opacity: 0.3 }} />
+              <Typography variant="h6">会話を選択してください</Typography>
+              <Typography variant="body2">
+                左のリストから相手を選ぶか、新規DMを開始しましょう
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      )}
 
       <NewDmDialog
         open={newDmOpen}

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
   FormControlLabel,
   Switch,
+  useMediaQuery,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -248,6 +249,7 @@ function TaskBoardContent({
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [activeId, setActiveId] = useState<number | null>(null);
+  const isMobile = useMediaQuery('(max-width: 767px)');
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
@@ -385,14 +387,28 @@ function TaskBoardContent({
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* ツールバー */}
-      <Box sx={{ display: 'flex', gap: 2, p: 2, alignItems: 'center', flexShrink: 0 }}>
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+      {/* ツールバー: モバイル時は縦スタック、デスクトップ時は横一列 */}
+      <Box
+        data-testid="task-toolbar"
+        sx={{
+          display: 'flex',
+          flexDirection: isMobile ? 'column' : 'row',
+          gap: isMobile ? 1 : 2,
+          p: 2,
+          alignItems: isMobile ? 'stretch' : 'center',
+          flexShrink: 0,
+        }}
+      >
+        <Typography variant="h6" sx={{ flexGrow: isMobile ? 0 : 1 }}>
           タスクボード
         </Typography>
 
         {/* チャンネル絞り込み */}
-        <FormControl size="small" sx={{ minWidth: 160 }}>
+        <FormControl
+          size="small"
+          data-testid="task-channel-filter"
+          sx={{ width: isMobile ? '100%' : undefined, minWidth: isMobile ? undefined : 160 }}
+        >
           <InputLabel>チャンネルで絞り込み</InputLabel>
           <Select
             value={channelFilter}
@@ -427,20 +443,24 @@ function TaskBoardContent({
           variant="contained"
           startIcon={<AddIcon />}
           onClick={() => setCreateDialogOpen(true)}
+          fullWidth={isMobile}
         >
           新規タスク作成
         </Button>
       </Box>
 
-      {/* カンバンボード */}
-      <Box sx={{ flexGrow: 1, overflow: 'auto', px: 2, pb: 2 }}>
+      {/* カンバンボード: 横スクロール対応 */}
+      <Box
+        data-testid="kanban-container"
+        sx={{ flexGrow: 1, overflow: 'auto', overflowX: 'auto', px: 2, pb: 2 }}
+      >
         <DndContext
           sensors={sensors}
           collisionDetection={closestCorners}
           onDragOver={handleDragOver}
           onDragEnd={(e) => void handleDragEnd(e)}
         >
-          <Box sx={{ display: 'flex', gap: 2, height: '100%' }}>
+          <Box sx={{ display: 'flex', gap: 2, height: '100%', minWidth: 'max-content' }}>
             {STATUS_COLUMNS.map((status) => (
               <KanbanColumn
                 key={status}


### PR DESCRIPTION
## 概要

モバイル幅（390px = iPhone 14 Pro 相当）で DM・タスク・カレンダーの3画面が崩れていた問題を修正。
共通の根本原因（デスクトップ向け 2-pane レイアウトがモバイル幅で reflow されない）に対し、
既存のチャット/受信箱と同じ `useMediaQuery('(max-width: 767px)')` パターンで対応した。

## 変更内容

- **DMPage**: モバイル時に一覧→会話の階層ナビゲーション化（未選択時は一覧のみ表示、会話タップで会話ビューへ切り替え、戻るボタンで一覧に戻る）
- **DmConversationList**: `isMobile` prop を追加し、モバイル時は幅 100% で表示（デスクトップは従来の 280px 固定）
- **TaskBoardPage**: ツールバーをモバイル時に縦スタック化（`flexDirection: column`）、チャンネルフィルターを全幅化、カンバン列コンテナを横スクロール対応（`overflowX: auto` + `minWidth: max-content`）
- **CalendarPage**: 左ペイン（ChannelFilterPanel）をモバイル時に MUI `Drawer` 化し、フィルターボタンから開閉。カレンダーグリッドをフル幅で表示
- **ChannelFilterPanel**: `isDrawer` prop を追加（Drawer 内では幅制限・ボーダーを解除）。`data-testid="channel-filter-panel"` を付与
- **MobileLayout.test.tsx (新規)**: 上記3画面のレイアウト分岐・条件付きレンダリング・遷移挙動のユニットテスト 18 件を追加

## 影響範囲

- `packages/client/src/pages/DMPage.tsx`
- `packages/client/src/pages/TaskBoardPage.tsx`
- `packages/client/src/pages/CalendarPage.tsx`
- `packages/client/src/components/DM/DmConversationList.tsx`
- `packages/client/src/components/Calendar/ChannelFilterPanel.tsx`
- `packages/client/src/__tests__/MobileLayout.test.tsx` (新規)

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（1594 件 / 107 ファイル）
- [x] バックエンドユニットテストがすべてパスする（変更なし）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #244

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した