### PR TITLE
docs: feature-ideas.md から不具合セクションを削除

### DIFF
--- a/doc/feature-ideas.md
+++ b/doc/feature-ideas.md
@@ -105,10 +105,10 @@
 
 ### 不具合（bug 候補）
 
-- [ ] **チャンネル URL 直リンク時にヘッダーのチャンネル名が空** — `?channel=N` で直接アクセスすると `activeChannelName` 初期化が走らず `# ` だけが表示される（`ChatPage.tsx` 304行目）。共有 URL からの遷移・ブラウザリロード時に致命的｜難易度: 低
-- [ ] **チャンネル URL 直リンク時にメッセージ入力欄が disabled** — `activeChannel` が null のため `canPostToActiveChannel === false` となり「このチャンネルには投稿できません」が誤表示される（`ChatPage.tsx` 44–49行）。`postingPermission` 未取得時はデフォルト許可にすべき｜難易度: 低
-- [ ] **検索ページの初期表示で「見つかりませんでした」が出る** — クエリ未入力でも空結果プレースホルダが表示される。初期は使い方ヒント／保存ビュー一覧／最近の検索を出すべき｜難易度: 低
-- [ ] **メンション表示の `@` アイコン重複** — 投稿本文に `@e2e_alice @ hello mention test` のようにメンションチップ後に余分な `@` 字が残る。MentionBlot のレンダリングを点検する｜難易度: 低
+- [x] **チャンネル URL 直リンク時にヘッダーのチャンネル名が空** — `?channel=N` で直接アクセスすると `activeChannelName` 初期化が走らず `# ` だけが表示される（`ChatPage.tsx` 304行目）。共有 URL からの遷移・ブラウザリロード時に致命的｜難易度: 低｜[#247](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/247)
+- [x] **チャンネル URL 直リンク時にメッセージ入力欄が disabled** — `activeChannel` が null のため `canPostToActiveChannel === false` となり「このチャンネルには投稿できません」が誤表示される（`ChatPage.tsx` 44–49行）。`postingPermission` 未取得時はデフォルト許可にすべき｜難易度: 低｜[#248](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/248)
+- [x] **検索ページの初期表示で「見つかりませんでした」が出る** — クエリ未入力でも空結果プレースホルダが表示される。初期は使い方ヒント／保存ビュー一覧／最近の検索を出すべき｜難易度: 低｜[#249](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/249)
+- [x] **メンション表示の `@` アイコン重複** — 投稿本文に `@e2e_alice @ hello mention test` のようにメンションチップ後に余分な `@` 字が残る。MentionBlot のレンダリングを点検する｜難易度: 低｜[#250](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/250)
 
 ### ナビゲーション・情報設計
 

--- a/doc/feature-ideas.md
+++ b/doc/feature-ideas.md
@@ -103,13 +103,6 @@
 
 新 UI を Playwright で巡回した際に検出した不具合・改善余地。リニューアル後の細部を整える施策。
 
-### 不具合（bug 候補）
-
-- [x] **チャンネル URL 直リンク時にヘッダーのチャンネル名が空** — `?channel=N` で直接アクセスすると `activeChannelName` 初期化が走らず `# ` だけが表示される（`ChatPage.tsx` 304行目）。共有 URL からの遷移・ブラウザリロード時に致命的｜難易度: 低｜[#247](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/247)
-- [x] **チャンネル URL 直リンク時にメッセージ入力欄が disabled** — `activeChannel` が null のため `canPostToActiveChannel === false` となり「このチャンネルには投稿できません」が誤表示される（`ChatPage.tsx` 44–49行）。`postingPermission` 未取得時はデフォルト許可にすべき｜難易度: 低｜[#248](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/248)
-- [x] **検索ページの初期表示で「見つかりませんでした」が出る** — クエリ未入力でも空結果プレースホルダが表示される。初期は使い方ヒント／保存ビュー一覧／最近の検索を出すべき｜難易度: 低｜[#249](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/249)
-- [x] **メンション表示の `@` アイコン重複** — 投稿本文に `@e2e_alice @ hello mention test` のようにメンションチップ後に余分な `@` 字が残る。MentionBlot のレンダリングを点検する｜難易度: 低｜[#250](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/250)
-
 ### ナビゲーション・情報設計
 
 - [ ] **コマンドパレット / クイックスイッチャー** — `Cmd+K` でチャンネル・DM・ユーザー・コマンドを横断検索しジャンプできる｜難易度: 中


### PR DESCRIPTION
## 概要

`doc/feature-ideas.md` の「UI/UX 刷新後の磨き込み（2026-05 観察）」配下にあった「### 不具合（bug 候補）」サブセクションを丸ごと削除する。

不具合は機能拡充リストの対象外（Issue / PR で個別管理する性質のもの）であり、4 件とも既に Issue 化（#247–#250）→ PR マージ済み（#251–#253）のため、ドキュメント上から除去する。

## 変更内容

- `### 不具合（bug 候補）` 見出し + 直下の 4 行（チャンネル名空 / 入力欄 disabled / 検索初期表示 / メンション @ 重複）を削除
- 改善案サブセクション（ナビゲーション・メッセージ作成・通知 等）は残置

## 影響範囲

`doc/feature-ideas.md` のみ。アプリ・ビルド・テストへの影響なし。

## 動作確認・テスト結果

- [ ] フロントエンドユニットテストがすべてパスする — N/A（ドキュメントのみ）
- [ ] バックエンドユニットテストがすべてパスする — N/A
- [ ] ビルドが正常に完了すること — N/A
- [x] (手動確認の場合) 確認した手順やスクリーンショット — Markdown のレンダリングを確認済み

## 関連Issue

Fixes #

参考: #247 / #248 / #249 / #250（すべて closed 済み、対応 PR #251–#253 マージ済み）

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている — N/A（ドキュメント）
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した — `feature-ideas.md` 自体が対象
- [x] `it.todo` / 空ボディの `it` が残っていない — N/A