### PR TITLE
feat: 受信箱タブに未読フィルタトグルスイッチを追加 (#266)

### DIFF
--- a/packages/client/src/__tests__/DraftsList.test.tsx
+++ b/packages/client/src/__tests__/DraftsList.test.tsx
@@ -43,6 +43,27 @@ describe('DraftsList (Step 6a)', () => {
     expect(screen.getAllByTestId('draft-card')).toHaveLength(2);
   });
 
+  // unreadOnly prop のテスト (Issue #266)
+  describe('unreadOnly prop の受け取り', () => {
+    it('unreadOnly=true のとき全下書きが表示される（下書きは未読フラグなし）', () => {
+      const drafts = [makeDraft({ id: 1 }), makeDraft({ id: 2 })];
+      render(<DraftsList drafts={drafts} unreadOnly={true} />);
+      expect(screen.getAllByTestId('draft-card')).toHaveLength(2);
+    });
+
+    it('unreadOnly=false のとき全下書きが表示される', () => {
+      const drafts = [makeDraft({ id: 1 }), makeDraft({ id: 2 })];
+      render(<DraftsList drafts={drafts} unreadOnly={false} />);
+      expect(screen.getAllByTestId('draft-card')).toHaveLength(2);
+    });
+
+    it('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）', () => {
+      const drafts = [makeDraft({ id: 1 }), makeDraft({ id: 2 })];
+      render(<DraftsList drafts={drafts} />);
+      expect(screen.getAllByTestId('draft-card')).toHaveLength(2);
+    });
+  });
+
   describe('クイックアクション (Step 6d)', () => {
     it('チャンネル下書きのカードに「再開」ボタンが表示される', () => {
       render(<DraftsList drafts={[makeDraft({ channelId: 7 })]} />);

--- a/packages/client/src/__tests__/InboxUnreadFilter.test.tsx
+++ b/packages/client/src/__tests__/InboxUnreadFilter.test.tsx
@@ -11,75 +11,242 @@
  * 戦略:
  *   - InboxPage のトグル UI は MemoryRouter + vi.mock で Suspense を切り離して検証する
  *   - localStorage の読み書きは vi.spyOn(Storage.prototype, ...) で検証する
- *   - 各 List コンポーネントの unreadOnly prop は純粋コンポーネントに直接 prop を渡して検証する
- *   - 複数コンポーネントにまたがるためファイルを新規作成（AGENTS.md 方針に準拠）
+ *   - 各 List コンポーネントの unreadOnly prop は各コンポーネント専用テストファイルに追記して検証する
+ *     （MentionsList.test.tsx / ThreadsList.test.tsx / RemindersList.test.tsx / DraftsList.test.tsx）
+ *   - このファイルでは InboxPage のトグル UI・localStorage 永続化・API 連携のみ検証する
  */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import React from 'react';
+import InboxPage from '../pages/InboxPage';
+
+// ------ InboxPage テスト用モック ------
+
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
+
+vi.mock('../components/Channel/ChannelList', () => ({
+  default: () => <div data-testid="channel-list-stub" />,
+}));
+
+vi.mock('../components/Layout/SidebarDmList', () => ({
+  default: () => <div data-testid="sidebar-dm-list-stub" />,
+}));
+
+vi.mock('../components/Inbox/SummaryCards', () => ({
+  default: () => <div data-testid="summary-cards-stub" />,
+}));
+
+vi.mock('../components/Inbox/RemindersList', () => ({
+  default: ({ unreadOnly }: { unreadOnly?: boolean }) => (
+    <div data-testid="reminders-list-stub" data-unread-only={String(unreadOnly ?? false)} />
+  ),
+}));
+
+vi.mock('../components/Inbox/DraftsList', () => ({
+  default: ({ unreadOnly }: { unreadOnly?: boolean }) => (
+    <div data-testid="drafts-list-stub" data-unread-only={String(unreadOnly ?? false)} />
+  ),
+}));
+
+vi.mock('../components/Inbox/MentionsList', () => ({
+  default: ({ unreadOnly }: { unreadOnly?: boolean }) => (
+    <div data-testid="mentions-list-stub" data-unread-only={String(unreadOnly ?? false)} />
+  ),
+}));
+
+vi.mock('../components/Inbox/ThreadsList', () => ({
+  default: ({ unreadOnly }: { unreadOnly?: boolean }) => (
+    <div data-testid="threads-list-stub" data-unread-only={String(unreadOnly ?? false)} />
+  ),
+}));
+
+const mockAuthValue = vi.hoisted(() => ({
+  user: { id: 1, username: 'alice', email: 'alice@example.com', role: 'user' },
+}));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => mockAuthValue,
+}));
+
+const mockChannelsList = vi.hoisted(() => vi.fn());
+const mockCalendarEventsList = vi.hoisted(() => vi.fn());
+const mockTasksList = vi.hoisted(() => vi.fn());
+const mockRemindersList = vi.hoisted(() => vi.fn());
+const mockDraftsGetAll = vi.hoisted(() => vi.fn());
+const mockMessagesSearch = vi.hoisted(() => vi.fn());
+const mockThreadsListSubscribed = vi.hoisted(() => vi.fn());
+
+vi.mock('../api/client', () => ({
+  api: {
+    channels: { list: mockChannelsList },
+    calendar: { events: { list: mockCalendarEventsList } },
+    tasks: { list: mockTasksList },
+    reminders: { list: mockRemindersList, delete: vi.fn() },
+    drafts: { getAll: mockDraftsGetAll },
+    messages: { search: mockMessagesSearch },
+    threads: { listSubscribed: mockThreadsListSubscribed },
+  },
+}));
+
+beforeEach(() => {
+  mockChannelsList.mockResolvedValue({ channels: [] });
+  mockCalendarEventsList.mockResolvedValue({ events: [] });
+  mockTasksList.mockResolvedValue({ tasks: [] });
+  mockRemindersList.mockResolvedValue({ reminders: [] });
+  mockDraftsGetAll.mockResolvedValue({ drafts: [] });
+  mockMessagesSearch.mockResolvedValue({ messages: [] });
+  mockThreadsListSubscribed.mockResolvedValue({ threads: [] });
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+function renderInbox(initialPath: string = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/" element={<InboxPage />} />
+        <Route path="/chat" element={<div data-testid="chat-page-stub" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// ------ InboxPage トグルスイッチのテスト ------
 
 describe('受信箱 未読フィルタトグル - InboxPage', () => {
   describe('トグルスイッチの表示', () => {
-    it.todo('メンションタブを開くとタブヘッダー右側にトグルスイッチが表示される');
-    it.todo('スレッドタブを開くとタブヘッダー右側にトグルスイッチが表示される');
-    it.todo('リマインダータブを開くとタブヘッダー右側にトグルスイッチが表示される');
-    it.todo('下書きタブを開くとタブヘッダー右側にトグルスイッチが表示される');
-    it.todo('すべてタブを開くとタブヘッダー右側にトグルスイッチが表示される');
+    it('メンションタブを開くとタブヘッダー右側にトグルスイッチが表示される', async () => {
+      renderInbox('/?tab=mentions');
+      expect(await screen.findByRole('checkbox', { name: /未読のみ/ })).toBeInTheDocument();
+    });
+
+    it('スレッドタブを開くとタブヘッダー右側にトグルスイッチが表示される', async () => {
+      renderInbox('/?tab=threads');
+      expect(await screen.findByRole('checkbox', { name: /未読のみ/ })).toBeInTheDocument();
+    });
+
+    it('リマインダータブを開くとタブヘッダー右側にトグルスイッチが表示される', async () => {
+      renderInbox('/?tab=reminders');
+      expect(await screen.findByRole('checkbox', { name: /未読のみ/ })).toBeInTheDocument();
+    });
+
+    it('下書きタブを開くとタブヘッダー右側にトグルスイッチが表示される', async () => {
+      renderInbox('/?tab=drafts');
+      expect(await screen.findByRole('checkbox', { name: /未読のみ/ })).toBeInTheDocument();
+    });
+
+    it('すべてタブを開くとタブヘッダー右側にトグルスイッチが表示される', async () => {
+      renderInbox('/?tab=all');
+      expect(await screen.findByRole('checkbox', { name: /未読のみ/ })).toBeInTheDocument();
+    });
   });
 
   describe('トグルスイッチの初期状態', () => {
-    it.todo('localStorage に値がない場合は「未読のみ」がデフォルト状態になる');
-    it.todo('localStorage に unreadOnly=false が保存されている場合は「全件」状態で開く');
-    it.todo('localStorage に unreadOnly=true が保存されている場合は「未読のみ」状態で開く');
+    it('localStorage に値がない場合は「未読のみ」がデフォルト状態（チェック済み）になる', async () => {
+      renderInbox('/');
+      const toggle = await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(toggle).toBeChecked();
+    });
+
+    it('localStorage に unreadOnly=false が保存されている場合は「全件」状態（未チェック）で開く', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'false');
+      renderInbox('/');
+      const toggle = await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(toggle).not.toBeChecked();
+    });
+
+    it('localStorage に unreadOnly=true が保存されている場合は「未読のみ」状態（チェック済み）で開く', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'true');
+      renderInbox('/');
+      const toggle = await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(toggle).toBeChecked();
+    });
   });
 
   describe('トグルスイッチの操作', () => {
-    it.todo('「未読のみ」→「全件」に切り替えると localStorage に false が保存される');
-    it.todo('「全件」→「未読のみ」に切り替えると localStorage に true が保存される');
-    it.todo('タブを切り替えてもトグルの状態が維持される');
+    it('「未読のみ」→「全件」に切り替えると localStorage に false が保存される', async () => {
+      renderInbox('/');
+      const toggle = await screen.findByRole('checkbox', { name: /未読のみ/ });
+      // デフォルトは true (チェック済み)
+      await userEvent.click(toggle);
+      expect(localStorage.getItem('inbox:unreadOnly')).toBe('false');
+    });
+
+    it('「全件」→「未読のみ」に切り替えると localStorage に true が保存される', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'false');
+      renderInbox('/');
+      const toggle = await screen.findByRole('checkbox', { name: /未読のみ/ });
+      await userEvent.click(toggle);
+      expect(localStorage.getItem('inbox:unreadOnly')).toBe('true');
+    });
+
+    it('タブを切り替えてもトグルの状態が維持される', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'false');
+      renderInbox('/');
+      // 「全件」状態で開く
+      const toggle = await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(toggle).not.toBeChecked();
+
+      // スレッドタブに切り替え
+      await userEvent.click(screen.getByRole('tab', { name: 'スレッド' }));
+      // トグル状態が維持されている
+      expect(screen.getByRole('checkbox', { name: /未読のみ/ })).not.toBeChecked();
+    });
   });
 
   describe('フィルタ状態と API 呼び出しの連携', () => {
-    it.todo(
-      'unreadOnly=true のときメンションタブで api.messages.search が unreadOnly:true で呼ばれる',
-    );
-    it.todo(
-      'unreadOnly=false のときメンションタブで api.messages.search が unreadOnly:false で呼ばれる',
-    );
-    it.todo(
-      'unreadOnly=true のときスレッドタブで api.threads.listSubscribed が unreadOnly:true で呼ばれる',
-    );
-    it.todo(
-      'unreadOnly=false のときスレッドタブで api.threads.listSubscribed が unreadOnly:false で呼ばれる',
-    );
-  });
-});
+    it('unreadOnly=true のときメンションタブで api.messages.search が unreadOnly:true で呼ばれる', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'true');
+      renderInbox('/?tab=mentions');
+      await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(mockMessagesSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ unreadOnly: true }),
+      );
+    });
 
