### PR TITLE
fix: ?channel 直リンク時のチャンネル情報未取得を修正 (#247 #248)

### DIFF
--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -16,7 +16,7 @@
 import { render, waitFor, act, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, useLocation } from 'react-router-dom';
+import { MemoryRouter, useLocation, useSearchParams } from 'react-router-dom';
 import ChatPage from '../pages/ChatPage';
 
 // Step 8b: 現在の URL を data-testid で表示する補助コンポーネント
@@ -100,12 +100,15 @@ vi.mock('../contexts/SnackbarContext', () => ({
 const mockSearch = vi.hoisted(() => vi.fn().mockResolvedValue({ messages: [] }));
 const mockBookmarksList = vi.hoisted(() => vi.fn().mockResolvedValue({ bookmarks: [] }));
 const mockDraftsGetAll = vi.hoisted(() => vi.fn().mockResolvedValue({ drafts: [] }));
+// #247 #248 ?channel 直リンク時は ChatPage が自前で channels.list() を呼んで activeChannel を埋める
+const mockChannelsList = vi.hoisted(() => vi.fn().mockResolvedValue({ channels: [] }));
 
 vi.mock('../api/client', () => ({
   api: {
     messages: { search: mockSearch },
     bookmarks: { list: mockBookmarksList },
     drafts: { getAll: mockDraftsGetAll },
+    channels: { list: mockChannelsList },
   },
 }));
 
@@ -150,6 +153,7 @@ beforeEach(() => {
   MockRichEditor.mockImplementation(() => null);
   mockSearch.mockResolvedValue({ messages: [] });
   mockBookmarksList.mockResolvedValue({ bookmarks: [] });
+  mockChannelsList.mockResolvedValue({ channels: [] });
   // useAuth のユーザーをデフォルトにリセット
   mockUser.current = { id: 1, role: 'user', isActive: true, username: 'testuser' };
   // socket モックをデフォルトの null に戻す
@@ -279,13 +283,47 @@ describe('ChatPage', () => {
   // #154 コンパクトヘッダー — 1行ヘッダー化 / ファイル切替アイコン
   describe('コンパクトヘッダー (#154)', () => {
     /** チャンネルを選択するヘルパー */
+    // #247 #248 修正後はヘッダー名が activeChannel.name から派生するため、
+    // テストでも実装と同じ第3引数 channel を必ず渡す（onSelect の正規シグネチャに合わせる）。
     const selectChannel = async () => {
       const calls = MockChannelList.mock.calls as unknown as Array<
-        [{ onSelect: (id: number, name: string) => void }]
+        [
+          {
+            onSelect: (
+              id: number,
+              name: string,
+              channel?: {
+                id: number;
+                name: string;
+                description: null;
+                topic: null;
+                createdBy: number;
+                isPrivate: boolean;
+                postingPermission: 'everyone' | 'admins' | 'readonly';
+                isArchived: boolean;
+                isRecommended: boolean;
+                createdAt: string;
+                unreadCount: number;
+              },
+            ) => void;
+          },
+        ]
       >;
       const props = calls[calls.length - 1][0];
       await act(async () => {
-        props.onSelect(1, 'general');
+        props.onSelect(1, 'general', {
+          id: 1,
+          name: 'general',
+          description: null,
+          topic: null,
+          createdBy: 99,
+          isPrivate: false,
+          postingPermission: 'everyone',
+          isArchived: false,
+          isRecommended: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          unreadCount: 0,
+        });
       });
     };
 
@@ -567,32 +605,191 @@ describe('ChatPage', () => {
   // - #248: 入力欄が disabled になる (activeChannel 未設定で canPostToActiveChannel === false)
   // 共通: ChannelList の onSelect を経由しないため activeChannel / activeChannelName が空になる
   describe('?channel 直リンク時のチャンネル情報補完 (#247 #248)', () => {
+    /** テスト用 Channel ファクトリ（必要最低限の Channel オブジェクトを生成） */
+    const makeChannel = (
+      overrides: Partial<{
+        id: number;
+        name: string;
+        postingPermission: 'everyone' | 'admins' | 'readonly';
+        isArchived: boolean;
+      }>,
+    ) => ({
+      id: 1,
+      name: 'general',
+      description: null,
+      topic: null,
+      createdBy: 99,
+      isPrivate: false,
+      postingPermission: 'everyone' as 'everyone' | 'admins' | 'readonly',
+      isArchived: false,
+      isRecommended: false,
+      createdAt: '2024-01-01T00:00:00Z',
+      unreadCount: 0,
+      mentionCount: 0,
+      ...overrides,
+    });
+
+    /** MockRichEditor に最後に渡された disabled prop を取得 */
+    const getLastDisabled = (): boolean | undefined => {
+      const calls = MockRichEditor.mock.calls as unknown as Array<[{ disabled?: boolean }]>;
+      return calls[calls.length - 1]?.[0]?.disabled;
+    };
+
     describe('ヘッダー表示 (#247)', () => {
-      it.todo('?channel=N で直接マウントしたとき、ヘッダーにチャンネル名が表示される');
+      it('?channel=N で直接マウントしたとき、ヘッダーにチャンネル名が表示される', async () => {
+        mockChannelsList.mockResolvedValue({
+          channels: [makeChannel({ id: 5, name: 'random', postingPermission: 'everyone' })],
+        });
+
+        renderChatPage('/chat?channel=5');
+
+        // チャンネル取得後にヘッダーが "# random" になること
+        await waitFor(() => {
+          expect(screen.getByText('# random')).toBeInTheDocument();
+        });
+      });
     });
 
     describe('入力欄 disabled 計算 (#248)', () => {
-      it.todo(
-        '?channel=N で直接マウントしたとき、postingPermission=everyone のチャンネルでは RichEditor が disabled=false で渡される',
-      );
-      it.todo(
-        '?channel=N で直接マウントしたとき、postingPermission=readonly のチャンネルでは RichEditor が disabled=true で渡される',
-      );
-      it.todo(
-        '?channel=N で直接マウントしたとき、postingPermission=admins のチャンネルでは一般ユーザーには disabled=true で渡される',
-      );
-      it.todo(
-        '?channel=N で直接マウントしたとき、postingPermission=admins のチャンネルでは管理者には disabled=false で渡される',
-      );
+      it('?channel=N で直接マウントしたとき、postingPermission=everyone のチャンネルでは RichEditor が disabled=false で渡される', async () => {
+        mockChannelsList.mockResolvedValue({
+          channels: [makeChannel({ id: 5, name: 'random', postingPermission: 'everyone' })],
+        });
+
+        renderChatPage('/chat?channel=5');
+
+        await waitFor(() => {
+          expect(getLastDisabled()).toBe(false);
+        });
+      });
+
+      it('?channel=N で直接マウントしたとき、postingPermission=readonly のチャンネルでは RichEditor が disabled=true で渡される', async () => {
+        mockChannelsList.mockResolvedValue({
+          channels: [makeChannel({ id: 5, name: 'announce', postingPermission: 'readonly' })],
+        });
+
+        renderChatPage('/chat?channel=5');
+
+        await waitFor(() => {
+          expect(getLastDisabled()).toBe(true);
+        });
+      });
+
+      it('?channel=N で直接マウントしたとき、postingPermission=admins のチャンネルでは一般ユーザーには disabled=true で渡される', async () => {
+        mockUser.current = { id: 1, role: 'user', isActive: true, username: 'testuser' };
+        mockChannelsList.mockResolvedValue({
+          channels: [makeChannel({ id: 5, name: 'admin-only', postingPermission: 'admins' })],
+        });
+
+        renderChatPage('/chat?channel=5');
+
+        await waitFor(() => {
+          expect(getLastDisabled()).toBe(true);
+        });
+      });
+
+      it('?channel=N で直接マウントしたとき、postingPermission=admins のチャンネルでは管理者には disabled=false で渡される', async () => {
+        mockUser.current = { id: 1, role: 'admin', isActive: true, username: 'adminuser' };
+        mockChannelsList.mockResolvedValue({
+          channels: [makeChannel({ id: 5, name: 'admin-only', postingPermission: 'admins' })],
+        });
+
+        renderChatPage('/chat?channel=5');
+
+        await waitFor(() => {
+          expect(getLastDisabled()).toBe(false);
+        });
+      });
     });
 
     describe('URL 変更時の同期', () => {
-      it.todo(
-        'URL を ?channel=1 から ?channel=2 へ切り替えると、ヘッダー名と postingPermission がチャンネル2 のものに反映される',
-      );
-      it.todo(
-        '?channel=N の状態から channel パラメータを除いた URL に変わると、activeChannel と activeChannelName がリセットされ案内文が表示される',
-      );
+      it('URL を ?channel=1 から ?channel=2 へ切り替えると、ヘッダー名と postingPermission がチャンネル2 のものに反映される', async () => {
+        mockChannelsList.mockResolvedValue({
+          channels: [
+            makeChannel({ id: 1, name: 'one', postingPermission: 'everyone' }),
+            makeChannel({ id: 2, name: 'two', postingPermission: 'readonly' }),
+          ],
+        });
+
+        // 初期 URL は ?channel=1。LocationDisplay 経由で URL 変更を観察できるように
+        // RouterFixture コンポーネントを内側に置き、テストから navigate を呼び出す。
+        function NavBtn() {
+          // 内部で useSearchParams を呼び、ボタン押下で ?channel=2 に書き換える
+          const [, setSearchParams] = useSearchParams();
+          return (
+            <button
+              type="button"
+              data-testid="goto-2"
+              onClick={() => setSearchParams({ channel: '2' })}
+            >
+              goto-2
+            </button>
+          );
+        }
+
+        render(
+          <MemoryRouter initialEntries={['/chat?channel=1']}>
+            <ChatPage users={[]} />
+            <NavBtn />
+          </MemoryRouter>,
+        );
+
+        // 1: 最初は channel=1（everyone, "# one"）
+        await waitFor(() => {
+          expect(screen.getByText('# one')).toBeInTheDocument();
+        });
+        await waitFor(() => {
+          expect(getLastDisabled()).toBe(false);
+        });
+
+        // 2: ボタン押下で URL を ?channel=2 に切り替える
+        await userEvent.click(screen.getByTestId('goto-2'));
+
+        // 3: 切替後は "# two"（readonly, disabled=true）
+        await waitFor(() => {
+          expect(screen.getByText('# two')).toBeInTheDocument();
+        });
+        await waitFor(() => {
+          expect(getLastDisabled()).toBe(true);
+        });
+      });
+
+      it('?channel=N の状態から channel パラメータを除いた URL に変わると、activeChannel と activeChannelName がリセットされ案内文が表示される', async () => {
+        mockChannelsList.mockResolvedValue({
+          channels: [makeChannel({ id: 5, name: 'random', postingPermission: 'everyone' })],
+        });
+
+        function ClearBtn() {
+          const [, setSearchParams] = useSearchParams();
+          return (
+            <button type="button" data-testid="clear-channel" onClick={() => setSearchParams({})}>
+              clear
+            </button>
+          );
+        }
+
+        render(
+          <MemoryRouter initialEntries={['/chat?channel=5']}>
+            <ChatPage users={[]} />
+            <ClearBtn />
+          </MemoryRouter>,
+        );
+
+        // チャンネル選択中: ヘッダーが表示される
+        await waitFor(() => {
+          expect(screen.getByText('# random')).toBeInTheDocument();
+        });
+
+        // URL から channel パラメータを除去
+        await userEvent.click(screen.getByTestId('clear-channel'));
+
+        // 案内文が表示される
+        await waitFor(() => {
+          expect(screen.getByText(/チャンネルを選択/)).toBeInTheDocument();
+        });
+        // ヘッダーは消える
+        expect(screen.queryByText('# random')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -561,4 +561,38 @@ describe('ChatPage', () => {
       expect(screen.getByText(/チャンネルを選択/)).toBeInTheDocument();
     });
   });
+
+  // #247 #248 ?channel=N URL 直リンク時のチャンネル情報未取得バグ修正
+  // - #247: ヘッダーが "# " だけになる (activeChannelName 未設定)
+  // - #248: 入力欄が disabled になる (activeChannel 未設定で canPostToActiveChannel === false)
+  // 共通: ChannelList の onSelect を経由しないため activeChannel / activeChannelName が空になる
+  describe('?channel 直リンク時のチャンネル情報補完 (#247 #248)', () => {
+    describe('ヘッダー表示 (#247)', () => {
+      it.todo('?channel=N で直接マウントしたとき、ヘッダーにチャンネル名が表示される');
+    });
+
+    describe('入力欄 disabled 計算 (#248)', () => {
+      it.todo(
+        '?channel=N で直接マウントしたとき、postingPermission=everyone のチャンネルでは RichEditor が disabled=false で渡される',
+      );
+      it.todo(
+        '?channel=N で直接マウントしたとき、postingPermission=readonly のチャンネルでは RichEditor が disabled=true で渡される',
+      );
+      it.todo(
+        '?channel=N で直接マウントしたとき、postingPermission=admins のチャンネルでは一般ユーザーには disabled=true で渡される',
+      );
+      it.todo(
+        '?channel=N で直接マウントしたとき、postingPermission=admins のチャンネルでは管理者には disabled=false で渡される',
+      );
+    });
+
+    describe('URL 変更時の同期', () => {
+      it.todo(
+        'URL を ?channel=1 から ?channel=2 へ切り替えると、ヘッダー名と postingPermission がチャンネル2 のものに反映される',
+      );
+      it.todo(
+        '?channel=N の状態から channel パラメータを除いた URL に変わると、activeChannel と activeChannelName がリセットされ案内文が表示される',
+      );
+    });
+  });
 });

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -31,8 +31,11 @@ interface Props {
 
 export default function ChatPage({ users }: Props) {
   const [activeChannelId, setActiveChannelId] = useState<number | null>(null);
-  const [activeChannelName, setActiveChannelName] = useState<string>('');
   const [activeChannel, setActiveChannel] = useState<Channel | null>(null);
+  // #247 #248 ヘッダー名は activeChannel から派生表示する（state の二重管理を排除）
+  const activeChannelName = activeChannel?.name ?? '';
+  // #247 #248 URL 直リンク時に activeChannel を埋めるための全チャンネルリスト
+  const [allChannels, setAllChannels] = useState<Channel[] | null>(null);
   const [activeTab, setActiveTab] = useState<'messages' | 'files'>('messages');
   // #148 下書きマップ: channelId → 下書きコンテンツ
   const [draftMap, setDraftMap] = useState<Map<number, string>>(new Map());
@@ -81,12 +84,34 @@ export default function ChatPage({ users }: Props) {
       }
     } else if (activeChannelId !== null) {
       setActiveChannelId(null);
-      setActiveChannelName('');
       setActiveChannel(null);
     }
     // activeChannelId は同期対象なので依存に含めない (URL → state の単方向反映)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [urlChannelId]);
+
+  // #247 #248 マウント時にチャンネル一覧を取得し、URL 直リンク時の activeChannel 補完用に保持する
+  // ChannelList の onSelect 経由なら activeChannel が直接渡されるが、
+  // ?channel=N の直リンク・リロード時は ChannelList の onSelect が走らないため
+  // 別ルートでチャンネル詳細を取得する必要がある。
+  useEffect(() => {
+    api.channels
+      .list()
+      .then(({ channels }) => setAllChannels(channels))
+      .catch(console.error);
+  }, []);
+
+  // activeChannelId が変わり、かつ allChannels が取得済みなら該当 channel を引いて activeChannel をセット
+  // (URL 直リンク・リロード時のヘッダー名・投稿権限の正しい計算のため)
+  useEffect(() => {
+    if (activeChannelId === null || !allChannels) return;
+    // 既に同 ID の activeChannel が埋まっている場合はスキップ（onSelect 経由で先に埋まるケース）
+    if (activeChannel && activeChannel.id === activeChannelId) return;
+    const found = allChannels.find((ch) => ch.id === activeChannelId);
+    if (found) {
+      setActiveChannel(found);
+    }
+  }, [activeChannelId, allChannels, activeChannel]);
 
   // ブックマーク済みメッセージIDセットをマウント時に取得する
   useEffect(() => {
@@ -254,8 +279,8 @@ export default function ChatPage({ users }: Props) {
           <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
             <ChannelList
               activeChannelId={activeChannelId}
-              onSelect={(id, name, channel) => {
-                setActiveChannelName(name);
+              onSelect={(id, _name, channel) => {
+                // activeChannelName は activeChannel?.name から派生するため name 引数は使わない (#247 #248)
                 setActiveChannel(channel ?? null);
                 setActiveTab('messages');
                 // URL を push 更新すると useEffect で activeChannelId が同期される


### PR DESCRIPTION
## 概要

`?channel=N` 形式の URL でチャンネルへ直接アクセスした際、`ChannelList` の `onSelect` を経由しないため `activeChannel` / `activeChannelName` が空のままとなり、以下の 2 つのバグが同時発生していた問題を修正する。

- #247: ヘッダーが `# ` のみ表示されチャンネル名が出ない
- #248: メッセージ入力欄が disabled になり「このチャンネルには投稿できません」と表示される

両バグは原因が同じ（`activeChannel` 未取得）ため一括で修正する。

## 変更内容

- `ChatPage` マウント時に `api.channels.list()` を呼んで全チャンネルを `allChannels` state に保持
- `activeChannelId` 変化時に `allChannels` から該当 channel を引いて `activeChannel` を補完（URL 直リンク・リロード時のヘッダー名・投稿権限判定を正しく動作させる）
- `activeChannelName` は state を廃止し `activeChannel?.name` から派生表示（二重 state を排除）
- `ChannelList` の `onSelect` コールバックから `setActiveChannelName(name)` 呼び出しを削除
- 新規テスト 7 件追加（ヘッダー表示・disabled 計算 4 種・URL 切替・URL クリア）
- 既存 `#154 1行ヘッダー` テストで `onSelect(id, name)` のみ渡していた箇所を、実装側シグネチャに合わせ Channel オブジェクトも渡す形へ更新

## 影響範囲

- `packages/client/src/pages/ChatPage.tsx`: state 構造を変更（`activeChannelName` を派生値化、`allChannels` を追加）。`ChannelList` 経由の選択経路は従来どおり動作する
- `packages/client/src/__tests__/ChatPage.test.tsx`: テスト 7 件追加 + 既存 `#154` テストヘルパー更新

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（ChatPage.test.tsx: 30/30 pass。client 全体 1583 pass。残り 18 failures は本変更と無関係な既存 timeout 系の不安定テスト — 並列 worktree 環境での CPU 競合に起因し、ChatPage 関連のテストはすべて成功）
- [ ] バックエンドユニットテストがすべてパスする（本 PR は client のみの変更のためサーバーテストは未実行）
- [x] ビルドが正常に完了すること（`npm run build` 成功）
- [ ] (手動確認の場合) 確認した手順やスクリーンショット — 未実施。レビュー時にユーザー側で確認をお願いします（`http://localhost:5173/chat?channel=1` 直アクセス → ヘッダー / 入力欄が正常になること）

## 関連Issue

Fixes #247
Fixes #248

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] `it.todo` / 空ボディの `it` が残っていない