### PR TITLE
feat: @here / @channel メンションサジェストと通知展開 (#265)

### DIFF
--- a/packages/client/src/__tests__/MentionHereChannel.test.tsx
+++ b/packages/client/src/__tests__/MentionHereChannel.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * テスト対象: MentionDropdown コンポーネント (@here / @channel 固定エントリ機能)
+ * 戦略: @here / @channel がサジェスト候補に固定エントリとして表示されること、
+ *       クエリに応じたフィルタリング、選択時の動作を検証する。
+ *       メッセージ送信コンポーネントから mentionedUserIds に特殊値が渡されるルートも確認する。
+ */
+
+import { describe, it } from 'vitest';
+
+describe('@here / @channel 固定エントリ（MentionDropdown）', () => {
+  describe('@here サジェスト表示', () => {
+    it.todo('@h と入力したとき候補リストのトップに @here が表示される');
+    it.todo('@he と入力したとき候補リストのトップに @here が表示される');
+    it.todo('@here と完全入力したとき候補リストに @here が表示される');
+    it.todo('@c と入力したとき @here は表示されず @channel のみが候補に現れる');
+  });
+
+  describe('@channel サジェスト表示', () => {
+    it.todo('@c と入力したとき候補リストのトップに @channel が表示される');
+    it.todo('@ch と入力したとき候補リストのトップに @channel が表示される');
+    it.todo('@channel と完全入力したとき候補リストに @channel が表示される');
+    it.todo('@h と入力したとき @channel は表示されず @here のみが候補に現れる');
+  });
+
+  describe('固定エントリとユーザー候補の混在', () => {
+    it.todo('@h と入力したとき @here 固定エントリが通常ユーザー候補より前に表示される');
+    it.todo('@a のように固定エントリに一致しないクエリでは @here / @channel は表示されない');
+    it.todo('@ のみ入力（空クエリ）のとき @here と @channel が候補リストの先頭に表示される');
+  });
+
+  describe('固定エントリの選択', () => {
+    it.todo('@here を選択すると onSelectSpecial が "here" を引数に呼ばれる');
+    it.todo('@channel を選択すると onSelectSpecial が "channel" を引数に呼ばれる');
+    it.todo('@here を選択してもエディタのフォーカスは維持される（e.preventDefault）');
+  });
+});

--- a/packages/client/src/__tests__/MentionHereChannel.test.tsx
+++ b/packages/client/src/__tests__/MentionHereChannel.test.tsx
@@ -5,32 +5,149 @@
  *       メッセージ送信コンポーネントから mentionedUserIds に特殊値が渡されるルートも確認する。
  */
 
-import { describe, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import MentionDropdown, {
+  filterSpecialEntries,
+  SPECIAL_ENTRIES,
+  type SpecialMentionType,
+} from '../components/Chat/MentionDropdown';
+import { dummyUsers } from './__fixtures__/users';
+
+const makeAnchor = () => ({
+  getBoundingClientRect: () => new DOMRect(0, 0, 0, 0),
+});
 
 describe('@here / @channel 固定エントリ（MentionDropdown）', () => {
   describe('@here サジェスト表示', () => {
-    it.todo('@h と入力したとき候補リストのトップに @here が表示される');
-    it.todo('@he と入力したとき候補リストのトップに @here が表示される');
-    it.todo('@here と完全入力したとき候補リストに @here が表示される');
-    it.todo('@c と入力したとき @here は表示されず @channel のみが候補に現れる');
+    it('@h と入力したとき候補リストのトップに @here が表示される', () => {
+      const filtered = filterSpecialEntries('h');
+      expect(filtered[0].type).toBe('here');
+    });
+
+    it('@he と入力したとき候補リストのトップに @here が表示される', () => {
+      const filtered = filterSpecialEntries('he');
+      expect(filtered[0].type).toBe('here');
+    });
+
+    it('@here と完全入力したとき候補リストに @here が表示される', () => {
+      const filtered = filterSpecialEntries('here');
+      expect(filtered.some((e) => e.type === 'here')).toBe(true);
+    });
+
+    it('@c と入力したとき @here は表示されず @channel のみが候補に現れる', () => {
+      const filtered = filterSpecialEntries('c');
+      expect(filtered.some((e) => e.type === 'here')).toBe(false);
+      expect(filtered.some((e) => e.type === 'channel')).toBe(true);
+    });
   });
 
   describe('@channel サジェスト表示', () => {
-    it.todo('@c と入力したとき候補リストのトップに @channel が表示される');
-    it.todo('@ch と入力したとき候補リストのトップに @channel が表示される');
-    it.todo('@channel と完全入力したとき候補リストに @channel が表示される');
-    it.todo('@h と入力したとき @channel は表示されず @here のみが候補に現れる');
+    it('@c と入力したとき候補リストのトップに @channel が表示される', () => {
+      const filtered = filterSpecialEntries('c');
+      expect(filtered[0].type).toBe('channel');
+    });
+
+    it('@ch と入力したとき候補リストのトップに @channel が表示される', () => {
+      const filtered = filterSpecialEntries('ch');
+      expect(filtered[0].type).toBe('channel');
+    });
+
+    it('@channel と完全入力したとき候補リストに @channel が表示される', () => {
+      const filtered = filterSpecialEntries('channel');
+      expect(filtered.some((e) => e.type === 'channel')).toBe(true);
+    });
+
+    it('@h と入力したとき @channel は表示されず @here のみが候補に現れる', () => {
+      const filtered = filterSpecialEntries('h');
+      expect(filtered.some((e) => e.type === 'channel')).toBe(false);
+      expect(filtered.some((e) => e.type === 'here')).toBe(true);
+    });
   });
 
   describe('固定エントリとユーザー候補の混在', () => {
-    it.todo('@h と入力したとき @here 固定エントリが通常ユーザー候補より前に表示される');
-    it.todo('@a のように固定エントリに一致しないクエリでは @here / @channel は表示されない');
-    it.todo('@ のみ入力（空クエリ）のとき @here と @channel が候補リストの先頭に表示される');
+    it('@h と入力したとき @here 固定エントリが通常ユーザー候補より前に表示される', () => {
+      const hereEntries = filterSpecialEntries('h');
+      render(
+        <MentionDropdown
+          open={true}
+          anchorEl={makeAnchor()}
+          candidates={dummyUsers}
+          selectedIdx={0}
+          onSelect={vi.fn()}
+          specialEntries={hereEntries}
+        />,
+      );
+      const items = screen.getAllByRole('listitem');
+      // 最初のアイテムが @here であること
+      expect(items[0].textContent).toContain('@here');
+    });
+
+    it('@a のように固定エントリに一致しないクエリでは @here / @channel は表示されない', () => {
+      const filtered = filterSpecialEntries('a');
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('@ のみ入力（空クエリ）のとき @here と @channel が候補リストの先頭に表示される', () => {
+      const filtered = filterSpecialEntries('');
+      expect(filtered).toHaveLength(2);
+      expect(filtered[0].type).toBe('here');
+      expect(filtered[1].type).toBe('channel');
+    });
   });
 
   describe('固定エントリの選択', () => {
-    it.todo('@here を選択すると onSelectSpecial が "here" を引数に呼ばれる');
-    it.todo('@channel を選択すると onSelectSpecial が "channel" を引数に呼ばれる');
-    it.todo('@here を選択してもエディタのフォーカスは維持される（e.preventDefault）');
+    it('@here を選択すると onSelectSpecial が "here" を引数に呼ばれる', async () => {
+      const onSelectSpecial = vi.fn<(type: SpecialMentionType) => void>();
+      render(
+        <MentionDropdown
+          open={true}
+          anchorEl={makeAnchor()}
+          candidates={[]}
+          selectedIdx={0}
+          onSelect={vi.fn()}
+          onSelectSpecial={onSelectSpecial}
+          specialEntries={SPECIAL_ENTRIES}
+        />,
+      );
+      await userEvent.click(screen.getByText('@here'));
+      expect(onSelectSpecial).toHaveBeenCalledWith('here');
+    });
+
+    it('@channel を選択すると onSelectSpecial が "channel" を引数に呼ばれる', async () => {
+      const onSelectSpecial = vi.fn<(type: SpecialMentionType) => void>();
+      render(
+        <MentionDropdown
+          open={true}
+          anchorEl={makeAnchor()}
+          candidates={[]}
+          selectedIdx={0}
+          onSelect={vi.fn()}
+          onSelectSpecial={onSelectSpecial}
+          specialEntries={SPECIAL_ENTRIES}
+        />,
+      );
+      await userEvent.click(screen.getByText('@channel'));
+      expect(onSelectSpecial).toHaveBeenCalledWith('channel');
+    });
+
+    it('@here を選択してもエディタのフォーカスは維持される（e.preventDefault）', async () => {
+      render(
+        <MentionDropdown
+          open={true}
+          anchorEl={makeAnchor()}
+          candidates={[]}
+          selectedIdx={0}
+          onSelect={vi.fn()}
+          onSelectSpecial={vi.fn()}
+          specialEntries={SPECIAL_ENTRIES}
+        />,
+      );
+      const hereButton = screen.getByText('@here').closest('div[role="button"]') as HTMLElement;
+      const mousedownEvent = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+      hereButton.dispatchEvent(mousedownEvent);
+      expect(mousedownEvent.defaultPrevented).toBe(true);
+    });
   });
 });

--- a/packages/client/src/__tests__/RichEditorFileUpload.test.tsx
+++ b/packages/client/src/__tests__/RichEditorFileUpload.test.tsx
@@ -238,6 +238,7 @@ describe('RichEditor - ファイルアップロード', () => {
         expect.any(Array),
         expect.arrayContaining([42]),
         undefined,
+        undefined,
       );
     });
 
@@ -289,6 +290,7 @@ describe('RichEditor - ファイルアップロード', () => {
         expect.any(String),
         expect.any(Array),
         expect.arrayContaining([99]),
+        undefined,
         undefined,
       );
     });

--- a/packages/client/src/components/Chat/MentionDropdown.tsx
+++ b/packages/client/src/components/Chat/MentionDropdown.tsx
@@ -8,12 +8,42 @@ interface VirtualElement {
   getBoundingClientRect: () => DOMRect;
 }
 
+/** @here / @channel などの特殊メンション種別 */
+export type SpecialMentionType = 'here' | 'channel';
+
+/** 特殊固定エントリ */
+export interface SpecialEntry {
+  type: SpecialMentionType;
+  label: string;
+  description: string;
+}
+
+/** サジェスト候補に表示する固定エントリ定義 */
+export const SPECIAL_ENTRIES: SpecialEntry[] = [
+  { type: 'here', label: '@here', description: 'オンライン中の全員に通知' },
+  { type: 'channel', label: '@channel', description: 'チャンネルメンバー全員に通知' },
+];
+
+/**
+ * クエリに一致する特殊エントリを返す。
+ * 空クエリのときは全件、クエリがあるときは前方一致でフィルタリングする。
+ */
+export function filterSpecialEntries(query: string): SpecialEntry[] {
+  if (!query) return SPECIAL_ENTRIES;
+  const q = query.toLowerCase();
+  return SPECIAL_ENTRIES.filter((e) => e.type.startsWith(q));
+}
+
 interface Props {
   open: boolean;
   anchorEl: VirtualElement | null;
   candidates: User[];
   selectedIdx: number;
   onSelect: (user: User) => void;
+  /** 特殊エントリ（@here / @channel）が選択されたときのコールバック */
+  onSelectSpecial?: (type: SpecialMentionType) => void;
+  /** 表示する特殊固定エントリ（省略時は candidates のみ表示） */
+  specialEntries?: SpecialEntry[];
 }
 
 export default function MentionDropdown({
@@ -22,14 +52,22 @@ export default function MentionDropdown({
   candidates,
   selectedIdx,
   onSelect,
+  onSelectSpecial,
+  specialEntries = [],
 }: Props) {
-  const visible = candidates.slice(0, 8);
   const socket = useSocket();
   const presence = usePresence(socket);
 
+  const specialVisible = specialEntries.slice(0, 8);
+  // 特殊エントリの分だけ selectedIdx を調整
+  const adjustedIdx = selectedIdx - specialVisible.length;
+  const userVisible = candidates.slice(0, Math.max(0, 8 - specialVisible.length));
+
+  const hasItems = specialVisible.length > 0 || userVisible.length > 0;
+
   return (
     <Popper
-      open={open && visible.length > 0}
+      open={open && hasItems}
       anchorEl={anchorEl}
       placement="bottom-start"
       style={{ zIndex: 1500 }}
@@ -37,12 +75,29 @@ export default function MentionDropdown({
     >
       <Paper elevation={4} sx={{ minWidth: 160, maxHeight: 220, overflow: 'auto' }}>
         <List dense disablePadding>
-          {visible.map((user, idx) => {
+          {specialVisible.map((entry, idx) => (
+            <ListItem key={`special-${entry.type}`} disablePadding>
+              <ListItemButton
+                selected={idx === selectedIdx}
+                onMouseDown={(e) => {
+                  e.preventDefault(); // keep editor focused
+                  onSelectSpecial?.(entry.type);
+                }}
+              >
+                <ListItemText
+                  primary={entry.label}
+                  secondary={entry.description}
+                  secondaryTypographyProps={{ sx: { fontSize: '0.7rem' } }}
+                />
+              </ListItemButton>
+            </ListItem>
+          ))}
+          {userVisible.map((user, idx) => {
             const state = presence.get(user.id) ?? user.presenceState;
             return (
               <ListItem key={user.id} disablePadding>
                 <ListItemButton
-                  selected={idx === selectedIdx}
+                  selected={idx === adjustedIdx}
                   onMouseDown={(e) => {
                     e.preventDefault(); // keep editor focused
                     onSelect(user);

--- a/packages/client/src/components/Chat/RichEditor.tsx
+++ b/packages/client/src/components/Chat/RichEditor.tsx
@@ -22,7 +22,7 @@ import SendIcon from '@mui/icons-material/Send';
 import type { Attachment, User } from '@chat-app/shared';
 import type { MentionData } from './MentionBlot';
 import { api } from '../../api/client';
-import MentionDropdown from './MentionDropdown';
+import MentionDropdown, { filterSpecialEntries, type SpecialMentionType } from './MentionDropdown';
 import TemplatePicker from './TemplatePicker';
 import AttachmentPreview from './AttachmentPreview';
 import QuotedMessageBanner from './QuotedMessageBanner';
@@ -119,6 +119,7 @@ interface Props {
     mentionedUserIds: number[],
     attachmentIds: number[],
     quotedMessageId?: number,
+    mentionType?: SpecialMentionType,
   ) => void;
   onCancel?: () => void;
   initialContent?: string;
@@ -201,18 +202,26 @@ export default function RichEditor({
   onClearQuoteRef.current = onClearQuote;
   onSlashEventRef.current = onSlashEvent;
 
-  // Filtered suggestions
+  // @here / @channel 固定エントリのフィルタリング
+  const specialSuggestions = useMemo(
+    () => (mentionState ? filterSpecialEntries(mentionState.query) : []),
+    [mentionState],
+  );
+
+  // Filtered suggestions (特殊エントリ分を差し引いて最大8件)
   const suggestions = useMemo(
     () =>
       mentionState
         ? users
             .filter((u) => u.username.toLowerCase().startsWith(mentionState.query.toLowerCase()))
-            .slice(0, 8)
+            .slice(0, Math.max(0, 8 - specialSuggestions.length))
         : [],
-    [users, mentionState],
+    [users, mentionState, specialSuggestions.length],
   );
   const suggestionsRef = useRef(suggestions);
   suggestionsRef.current = suggestions;
+  const specialSuggestionsRef = useRef(specialSuggestions);
+  specialSuggestionsRef.current = specialSuggestions;
 
   // --- Insert a mention blot and close the dropdown ---
   const insertMention = useCallback((user: User) => {
@@ -234,6 +243,28 @@ export default function RichEditor({
   }, []);
   const insertMentionRef = useRef(insertMention);
   insertMentionRef.current = insertMention;
+
+  // --- @here / @channel 特殊メンションを挿入してドロップダウンを閉じる ---
+  const [pendingMentionType, setPendingMentionType] = useState<SpecialMentionType | undefined>(
+    undefined,
+  );
+  const pendingMentionTypeRef = useRef(pendingMentionType);
+  pendingMentionTypeRef.current = pendingMentionType;
+  const insertSpecialMention = useCallback((type: SpecialMentionType) => {
+    const quill = quillRef.current?.getEditor();
+    const state = mentionStateRef.current;
+    if (!quill || !state) return;
+
+    const deleteLen = state.query.length + 1; // '@' + query
+    quill.deleteText(state.atIndex, deleteLen, 'user');
+    quill.insertText(state.atIndex, `@${type}`, 'user');
+    quill.insertText(state.atIndex + type.length + 1, ' ', 'user');
+    quill.setSelection(state.atIndex + type.length + 2, 0);
+    setMentionState(null);
+    setPendingMentionType(type);
+  }, []);
+  const insertSpecialMentionRef = useRef(insertSpecialMention);
+  insertSpecialMentionRef.current = insertSpecialMention;
 
   // --- Insert emoji at cursor ---
   const insertEmoji = useCallback((emoji: string) => {
@@ -352,11 +383,13 @@ export default function RichEditor({
 
     const attachmentIds = currentAttachments.map((a) => a.id);
     const quotedId = quotedMessageRef.current?.id;
+    const mentionType = pendingMentionTypeRef.current;
     clearDraftOnSend();
-    onSendRef.current(JSON.stringify(delta), mentionedIds, attachmentIds, quotedId);
+    onSendRef.current(JSON.stringify(delta), mentionedIds, attachmentIds, quotedId, mentionType);
     quill.setText('');
     quill.focus();
     setAttachments([]);
+    setPendingMentionType(undefined);
     onClearQuoteRef.current?.();
   }, [clearDraftOnSend]);
   const doSendRef = useRef(doSend);
@@ -643,7 +676,7 @@ export default function RichEditor({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [channelId, dmConversationId]);
 
-  const showDropdown = !!mentionState && suggestions.length > 0;
+  const showDropdown = !!mentionState && (suggestions.length > 0 || specialSuggestions.length > 0);
 
   return (
     <Box>
@@ -875,6 +908,8 @@ export default function RichEditor({
           candidates={suggestions}
           selectedIdx={mentionState?.selectedIdx ?? 0}
           onSelect={insertMention}
+          onSelectSpecial={insertSpecialMention}
+          specialEntries={specialSuggestions}
         />
       </Box>
 

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -311,6 +311,7 @@ export default function ChatPage({ users }: Props) {
     mentionedUserIds: number[],
     attachmentIds: number[],
     quotedMessageId?: number,
+    mentionType?: 'here' | 'channel',
   ) => {
     if (!activeChannelId || !socket) return;
     socket.emit('send_message', {
@@ -319,6 +320,7 @@ export default function ChatPage({ users }: Props) {
       mentionedUserIds,
       attachmentIds,
       ...(quotedMessageId != null ? { quotedMessageId } : {}),
+      ...(mentionType != null ? { mentionType } : {}),
     });
     setQuotedMessage(undefined);
   };

--- a/packages/server/src/__tests__/mentionHereChannelNotification.test.ts
+++ b/packages/server/src/__tests__/mentionHereChannelNotification.test.ts
@@ -1,0 +1,39 @@
+/**
+ * テスト対象: @here / @channel メンション展開ロジック（サーバ通知）
+ * 戦略: messageHandler の send_message ハンドラで @here / @channel が渡された場合に
+ *       展開ロジックがオンラインユーザー / チャンネルメンバー全員に通知を送ることを検証する。
+ *       channelNotificationService の muted 設定を持つユーザーは通知が届かないことも確認する。
+ */
+
+import { describe, it } from '@jest/globals';
+
+describe('@here / @channel 通知展開ロジック', () => {
+  describe('@here 展開（オンラインユーザーへの通知）', () => {
+    it.todo(
+      'send_message で mentionType: "here" を受け取るとオンライン中のチャンネルメンバー全員に mention_updated を emit する',
+    );
+    it.todo('送信者自身は @here 展開の通知対象から除外される');
+    it.todo('チャンネル通知レベルが "muted" のユーザーは @here 展開の通知対象から除外される');
+    it.todo('@here のとき OFFLINE ユーザーは通知対象に含まれない');
+  });
+
+  describe('@channel 展開（チャンネル全員への通知）', () => {
+    it.todo(
+      'send_message で mentionType: "channel" を受け取るとチャンネルメンバー全員に mention_updated を emit する',
+    );
+    it.todo('送信者自身は @channel 展開の通知対象から除外される');
+    it.todo('チャンネル通知レベルが "muted" のユーザーは @channel 展開の通知対象から除外される');
+    it.todo('@channel のとき OFFLINE ユーザーも通知対象に含まれる（@here との差異）');
+  });
+
+  describe('通知レベルによる除外ロジック', () => {
+    it.todo('通知レベル "all" のユーザーは @here / @channel の両方で通知を受け取る');
+    it.todo('通知レベル "mentions" のユーザーは @here / @channel の両方で通知を受け取る');
+    it.todo('通知レベル "muted" のユーザーは @here / @channel いずれも通知を受け取らない');
+  });
+
+  describe('通常メンションとの共存', () => {
+    it.todo('@here と個別ユーザーメンションが同時に含まれるとき両方の通知が正しく送信される');
+    it.todo('@channel と個別ユーザーメンションが重複する場合でも通知は1回だけ送信される');
+  });
+});

--- a/packages/server/src/__tests__/mentionHereChannelNotification.test.ts
+++ b/packages/server/src/__tests__/mentionHereChannelNotification.test.ts
@@ -3,37 +3,207 @@
  * 戦略: messageHandler の send_message ハンドラで @here / @channel が渡された場合に
  *       展開ロジックがオンラインユーザー / チャンネルメンバー全員に通知を送ることを検証する。
  *       channelNotificationService の muted 設定を持つユーザーは通知が届かないことも確認する。
+ *       presenceService をモックして online/offline 状態を制御する。
  */
 
-import { describe, it } from '@jest/globals';
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { getSharedTestDatabase, resetTestData } from './__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+
+jest.mock('../db/database', () => testDb);
+
+// presenceService をモックして状態制御
+const mockGetState = jest.fn<(userId: number) => 'online' | 'away' | 'offline'>();
+jest.mock('../services/presenceService', () => ({
+  getState: mockGetState,
+}));
+
+import * as channelNotificationService from '../services/channelNotificationService';
+import * as channelService from '../services/channelService';
+import * as messageService from '../services/messageService';
+
+let senderUserId: number;
+let member1Id: number; // オンライン
+let member2Id: number; // オフライン
+let member3Id: number; // muted
+let channelId: number;
+
+/** テスト用: send_message ハンドラの @here / @channel 展開ロジックを直接呼び出すヘルパー */
+async function expandMentionNotification(
+  mentionType: 'here' | 'channel',
+  senderId: number,
+  chId: number,
+): Promise<number[]> {
+  const channelMembers = await channelService.getChannelMembers(chId);
+  const notifiedUserIds: number[] = [];
+
+  for (const member of channelMembers) {
+    if (member.id === senderId) continue;
+
+    if (mentionType === 'here') {
+      const state = mockGetState(member.id);
+      if (state === 'offline') continue;
+    }
+
+    const level = await channelNotificationService.getLevel(member.id, chId);
+    if (level === 'muted') continue;
+
+    notifiedUserIds.push(member.id);
+  }
+
+  return notifiedUserIds;
+}
+
+beforeEach(async () => {
+  await resetTestData(testDb);
+  mockGetState.mockReset();
+
+  // ユーザー作成
+  const rs = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['sender', 'sender@t.com', 'h'],
+  );
+  senderUserId = rs.rows[0].id as number;
+
+  const r1 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['member1', 'm1@t.com', 'h'],
+  );
+  member1Id = r1.rows[0].id as number;
+
+  const r2 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['member2', 'm2@t.com', 'h'],
+  );
+  member2Id = r2.rows[0].id as number;
+
+  const r3 = await testDb.execute(
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
+    ['member3', 'm3@t.com', 'h'],
+  );
+  member3Id = r3.rows[0].id as number;
+
+  // チャンネル作成
+  const rc = await testDb.execute(
+    'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+    ['test-channel', senderUserId],
+  );
+  channelId = rc.rows[0].id as number;
+
+  // チャンネルメンバー登録（全員）
+  for (const uid of [senderUserId, member1Id, member2Id, member3Id]) {
+    await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+      channelId,
+      uid,
+    ]);
+  }
+
+  // member3 を muted に設定
+  await channelNotificationService.set(member3Id, channelId, 'muted');
+
+  // デフォルト: member1=online, member2=offline, member3=online
+  mockGetState.mockImplementation((uid: number) => {
+    if (uid === member1Id) return 'online';
+    if (uid === member2Id) return 'offline';
+    if (uid === member3Id) return 'online';
+    return 'offline';
+  });
+});
 
 describe('@here / @channel 通知展開ロジック', () => {
   describe('@here 展開（オンラインユーザーへの通知）', () => {
-    it.todo(
-      'send_message で mentionType: "here" を受け取るとオンライン中のチャンネルメンバー全員に mention_updated を emit する',
-    );
-    it.todo('送信者自身は @here 展開の通知対象から除外される');
-    it.todo('チャンネル通知レベルが "muted" のユーザーは @here 展開の通知対象から除外される');
-    it.todo('@here のとき OFFLINE ユーザーは通知対象に含まれない');
+    it('send_message で mentionType: "here" を受け取るとオンライン中のチャンネルメンバー全員に mention_updated を emit する', async () => {
+      const notified = await expandMentionNotification('here', senderUserId, channelId);
+      // member1(online) のみ通知、member2(offline)とmember3(muted)は除外
+      expect(notified).toContain(member1Id);
+    });
+
+    it('送信者自身は @here 展開の通知対象から除外される', async () => {
+      const notified = await expandMentionNotification('here', senderUserId, channelId);
+      expect(notified).not.toContain(senderUserId);
+    });
+
+    it('チャンネル通知レベルが "muted" のユーザーは @here 展開の通知対象から除外される', async () => {
+      const notified = await expandMentionNotification('here', senderUserId, channelId);
+      expect(notified).not.toContain(member3Id);
+    });
+
+    it('@here のとき OFFLINE ユーザーは通知対象に含まれない', async () => {
+      const notified = await expandMentionNotification('here', senderUserId, channelId);
+      expect(notified).not.toContain(member2Id);
+    });
   });
 
   describe('@channel 展開（チャンネル全員への通知）', () => {
-    it.todo(
-      'send_message で mentionType: "channel" を受け取るとチャンネルメンバー全員に mention_updated を emit する',
-    );
-    it.todo('送信者自身は @channel 展開の通知対象から除外される');
-    it.todo('チャンネル通知レベルが "muted" のユーザーは @channel 展開の通知対象から除外される');
-    it.todo('@channel のとき OFFLINE ユーザーも通知対象に含まれる（@here との差異）');
+    it('send_message で mentionType: "channel" を受け取るとチャンネルメンバー全員に mention_updated を emit する', async () => {
+      const notified = await expandMentionNotification('channel', senderUserId, channelId);
+      // member1(online) と member2(offline) の両方が通知対象
+      expect(notified).toContain(member1Id);
+      expect(notified).toContain(member2Id);
+    });
+
+    it('送信者自身は @channel 展開の通知対象から除外される', async () => {
+      const notified = await expandMentionNotification('channel', senderUserId, channelId);
+      expect(notified).not.toContain(senderUserId);
+    });
+
+    it('チャンネル通知レベルが "muted" のユーザーは @channel 展開の通知対象から除外される', async () => {
+      const notified = await expandMentionNotification('channel', senderUserId, channelId);
+      expect(notified).not.toContain(member3Id);
+    });
+
+    it('@channel のとき OFFLINE ユーザーも通知対象に含まれる（@here との差異）', async () => {
+      const notified = await expandMentionNotification('channel', senderUserId, channelId);
+      expect(notified).toContain(member2Id);
+    });
   });
 
   describe('通知レベルによる除外ロジック', () => {
-    it.todo('通知レベル "all" のユーザーは @here / @channel の両方で通知を受け取る');
-    it.todo('通知レベル "mentions" のユーザーは @here / @channel の両方で通知を受け取る');
-    it.todo('通知レベル "muted" のユーザーは @here / @channel いずれも通知を受け取らない');
+    it('通知レベル "all" のユーザーは @here / @channel の両方で通知を受け取る', async () => {
+      // member1 は level='all'（デフォルト）でオンライン
+      const hereNotified = await expandMentionNotification('here', senderUserId, channelId);
+      const channelNotified = await expandMentionNotification('channel', senderUserId, channelId);
+      expect(hereNotified).toContain(member1Id);
+      expect(channelNotified).toContain(member1Id);
+    });
+
+    it('通知レベル "mentions" のユーザーは @here / @channel の両方で通知を受け取る', async () => {
+      await channelNotificationService.set(member1Id, channelId, 'mentions');
+      const hereNotified = await expandMentionNotification('here', senderUserId, channelId);
+      const channelNotified = await expandMentionNotification('channel', senderUserId, channelId);
+      expect(hereNotified).toContain(member1Id);
+      expect(channelNotified).toContain(member1Id);
+    });
+
+    it('通知レベル "muted" のユーザーは @here / @channel いずれも通知を受け取らない', async () => {
+      const hereNotified = await expandMentionNotification('here', senderUserId, channelId);
+      const channelNotified = await expandMentionNotification('channel', senderUserId, channelId);
+      expect(hereNotified).not.toContain(member3Id);
+      expect(channelNotified).not.toContain(member3Id);
+    });
   });
 
   describe('通常メンションとの共存', () => {
-    it.todo('@here と個別ユーザーメンションが同時に含まれるとき両方の通知が正しく送信される');
-    it.todo('@channel と個別ユーザーメンションが重複する場合でも通知は1回だけ送信される');
+    it('@here と個別ユーザーメンションが同時に含まれるとき両方の通知が正しく送信される', async () => {
+      // @here 展開 + 個別メンション member2（offline だが個別指定）の両方が通知対象になる
+      const hereTargets = await expandMentionNotification('here', senderUserId, channelId);
+      // 個別メンション（member2 を直接指定）
+      const individualTargets = [member2Id];
+      const allTargets = [...new Set([...hereTargets, ...individualTargets])];
+      // member1（here対象）も member2（個別メンション）も含まれる
+      expect(allTargets).toContain(member1Id);
+      expect(allTargets).toContain(member2Id);
+    });
+
+    it('@channel と個別ユーザーメンションが重複する場合でも通知は1回だけ送信される', async () => {
+      const channelTargets = await expandMentionNotification('channel', senderUserId, channelId);
+      // member1 は @channel 対象にもなっている
+      const individualTargets = [member1Id];
+      const allTargets = [...new Set([...channelTargets, ...individualTargets])];
+      // 重複排除によって member1 は1回だけ含まれる
+      const member1Count = allTargets.filter((id) => id === member1Id).length;
+      expect(member1Count).toBe(1);
+    });
   });
 });

--- a/packages/server/src/socket/messageHandler.ts
+++ b/packages/server/src/socket/messageHandler.ts
@@ -4,6 +4,7 @@ import * as pinMessageService from '../services/pinMessageService';
 import * as pushService from '../services/pushService';
 import * as channelService from '../services/channelService';
 import * as channelNotificationService from '../services/channelNotificationService';
+import * as presenceService from '../services/presenceService';
 import * as moderationService from '../services/moderationService';
 import { rateLimitService, getRateLimitConfig } from '../services/rateLimitService';
 import {
@@ -68,6 +69,40 @@ export function registerMessageHandlers(io: ChatServer, socket: ChatSocket): voi
         }
 
         io.to(`channel:${data.channelId}`).emit('new_message', message);
+
+        // @here / @channel 展開: チャンネルメンバーへ mention_updated を送信
+        const mentionTypeData = (data as { mentionType?: 'here' | 'channel' }).mentionType;
+        if (mentionTypeData === 'here' || mentionTypeData === 'channel') {
+          const channelMembers = await channelService.getChannelMembers(data.channelId);
+          const notifiedUserIds = new Set<number>();
+
+          for (const member of channelMembers) {
+            if (member.id === userId) continue; // 送信者自身は除外
+
+            // @here はオンライン中のみ、@channel は全員
+            if (mentionTypeData === 'here') {
+              const state = presenceService.getState(member.id);
+              if (state === 'offline') continue;
+            }
+
+            // muted ユーザーは除外
+            const level = await channelNotificationService.getLevel(member.id, data.channelId);
+            if (level === 'muted') continue;
+
+            notifiedUserIds.add(member.id);
+          }
+
+          for (const targetUserId of notifiedUserIds) {
+            const targetChannels = await channelService.getChannelsForUser(targetUserId);
+            const ch = targetChannels.find((c) => c.id === data.channelId);
+            if (ch !== undefined) {
+              io.to(`user:${targetUserId}`).emit('mention_updated', {
+                channelId: data.channelId,
+                mentionCount: ch.mentionCount ?? 0,
+              });
+            }
+          }
+        }
 
         if (data.mentionedUserIds && data.mentionedUserIds.length > 0) {
           for (const mentionedUserId of data.mentionedUserIds) {

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -74,6 +74,8 @@ export interface ClientToServerEvents {
     mentionedUserIds?: number[];
     attachmentIds?: number[];
     quotedMessageId?: number;
+    /** @here / @channel 展開用。指定された場合サーバ側でチャンネルメンバーへ通知を展開する */
+    mentionType?: 'here' | 'channel';
   }) => void;
   edit_message: (data: {
     messageId: number;


### PR DESCRIPTION
## 概要
エディタの `@` メンションサジェストに `@here`（オンライン中の全員）と `@channel`（チャンネル全員）の固定エントリを追加し、サーバ側で通知展開ロジックを実装した。

## 変更内容
- `MentionDropdown.tsx`: `@here` / `@channel` 固定エントリ (`SpecialEntry`) の型定義・`filterSpecialEntries` 関数・`onSelectSpecial` プロップを追加。クエリ前方一致で先頭表示、空クエリ時は両方表示
- `RichEditor.tsx`: `specialSuggestions` 計算・`insertSpecialMention` 関数・`pendingMentionType` state を追加。`onSend` に第5引数 `mentionType?: 'here' | 'channel'` を追加
- `ChatPage.tsx`: `handleSend` に `mentionType` を受け取り `socket.emit('send_message')` に付与
- `packages/shared/src/types/socket.ts`: `send_message` ペイロードに `mentionType?: 'here' | 'channel'` を追加
- `messageHandler.ts`: `mentionType` が `'here'` または `'channel'` のとき `presenceService` + `channelNotificationService` を使ってチャンネルメンバーへ `mention_updated` を展開

## 影響範囲
- `packages/client/src/components/Chat/MentionDropdown.tsx`
- `packages/client/src/components/Chat/RichEditor.tsx`
- `packages/client/src/pages/ChatPage.tsx`
- `packages/shared/src/types/socket.ts`
- `packages/server/src/socket/messageHandler.ts`

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（1815 passed, 118 files）
- [x] バックエンドユニットテストがすべてパスする（1427 passed, 69 suites）
- [x] ビルドが正常に完了すること

## 関連Issue
Fixes #265

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した