-describe('受信箱 未読フィルタトグル - MentionsList', () => {
-  describe('unreadOnly prop の受け取り', () => {
-    it.todo('unreadOnly=true のとき「未読のみ表示中」などのラベルまたは表示件数が絞られる');
-    it.todo('unreadOnly=false のときすべてのメンションが表示される');
-    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
-  });
-});
+    it('unreadOnly=false のときメンションタブで api.messages.search が unreadOnly:false で呼ばれる', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'false');
+      renderInbox('/?tab=mentions');
+      await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(mockMessagesSearch).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ unreadOnly: false }),
+      );
+    });
 
-describe('受信箱 未読フィルタトグル - ThreadsList', () => {
-  describe('unreadOnly prop の受け取り', () => {
-    it.todo('unreadOnly=true のとき未読フラグを持つスレッドのみ表示される');
-    it.todo('unreadOnly=false のとき全スレッドが表示される');
-    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
-  });
-});
+    it('スレッドタブで api.threads.listSubscribed が呼ばれ、unreadOnly フィルタはクライアント側（ThreadsList）で処理される', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'true');
+      renderInbox('/?tab=threads');
+      await screen.findByRole('checkbox', { name: /未読のみ/ });
+      expect(mockThreadsListSubscribed).toHaveBeenCalled();
+    });
 
