### PR TITLE
feat: ブックマークから元メッセージへのジャンプ (#269)

### DIFF
--- a/packages/client/src/__tests__/BookmarkPageJump.test.tsx
+++ b/packages/client/src/__tests__/BookmarkPageJump.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * テスト対象: BookmarkPage のジャンプ機能（元メッセージへの遷移とハイライト）
+ * 戦略:
+ *   - ネットワーク通信は vi.mock('../api/client') で差し替える
+ *   - useNavigate をモックして遷移先 URL を検証する
+ *   - チャンネルメッセージと DM メッセージの両遷移パスを検証する
+ *   - ChatPage の既存 highlightMessageId 実装との連携は ChatPagePermalink.test.tsx で担保済みのため、
+ *     ここでは BookmarkPage 側の遷移 URL 生成ロジックのみを検証する
+ */
+
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import BookmarkPage, { resetBookmarksCache } from '../pages/BookmarkPage';
+import type { Bookmark } from '@chat-app/shared';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock('../api/client', () => ({
+  api: {
+    bookmarks: {
+      list: vi.fn(),
+      add: vi.fn(),
+      remove: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('../contexts/DensityContext', () => ({
+  useDensity: () => ({ density: 'cozy', setDensity: vi.fn() }),
+}));
+
+vi.mock('../contexts/SocketContext', () => ({
+  useSocket: () => ({ emit: vi.fn(), on: vi.fn(), off: vi.fn() }),
+}));
+
+vi.mock('../components/Chat/RichEditor', () => ({
+  default: ({ onCancel }: { onCancel: () => void }) => (
+    <div data-testid="rich-editor">
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}));
+
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="app-layout-stub">{children}</div>
+  ),
+}));
+
+import { api } from '../api/client';
+const mockApi = api as unknown as {
+  bookmarks: {
+    list: ReturnType<typeof vi.fn>;
+    add: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+};
+
+const makeBookmark = (overrides: Partial<Bookmark> = {}): Bookmark => ({
+  id: 1,
+  userId: 1,
+  messageId: 10,
+  bookmarkedAt: '2024-06-01T12:00:00Z',
+  channelName: 'general',
+  message: {
+    id: 10,
+    channelId: 1,
+    userId: 1,
+    username: 'alice',
+    avatarUrl: null,
+    content: 'Hello world',
+    isEdited: false,
+    isDeleted: false,
+    createdAt: '2024-06-01T11:00:00Z',
+    updatedAt: '2024-06-01T11:00:00Z',
+    mentions: [],
+    reactions: [],
+    parentMessageId: null,
+    rootMessageId: null,
+    replyCount: 0,
+    quotedMessageId: null,
+    quotedMessage: null,
+  },
+  ...overrides,
+});
+
+async function renderBookmarkPage() {
+  await act(async () => {
+    render(
+      <MemoryRouter>
+        <BookmarkPage />
+      </MemoryRouter>,
+    );
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetBookmarksCache();
+});
+
+describe('BookmarkPage ジャンプ機能', () => {
+  describe('チャンネルメッセージへのジャンプ', () => {
+    it.todo(
+      'ブックマーク行をクリックすると /chat?channel={channelId}&message={messageId} へ遷移する',
+    );
+
+    it.todo('channelId が null のブックマーク行をクリックしても遷移しない');
+  });
+
+  describe('DM メッセージへのジャンプ', () => {
+    it.todo('DM のブックマーク行をクリックすると /dm/{dmUserId}?message={messageId} へ遷移する');
+
+    it.todo('dmUserId が取得できない DM ブックマークをクリックしても遷移しない');
+  });
+
+  describe('遷移先でのハイライト', () => {
+    it.todo(
+      'チャンネルジャンプ時に message パラメータが URL に含まれる（ChatPage の highlightMessageId 連携前提）',
+    );
+  });
+
+  describe('クリック操作と解除ボタンの競合', () => {
+    it.todo('解除ボタンのクリックではジャンプが発火しない（stopPropagation が正しく機能する）');
+  });
+});

--- a/packages/client/src/__tests__/BookmarkPageJump.test.tsx
+++ b/packages/client/src/__tests__/BookmarkPageJump.test.tsx
@@ -107,26 +107,68 @@ beforeEach(() => {
 
 describe('BookmarkPage ジャンプ機能', () => {
   describe('チャンネルメッセージへのジャンプ', () => {
-    it.todo(
-      'ブックマーク行をクリックすると /chat?channel={channelId}&message={messageId} へ遷移する',
-    );
+    it('ブックマーク行をクリックすると /chat?channel={channelId}&message={messageId} へ遷移する', async () => {
+      mockApi.bookmarks.list.mockResolvedValue({ bookmarks: [makeBookmark()] });
+      await renderBookmarkPage();
+      await userEvent.click(screen.getByText('Hello world'));
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=1&message=10');
+    });
 
-    it.todo('channelId が null のブックマーク行をクリックしても遷移しない');
+    it('channelId が null のブックマーク行をクリックしても遷移しない', async () => {
+      const bookmarkWithoutChannel = makeBookmark({
+        message: {
+          id: 10,
+          channelId: null as unknown as number,
+          userId: 1,
+          username: 'alice',
+          avatarUrl: null,
+          content: 'Hello world',
+          isEdited: false,
+          isDeleted: false,
+          createdAt: '2024-06-01T11:00:00Z',
+          updatedAt: '2024-06-01T11:00:00Z',
+          mentions: [],
+          reactions: [],
+          parentMessageId: null,
+          rootMessageId: null,
+          replyCount: 0,
+          quotedMessageId: null,
+          quotedMessage: null,
+        },
+      });
+      mockApi.bookmarks.list.mockResolvedValue({ bookmarks: [bookmarkWithoutChannel] });
+      await renderBookmarkPage();
+      await userEvent.click(screen.getByText('Hello world'));
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 
   describe('DM メッセージへのジャンプ', () => {
+    // Bookmark 型に DM 識別情報（dmUserId 等）が存在しないため、DM ジャンプは未実装
     it.todo('DM のブックマーク行をクリックすると /dm/{dmUserId}?message={messageId} へ遷移する');
 
     it.todo('dmUserId が取得できない DM ブックマークをクリックしても遷移しない');
   });
 
   describe('遷移先でのハイライト', () => {
-    it.todo(
-      'チャンネルジャンプ時に message パラメータが URL に含まれる（ChatPage の highlightMessageId 連携前提）',
-    );
+    it('チャンネルジャンプ時に message パラメータが URL に含まれる（ChatPage の highlightMessageId 連携前提）', async () => {
+      mockApi.bookmarks.list.mockResolvedValue({ bookmarks: [makeBookmark()] });
+      await renderBookmarkPage();
+      await userEvent.click(screen.getByText('Hello world'));
+      // navigate の第1引数に &message={messageId} が含まれることを確認
+      const calledUrl = mockNavigate.mock.calls[0][0] as string;
+      expect(calledUrl).toContain('message=10');
+    });
   });
 
   describe('クリック操作と解除ボタンの競合', () => {
-    it.todo('解除ボタンのクリックではジャンプが発火しない（stopPropagation が正しく機能する）');
+    it('解除ボタンのクリックではジャンプが発火しない（stopPropagation が正しく機能する）', async () => {
+      mockApi.bookmarks.list.mockResolvedValue({ bookmarks: [makeBookmark()] });
+      mockApi.bookmarks.remove.mockResolvedValue(undefined);
+      await renderBookmarkPage();
+      await userEvent.click(screen.getByRole('button', { name: 'ブックマーク解除' }));
+      // 解除ボタンをクリックしても navigate は呼ばれない
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## 概要

ブックマークページの行クリックで、対象メッセージのチャンネルへ遷移し、当該メッセージをハイライト表示する機能を実装した。

## 変更内容

- `BookmarkPage.tsx`: `handleJump` 実装（行クリック → `/chat?channel={channelId}&message={messageId}` へ遷移）
- 解除ボタンに `e.stopPropagation()` を追加し、行クリックとの競合を防止
- `BookmarkPageJump.test.tsx`: ジャンプ機能のテスト実装（4件パス・2件todo）
  - チャンネルジャンプURL生成の検証
  - channelId null 時は遷移しないことの検証
  - message パラメータが URL に含まれることの検証（ChatPage highlight 連携）
  - 解除ボタンの stopPropagation 検証

## 影響範囲

- `packages/client/src/pages/BookmarkPage.tsx`
- `packages/client/src/__tests__/BookmarkPageJump.test.tsx`

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（1904件パス）
- [x] バックエンドユニットテストがすべてパスする（変更なし）
- [x] ビルドが正常に完了すること

## 関連Issue

Fixes #269

### 残課題

- Bookmark 型に DM 識別情報（dmUserId 等）が存在しないため、DM メッセージへのジャンプは未実装
- DM 対応は別 Issue で Bookmark 型拡張と合わせて実装予定
- 該当テストは `it.todo` で残置（`BookmarkPageJump.test.tsx` の DMメッセージへのジャンプ describe 内）

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した