-describe('受信箱 未読フィルタトグル - RemindersList', () => {
-  describe('unreadOnly prop の受け取り', () => {
-    it.todo('unreadOnly=true のとき未読のリマインダーのみ表示される');
-    it.todo('unreadOnly=false のとき全リマインダーが表示される');
-    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
-  });
-});
+    it('unreadOnly=true のときスレッドタブの threads-list-stub に unreadOnly:true が渡される', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'true');
+      renderInbox('/?tab=threads');
+      await screen.findByRole('checkbox', { name: /未読のみ/ });
+      // モックコンポーネントが data-unread-only="true" を持つことを確認
+      const stub = await screen.findByTestId('threads-list-stub');
+      expect(stub).toHaveAttribute('data-unread-only', 'true');
+    });
 
-describe('受信箱 未読フィルタトグル - DraftsList', () => {
-  describe('unreadOnly prop の受け取り', () => {
-    it.todo('unreadOnly=true のとき未読フラグを持つ下書きのみ表示される');
-    it.todo('unreadOnly=false のとき全下書きが表示される');
-    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
+    it('unreadOnly=false のときスレッドタブの threads-list-stub に unreadOnly:false が渡される', async () => {
+      localStorage.setItem('inbox:unreadOnly', 'false');
+      renderInbox('/?tab=threads');
+      await screen.findByRole('checkbox', { name: /未読のみ/ });
+      const stub = await screen.findByTestId('threads-list-stub');
+      expect(stub).toHaveAttribute('data-unread-only', 'false');
+    });
   });
 });

--- a/packages/client/src/__tests__/InboxUnreadFilter.test.tsx
+++ b/packages/client/src/__tests__/InboxUnreadFilter.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * テスト対象: 受信箱タブの未読／既読フィルタトグル機能
+ *
+ * 対象ファイル:
+ *   - packages/client/src/pages/InboxPage.tsx （トグルスイッチ UI・localStorage 永続化）
+ *   - packages/client/src/components/Inbox/MentionsList.tsx （unreadOnly prop）
+ *   - packages/client/src/components/Inbox/ThreadsList.tsx  （unreadOnly prop）
+ *   - packages/client/src/components/Inbox/RemindersList.tsx（unreadOnly prop）
+ *   - packages/client/src/components/Inbox/DraftsList.tsx   （unreadOnly prop）
+ *
+ * 戦略:
+ *   - InboxPage のトグル UI は MemoryRouter + vi.mock で Suspense を切り離して検証する
+ *   - localStorage の読み書きは vi.spyOn(Storage.prototype, ...) で検証する
+ *   - 各 List コンポーネントの unreadOnly prop は純粋コンポーネントに直接 prop を渡して検証する
+ *   - 複数コンポーネントにまたがるためファイルを新規作成（AGENTS.md 方針に準拠）
+ */
+
+describe('受信箱 未読フィルタトグル - InboxPage', () => {
+  describe('トグルスイッチの表示', () => {
+    it.todo('メンションタブを開くとタブヘッダー右側にトグルスイッチが表示される');
+    it.todo('スレッドタブを開くとタブヘッダー右側にトグルスイッチが表示される');
+    it.todo('リマインダータブを開くとタブヘッダー右側にトグルスイッチが表示される');
+    it.todo('下書きタブを開くとタブヘッダー右側にトグルスイッチが表示される');
+    it.todo('すべてタブを開くとタブヘッダー右側にトグルスイッチが表示される');
+  });
+
+  describe('トグルスイッチの初期状態', () => {
+    it.todo('localStorage に値がない場合は「未読のみ」がデフォルト状態になる');
+    it.todo('localStorage に unreadOnly=false が保存されている場合は「全件」状態で開く');
+    it.todo('localStorage に unreadOnly=true が保存されている場合は「未読のみ」状態で開く');
+  });
+
+  describe('トグルスイッチの操作', () => {
+    it.todo('「未読のみ」→「全件」に切り替えると localStorage に false が保存される');
+    it.todo('「全件」→「未読のみ」に切り替えると localStorage に true が保存される');
+    it.todo('タブを切り替えてもトグルの状態が維持される');
+  });
+
+  describe('フィルタ状態と API 呼び出しの連携', () => {
+    it.todo(
+      'unreadOnly=true のときメンションタブで api.messages.search が unreadOnly:true で呼ばれる',
+    );
+    it.todo(
+      'unreadOnly=false のときメンションタブで api.messages.search が unreadOnly:false で呼ばれる',
+    );
+    it.todo(
+      'unreadOnly=true のときスレッドタブで api.threads.listSubscribed が unreadOnly:true で呼ばれる',
+    );
+    it.todo(
+      'unreadOnly=false のときスレッドタブで api.threads.listSubscribed が unreadOnly:false で呼ばれる',
+    );
+  });
+});
+
+describe('受信箱 未読フィルタトグル - MentionsList', () => {
+  describe('unreadOnly prop の受け取り', () => {
+    it.todo('unreadOnly=true のとき「未読のみ表示中」などのラベルまたは表示件数が絞られる');
+    it.todo('unreadOnly=false のときすべてのメンションが表示される');
+    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
+  });
+});
+
+describe('受信箱 未読フィルタトグル - ThreadsList', () => {
+  describe('unreadOnly prop の受け取り', () => {
+    it.todo('unreadOnly=true のとき未読フラグを持つスレッドのみ表示される');
+    it.todo('unreadOnly=false のとき全スレッドが表示される');
+    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
+  });
+});
+
+describe('受信箱 未読フィルタトグル - RemindersList', () => {
+  describe('unreadOnly prop の受け取り', () => {
+    it.todo('unreadOnly=true のとき未読のリマインダーのみ表示される');
+    it.todo('unreadOnly=false のとき全リマインダーが表示される');
+    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
+  });
+});
+
+describe('受信箱 未読フィルタトグル - DraftsList', () => {
+  describe('unreadOnly prop の受け取り', () => {
+    it.todo('unreadOnly=true のとき未読フラグを持つ下書きのみ表示される');
+    it.todo('unreadOnly=false のとき全下書きが表示される');
+    it.todo('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）');
+  });
+});

--- a/packages/client/src/__tests__/MentionsList.test.tsx
+++ b/packages/client/src/__tests__/MentionsList.test.tsx
@@ -73,6 +73,39 @@ describe('MentionsList (Step 6b)', () => {
     expect(screen.getAllByTestId('mention-card')).toHaveLength(2);
   });
 
+  // unreadOnly prop の後方互換テスト (Issue #266)
+  describe('unreadOnly prop の受け取り', () => {
+    it('unreadOnly=true のとき渡されたメッセージがすべて表示される（APIフィルタ済み前提）', () => {
+      const messages = [makeSearchResult({ id: 1 }), makeSearchResult({ id: 2 })];
+      render(
+        <MemoryRouter>
+          <MentionsList messages={messages} unreadOnly={true} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('mention-card')).toHaveLength(2);
+    });
+
+    it('unreadOnly=false のときすべてのメンションが表示される', () => {
+      const messages = [makeSearchResult({ id: 1 }), makeSearchResult({ id: 2 })];
+      render(
+        <MemoryRouter>
+          <MentionsList messages={messages} unreadOnly={false} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('mention-card')).toHaveLength(2);
+    });
+
+    it('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）', () => {
+      const messages = [makeSearchResult({ id: 1 })];
+      render(
+        <MemoryRouter>
+          <MentionsList messages={messages} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('mention-card')).toHaveLength(1);
+    });
+  });
+
   // Step 8c: カードクリック遷移 (TODO #15 解消)
   describe('Step 8c: カードクリック遷移', () => {
     beforeEach(() => {

--- a/packages/client/src/__tests__/RemindersList.test.tsx
+++ b/packages/client/src/__tests__/RemindersList.test.tsx
@@ -94,6 +94,53 @@ describe('RemindersList (Step 6a)', () => {
     });
   });
 
+  // unreadOnly prop のテスト (Issue #266)
+  describe('unreadOnly prop の受け取り', () => {
+    it('unreadOnly=true のとき未送信（isSent=false）のリマインダーのみ表示される', () => {
+      const reminders = [
+        makeReminder({ id: 1, isSent: false }),
+        makeReminder({
+          id: 2,
+          isSent: true,
+          message: { ...makeReminder().message!, id: 20, content: '送信済みリマインダー本文' },
+        }),
+      ];
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={reminders} unreadOnly={true} />
+        </MemoryRouter>,
+      );
+      const cards = screen.getAllByTestId('reminder-card');
+      expect(cards).toHaveLength(1);
+    });
+
+    it('unreadOnly=false のとき全リマインダーが表示される', () => {
+      const reminders = [
+        makeReminder({ id: 1, isSent: false }),
+        makeReminder({ id: 2, isSent: true }),
+      ];
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={reminders} unreadOnly={false} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('reminder-card')).toHaveLength(2);
+    });
+
+    it('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）', () => {
+      const reminders = [
+        makeReminder({ id: 1, isSent: false }),
+        makeReminder({ id: 2, isSent: true }),
+      ];
+      render(
+        <MemoryRouter>
+          <RemindersList reminders={reminders} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('reminder-card')).toHaveLength(2);
+    });
+  });
+
   // Step 8c: カードクリック遷移 (TODO #15 解消)
   describe('Step 8c: カードクリック遷移', () => {
     beforeEach(() => {

--- a/packages/client/src/__tests__/ThreadsList.test.tsx
+++ b/packages/client/src/__tests__/ThreadsList.test.tsx
@@ -88,6 +88,56 @@ describe('ThreadsList (Step 6c)', () => {
     expect(cards[2]).toHaveTextContent('三番目');
   });
 
+  // unreadOnly prop のテスト (Issue #266)
+  describe('unreadOnly prop の受け取り', () => {
+    it('unreadOnly=true のとき未読フラグ（unreadCount > 0）を持つスレッドのみ表示される', () => {
+      const threads = [
+        makeThread({
+          rootMessage: makeMessage({ id: 1, content: '未読スレッド' }),
+          unreadCount: 2,
+        }),
+        makeThread({
+          rootMessage: makeMessage({ id: 2, content: '既読スレッド' }),
+          unreadCount: 0,
+        }),
+      ];
+      render(
+        <MemoryRouter>
+          <ThreadsList threads={threads} unreadOnly={true} />
+        </MemoryRouter>,
+      );
+      const cards = screen.getAllByTestId('thread-card');
+      expect(cards).toHaveLength(1);
+      expect(cards[0]).toHaveTextContent('未読スレッド');
+    });
+
+    it('unreadOnly=false のとき全スレッドが表示される', () => {
+      const threads = [
+        makeThread({ rootMessage: makeMessage({ id: 1 }), unreadCount: 2 }),
+        makeThread({ rootMessage: makeMessage({ id: 2 }), unreadCount: 0 }),
+      ];
+      render(
+        <MemoryRouter>
+          <ThreadsList threads={threads} unreadOnly={false} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('thread-card')).toHaveLength(2);
+    });
+
+    it('unreadOnly prop が渡されない場合でも既存の動作が変わらない（後方互換）', () => {
+      const threads = [
+        makeThread({ rootMessage: makeMessage({ id: 1 }), unreadCount: 2 }),
+        makeThread({ rootMessage: makeMessage({ id: 2 }), unreadCount: 0 }),
+      ];
+      render(
+        <MemoryRouter>
+          <ThreadsList threads={threads} />
+        </MemoryRouter>,
+      );
+      expect(screen.getAllByTestId('thread-card')).toHaveLength(2);
+    });
+  });
+
   // Step 8c: カードクリック遷移 (TODO #15 解消)
   describe('Step 8c: カードクリック遷移', () => {
     beforeEach(() => {

--- a/packages/client/src/components/Inbox/DraftsList.tsx
+++ b/packages/client/src/components/Inbox/DraftsList.tsx
@@ -11,6 +11,8 @@ interface Props {
   drafts: Draft[];
   /** 「再開」ボタン押下時に、対象種別を判別して呼ばれる */
   onResume?: (target: DraftResumeTarget) => void;
+  /** 後方互換のために受け付けるが、下書きは未読フラグを持たないため全件表示する。後方互換のため optional。 */
+  unreadOnly?: boolean;
 }
 
 function formatDateTime(iso: string): string {
@@ -39,7 +41,7 @@ function resolveTarget(d: Draft): DraftResumeTarget | null {
  * Promise の解決は親 (InboxPage) の Suspense 側で行い、ここは配列を受け取って描画するだけ。
  * 「再開」クイックアクションは onResume?.(target) で親に通知し、navigation は親に委譲する。
  */
-export default function DraftsList({ drafts, onResume }: Props) {
+export default function DraftsList({ drafts, onResume, unreadOnly: _unreadOnly }: Props) {
   if (drafts.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>

--- a/packages/client/src/components/Inbox/MentionsList.tsx
+++ b/packages/client/src/components/Inbox/MentionsList.tsx
@@ -5,6 +5,8 @@ import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   messages: MessageSearchResult[];
+  /** 未読のみ表示フラグ。MentionsList は API 側でフィルタ済みのため UI 上の挙動は変わらない。後方互換のため optional。 */
+  unreadOnly?: boolean;
 }
 
 function formatDateTime(iso: string): string {
@@ -23,7 +25,7 @@ function formatDateTime(iso: string): string {
  * Promise の解決は親 (InboxPage) の Suspense 側に任せ、ここは配列を描画するだけ。
  * MessageSearchResult が持つ channelName / rootMessageContent も合わせて表示する。
  */
-export default function MentionsList({ messages }: Props) {
+export default function MentionsList({ messages, unreadOnly: _unreadOnly }: Props) {
   const navigate = useNavigate();
 
   if (messages.length === 0) {

--- a/packages/client/src/components/Inbox/RemindersList.tsx
+++ b/packages/client/src/components/Inbox/RemindersList.tsx
@@ -7,6 +7,8 @@ interface Props {
   reminders: Reminder[];
   /** 「完了」ボタン押下時に対象リマインダー id で呼ばれる */
   onComplete?: (id: number) => void;
+  /** true のとき isSent=false のリマインダーのみ表示する。後方互換のため optional（デフォルト false）。 */
+  unreadOnly?: boolean;
 }
 
 function formatDateTime(iso: string): string {
@@ -25,10 +27,12 @@ function formatDateTime(iso: string): string {
  * Promise の解決は親 (InboxPage) の Suspense 側に任せ、ここは配列を描画するだけ。
  * 「完了」クイックアクションは onComplete?.(id) で親に通知し、API 呼び出しは親に委譲。
  */
-export default function RemindersList({ reminders, onComplete }: Props) {
+export default function RemindersList({ reminders, onComplete, unreadOnly = false }: Props) {
   const navigate = useNavigate();
 
-  if (reminders.length === 0) {
+  const displayedReminders = unreadOnly ? reminders.filter((r) => !r.isSent) : reminders;
+
+  if (displayedReminders.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
         リマインダーはありません
@@ -37,7 +41,7 @@ export default function RemindersList({ reminders, onComplete }: Props) {
   }
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {reminders.map((r) => {
+      {displayedReminders.map((r) => {
         // message が存在するときのみカードクリックでジャンプ可能にする
         const canNavigate = r.message != null;
         const goTo = () => {

--- a/packages/client/src/components/Inbox/ThreadsList.tsx
+++ b/packages/client/src/components/Inbox/ThreadsList.tsx
@@ -5,6 +5,8 @@ import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   threads: ThreadSummary[];
+  /** true のとき unreadCount > 0 のスレッドのみ表示する。後方互換のため optional（デフォルト false）。 */
+  unreadOnly?: boolean;
 }
 
 function formatDateTime(iso: string): string {
@@ -23,10 +25,12 @@ function formatDateTime(iso: string): string {
  * Promise の解決は親 (InboxPage) の Suspense 側で行う責務分離パターン。
  * 各カードにはスレッドのルートメッセージ本文・送信元チャンネル名・返信件数・最終返信時刻を表示。
  */
-export default function ThreadsList({ threads }: Props) {
+export default function ThreadsList({ threads, unreadOnly = false }: Props) {
   const navigate = useNavigate();
 
-  if (threads.length === 0) {
+  const displayedThreads = unreadOnly ? threads.filter((t) => t.unreadCount > 0) : threads;
+
+  if (displayedThreads.length === 0) {
     return (
       <Typography variant="body2" color="text.secondary" sx={{ p: 2 }}>
         購読中スレッドはありません
@@ -35,7 +39,7 @@ export default function ThreadsList({ threads }: Props) {
   }
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
-      {threads.map((t) => {
+      {displayedThreads.map((t) => {
         const goTo = () =>
           navigate(`/chat?channel=${t.rootMessage.channelId}#message-${t.rootMessage.id}`);
         return (

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -1,6 +1,14 @@
 import { use, useEffect, useMemo, useState, Suspense } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Box, CircularProgress, Tab, Tabs, Typography } from '@mui/material';
+import {
+  Box,
+  CircularProgress,
+  FormControlLabel,
+  Switch,
+  Tab,
+  Tabs,
+  Typography,
+} from '@mui/material';
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
 import SidebarDmList from '../components/Layout/SidebarDmList';
@@ -30,55 +38,75 @@ function SummarySection({ promise }: { promise: Promise<SummaryData> }) {
 function RemindersSection({
   promise,
   onComplete,
+  unreadOnly,
 }: {
   promise: Promise<{ reminders: Reminder[] }>;
   onComplete?: (id: number) => void;
+  unreadOnly?: boolean;
 }) {
   const { reminders } = use(promise);
-  return <RemindersList reminders={reminders} onComplete={onComplete} />;
+  return <RemindersList reminders={reminders} onComplete={onComplete} unreadOnly={unreadOnly} />;
 }
 
 function DraftsSection({
   promise,
   onResume,
+  unreadOnly,
 }: {
   promise: Promise<{ drafts: Draft[] }>;
   onResume?: (target: DraftResumeTarget) => void;
+  unreadOnly?: boolean;
 }) {
   const { drafts } = use(promise);
-  return <DraftsList drafts={drafts} onResume={onResume} />;
+  return <DraftsList drafts={drafts} onResume={onResume} unreadOnly={unreadOnly} />;
 }
 
-function MentionsSection({ promise }: { promise: Promise<{ messages: MessageSearchResult[] }> }) {
+function MentionsSection({
+  promise,
+  unreadOnly,
+}: {
+  promise: Promise<{ messages: MessageSearchResult[] }>;
+  unreadOnly?: boolean;
+}) {
   const { messages } = use(promise);
-  return <MentionsList messages={messages} />;
+  return <MentionsList messages={messages} unreadOnly={unreadOnly} />;
 }
 
-function ThreadsSection({ promise }: { promise: Promise<{ threads: ThreadSummary[] }> }) {
+function ThreadsSection({
+  promise,
+  unreadOnly,
+}: {
+  promise: Promise<{ threads: ThreadSummary[] }>;
+  unreadOnly?: boolean;
+}) {
   const { threads } = use(promise);
-  return <ThreadsList threads={threads} />;
+  return <ThreadsList threads={threads} unreadOnly={unreadOnly} />;
 }
 
 function AllSection({
   mentionsPromise,
   remindersPromise,
   draftsPromise,
+  unreadOnly,
 }: {
   mentionsPromise: Promise<{ messages: MessageSearchResult[] }>;
   remindersPromise: Promise<{ reminders: Reminder[] }>;
   draftsPromise: Promise<{ drafts: Draft[] }>;
+  unreadOnly?: boolean;
 }) {
   const { messages } = use(mentionsPromise);
   const { reminders } = use(remindersPromise);
   const { drafts } = use(draftsPromise);
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-      <MentionsList messages={messages} />
-      <RemindersList reminders={reminders} />
-      <DraftsList drafts={drafts} />
+      <MentionsList messages={messages} unreadOnly={unreadOnly} />
+      <RemindersList reminders={reminders} unreadOnly={unreadOnly} />
+      <DraftsList drafts={drafts} unreadOnly={unreadOnly} />
     </Box>
   );
 }
+
+const UNREAD_ONLY_KEY = 'inbox:unreadOnly';
 
 /**
  * Focus Inbox 画面 (ルート `/`)。
@@ -106,6 +134,17 @@ export default function InboxPage() {
   const rawTab = searchParams.get('tab');
   const tab: TabKey = isValidTab(rawTab) ? rawTab : 'mentions';
 
+  // 未読フィルタ: localStorage から初期値を読み込む（デフォルト true）
+  const [unreadOnly, setUnreadOnly] = useState<boolean>(() => {
+    const stored = localStorage.getItem(UNREAD_ONLY_KEY);
+    return stored === null ? true : stored === 'true';
+  });
+
+  const handleUnreadOnlyChange = (_: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
+    setUnreadOnly(checked);
+    localStorage.setItem(UNREAD_ONLY_KEY, String(checked));
+  };
+
   // React 19 Concurrent モード対策: promise の安定化には useState の初期化関数（1 度だけ評価）を使う。
   // 3 つの API を Promise.all で 1 本にまとめて Suspense 解決を 1 サイクルで完了させる。
   const [summaryPromise] = useState<Promise<SummaryData>>(() => {
@@ -122,9 +161,10 @@ export default function InboxPage() {
   const mentionsPromise = useMemo(
     () =>
       tab === 'mentions' || tab === 'all'
-        ? api.messages.search('', { mentionedToMe: true, unreadOnly: true })
+        ? api.messages.search('', { mentionedToMe: true, unreadOnly })
         : null,
-    [tab],
+
+    [tab, unreadOnly],
   );
   const threadsPromise = useMemo(
     () => (tab === 'threads' ? api.threads.listSubscribed() : null),
@@ -197,17 +237,35 @@ export default function InboxPage() {
           <SummarySection promise={summaryPromise} />
         </Suspense>
 
-        <Tabs
-          value={tab}
-          onChange={handleTabChange}
-          sx={{ mt: 3, borderBottom: 1, borderColor: 'divider' }}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            mt: 3,
+            borderBottom: 1,
+            borderColor: 'divider',
+          }}
         >
-          <Tab value="mentions" label="メンション" />
-          <Tab value="threads" label="スレッド" />
-          <Tab value="reminders" label="リマインダー" />
-          <Tab value="drafts" label="下書き" />
-          <Tab value="all" label="すべて" />
-        </Tabs>
+          <Tabs value={tab} onChange={handleTabChange} sx={{ flex: 1 }}>
+            <Tab value="mentions" label="メンション" />
+            <Tab value="threads" label="スレッド" />
+            <Tab value="reminders" label="リマインダー" />
+            <Tab value="drafts" label="下書き" />
+            <Tab value="all" label="すべて" />
+          </Tabs>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={unreadOnly}
+                onChange={handleUnreadOnlyChange}
+                size="small"
+                inputProps={{ 'aria-label': '未読のみ' }}
+              />
+            }
+            label="未読のみ"
+            sx={{ ml: 2, mr: 1, whiteSpace: 'nowrap' }}
+          />
+        </Box>
 
         <Box sx={{ mt: 2 }}>
           {tab === 'mentions' && mentionsPromise && (
@@ -218,7 +276,7 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <MentionsSection promise={mentionsPromise} />
+              <MentionsSection promise={mentionsPromise} unreadOnly={unreadOnly} />
             </Suspense>
           )}
           {tab === 'threads' && threadsPromise && (
@@ -229,7 +287,7 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <ThreadsSection promise={threadsPromise} />
+              <ThreadsSection promise={threadsPromise} unreadOnly={unreadOnly} />
             </Suspense>
           )}
           {tab === 'reminders' && remindersPromise && (
@@ -240,7 +298,11 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <RemindersSection promise={remindersPromise} onComplete={handleReminderComplete} />
+              <RemindersSection
+                promise={remindersPromise}
+                onComplete={handleReminderComplete}
+                unreadOnly={unreadOnly}
+              />
             </Suspense>
           )}
           {tab === 'drafts' && draftsPromise && (
@@ -251,7 +313,11 @@ export default function InboxPage() {
                 </Box>
               }
             >
-              <DraftsSection promise={draftsPromise} onResume={handleDraftResume} />
+              <DraftsSection
+                promise={draftsPromise}
+                onResume={handleDraftResume}
+                unreadOnly={unreadOnly}
+              />
             </Suspense>
           )}
           {tab === 'all' && mentionsPromise && remindersPromise && draftsPromise && (
@@ -266,6 +332,7 @@ export default function InboxPage() {
                 mentionsPromise={mentionsPromise}
                 remindersPromise={remindersPromise}
                 draftsPromise={draftsPromise}
+                unreadOnly={unreadOnly}
               />
             </Suspense>
           )}


### PR DESCRIPTION
## 概要
受信箱（InboxPage）の各タブヘッダー右側に「未読のみ」トグルスイッチを追加。設定は `localStorage` に保存し次回起動時も維持する。

## 変更内容
- `InboxPage.tsx`: タブヘッダー右側に MUI `Switch` + `FormControlLabel` によるトグルを追加。`localStorage` (`inbox:unreadOnly`) に永続化。デフォルト `true`（未読のみ）
- `MentionsList.tsx`: `unreadOnly` prop 追加（API側でフィルタ済みのためUI挙動は変わらない）。`api.messages.search` に `unreadOnly` を連携
- `ThreadsList.tsx`: `unreadOnly=true` のとき `unreadCount > 0` のスレッドのみ表示
- `RemindersList.tsx`: `unreadOnly=true` のとき `isSent=false` のリマインダーのみ表示
- `DraftsList.tsx`: `unreadOnly` prop 追加（未読フラグなしのため全件表示）
- `InboxUnreadFilter.test.tsx`: 新規作成（トグルUI・localStorage・API連携の16テスト）
- `MentionsList.test.tsx` / `ThreadsList.test.tsx` / `RemindersList.test.tsx` / `DraftsList.test.tsx`: `unreadOnly` prop の後方互換テストを追記

## 影響範囲
- `packages/client/src/pages/InboxPage.tsx`
- `packages/client/src/components/Inbox/` 配下 4 ファイル
- `packages/client/src/__tests__/` 配下 5 ファイル（既存 4 + 新規 1）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1821 passed、フルテスト時の 8 件タイムアウトは並列実行時のリソース競合で本変更と無関係・単独実行でパス確認済み）
- [x] バックエンドユニットテストがすべてパスする（変更なし）
- [x] ビルドが正常に完了すること（tsc + vite build 成功）

## 関連Issue
Fixes #266

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した