### PR TITLE
feat: Rail アイコンの常時ラベル表示モード

### DIFF
--- a/packages/client/src/__tests__/RailLabelMode.test.tsx
+++ b/packages/client/src/__tests__/RailLabelMode.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * テスト対象: Rail コンポーネントの「アイコン + ラベル」常時表示モード (Issue #316)
+ * 戦略:
+ *   - 既存の Rail.test.tsx を変更せず、新機能の追加テストのみをこのファイルに集約する
+ *   - 「アイコンのみ」モードと「アイコン + ラベル」モードの切り替えを検証する
+ *   - localStorage への永続化（キー: rail.labelMode）を検証する
+ *   - 既存の折り畳み（collapsed）モードとの共存を確認する
+ *   - MemoryRouter でラップして react-router の NavLink を動作させる
+ *   - AuthContext・useDmUnreadCount・useMentionUnreadCount・SidebarFooter はモックする
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Rail from '../components/Layout/Rail';
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+vi.mock('../hooks/useDmUnreadCount', () => ({
+  useDmUnreadCount: () => 0,
+}));
+
+vi.mock('../hooks/useMentionUnreadCount', () => ({
+  useMentionUnreadCount: () => 0,
+}));
+
+vi.mock('../components/Layout/SidebarFooter', () => ({
+  default: () => (
+    <div data-testid="sidebar-footer-stub">
+      <button aria-label="ステータスを設定">stub-status</button>
+      <button aria-label="ダークモードに切り替える">stub-theme</button>
+      <button aria-label="プロフィール設定">stub-profile</button>
+      <button aria-label="ログアウト">stub-logout</button>
+    </div>
+  ),
+}));
+
+const mockUser = {
+  id: 1,
+  username: 'alice',
+  email: 'alice@example.com',
+  displayName: null as string | null,
+  role: 'user' as 'user' | 'admin',
+  location: null,
+  avatarUrl: null,
+  createdAt: '2024-01-01T00:00:00Z',
+};
+
+beforeEach(() => {
+  mockUser.role = 'user';
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+function renderRail(initialPath = '/') {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Rail />
+    </MemoryRouter>,
+  );
+}
+
+describe('Rail ラベル表示モード (Issue #316)', () => {
+  describe('表示モード切替ボタン', () => {
+    it.todo('「アイコン + ラベル」モードに切り替えるボタンが存在する');
+    it.todo('「アイコンのみ」モードに切り替えるボタンが存在する');
+    it.todo('現在のモードに応じてボタンのラベルが変わる');
+  });
+
+  describe('アイコンのみモード（デフォルト）', () => {
+    it.todo(
+      'localStorage に rail.labelMode が存在しない場合、デフォルトは「アイコンのみ」モードになる',
+    );
+    it.todo('「アイコンのみ」モードでは各ナビ項目にテキストラベルが表示されない');
+    it.todo('「アイコンのみ」モードでも Tooltip によるラベルは機能する（aria-label が存在する）');
+  });
+
+  describe('アイコン + ラベルモード', () => {
+    it.todo('「アイコン + ラベル」モードでは各ナビ項目に日本語テキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「受信箱」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「チャット」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「DM」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「カレンダー」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「タスク」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「ブックマーク」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「検索」のテキストラベルが表示される');
+    it.todo('「アイコン + ラベル」モードで「テンプレート」のテキストラベルが表示される');
+    it.todo('admin ロール時、「アイコン + ラベル」モードで「管理」のテキストラベルが表示される');
+  });
+
+  describe('localStorage への永続化', () => {
+    it.todo('ラベルモードに切り替えると localStorage["rail.labelMode"] に "label" が保存される');
+    it.todo(
+      'アイコンのみモードに切り替えると localStorage["rail.labelMode"] に "icon" が保存される',
+    );
+    it.todo('localStorage["rail.labelMode"] が "label" の場合、再訪時にラベルモードで表示される');
+    it.todo(
+      'localStorage["rail.labelMode"] が "icon" の場合、再訪時にアイコンのみモードで表示される',
+    );
+    it.todo(
+      'localStorage["rail.labelMode"] が不正な値の場合、デフォルト（アイコンのみ）にフォールバックする',
+    );
+  });
+
+  describe('既存の折り畳みモードとの共存', () => {
+    it.todo(
+      'collapsed=true のとき、ラベルモードに設定していてもナビゲーションリンクは表示されない',
+    );
+    it.todo('collapsed=true から展開すると、保存されたラベルモードが復元される');
+    it.todo('折り畳み状態の localStorage ("rail.collapsed") の挙動はラベルモードに影響されない');
+  });
+
+  describe('Rail 幅の変化', () => {
+    it.todo('「アイコン + ラベル」モードでは Rail の幅がアイコンのみモードより広くなる');
+    it.todo('「アイコンのみ」モードの Rail の幅は従来どおり 64px である');
+  });
+});

--- a/packages/client/src/__tests__/RailLabelMode.test.tsx
+++ b/packages/client/src/__tests__/RailLabelMode.test.tsx
@@ -67,56 +67,235 @@ function renderRail(initialPath = '/') {
 
 describe('Rail ラベル表示モード (Issue #316)', () => {
   describe('表示モード切替ボタン', () => {
-    it.todo('「アイコン + ラベル」モードに切り替えるボタンが存在する');
-    it.todo('「アイコンのみ」モードに切り替えるボタンが存在する');
-    it.todo('現在のモードに応じてボタンのラベルが変わる');
+    it('「アイコン + ラベル」モードに切り替えるボタンが存在する', () => {
+      renderRail();
+      // デフォルトはアイコンのみ → ラベル表示に切り替えるボタンがある
+      expect(screen.getByRole('button', { name: 'ラベル表示に切り替える' })).toBeInTheDocument();
+    });
+
+    it('「アイコンのみ」モードに切り替えるボタンが存在する', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      // ラベルモード → アイコンのみに切り替えるボタンがある
+      expect(screen.getByRole('button', { name: 'アイコンのみに切り替える' })).toBeInTheDocument();
+    });
+
+    it('現在のモードに応じてボタンのラベルが変わる', async () => {
+      const userEvent = (await import('@testing-library/user-event')).default;
+      renderRail();
+      // アイコンのみモード → 「ラベル表示に切り替える」ボタン
+      expect(screen.getByRole('button', { name: 'ラベル表示に切り替える' })).toBeInTheDocument();
+
+      // クリックするとラベルモードになり、ボタンラベルが変わる
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'ラベル表示に切り替える' }));
+      });
+      expect(screen.getByRole('button', { name: 'アイコンのみに切り替える' })).toBeInTheDocument();
+    });
   });
 
   describe('アイコンのみモード（デフォルト）', () => {
-    it.todo(
-      'localStorage に rail.labelMode が存在しない場合、デフォルトは「アイコンのみ」モードになる',
-    );
-    it.todo('「アイコンのみ」モードでは各ナビ項目にテキストラベルが表示されない');
-    it.todo('「アイコンのみ」モードでも Tooltip によるラベルは機能する（aria-label が存在する）');
+    it('localStorage に rail.labelMode が存在しない場合、デフォルトは「アイコンのみ」モードになる', () => {
+      renderRail();
+      // アイコンのみモード: nav が data-labelmode="icon" を持つ
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav).toHaveAttribute('data-labelmode', 'icon');
+    });
+
+    it('「アイコンのみ」モードでは各ナビ項目にテキストラベルが表示されない', () => {
+      renderRail();
+      // data-testid="rail-item-label" の要素が存在しない
+      expect(screen.queryAllByTestId('rail-item-label')).toHaveLength(0);
+    });
+
+    it('「アイコンのみ」モードでも Tooltip によるラベルは機能する（aria-label が存在する）', () => {
+      renderRail();
+      // aria-label が各ナビリンクに存在する
+      expect(screen.getByRole('link', { name: '受信箱' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'チャット' })).toBeInTheDocument();
+    });
   });
 
   describe('アイコン + ラベルモード', () => {
-    it.todo('「アイコン + ラベル」モードでは各ナビ項目に日本語テキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「受信箱」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「チャット」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「DM」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「カレンダー」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「タスク」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「ブックマーク」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「検索」のテキストラベルが表示される');
-    it.todo('「アイコン + ラベル」モードで「テンプレート」のテキストラベルが表示される');
-    it.todo('admin ロール時、「アイコン + ラベル」モードで「管理」のテキストラベルが表示される');
+    it('「アイコン + ラベル」モードでは各ナビ項目に日本語テキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      expect(labels.length).toBeGreaterThan(0);
+    });
+
+    it('「アイコン + ラベル」モードで「受信箱」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('受信箱');
+    });
+
+    it('「アイコン + ラベル」モードで「チャット」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('チャット');
+    });
+
+    it('「アイコン + ラベル」モードで「DM」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('DM');
+    });
+
+    it('「アイコン + ラベル」モードで「カレンダー」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('カレンダー');
+    });
+
+    it('「アイコン + ラベル」モードで「タスク」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('タスク');
+    });
+
+    it('「アイコン + ラベル」モードで「ブックマーク」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('ブックマーク');
+    });
+
+    it('「アイコン + ラベル」モードで「検索」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('検索');
+    });
+
+    it('「アイコン + ラベル」モードで「テンプレート」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('テンプレート');
+    });
+
+    it('admin ロール時、「アイコン + ラベル」モードで「管理」のテキストラベルが表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      mockUser.role = 'admin';
+      renderRail();
+      const labels = screen.getAllByTestId('rail-item-label');
+      const texts = labels.map((el) => el.textContent);
+      expect(texts).toContain('管理');
+    });
   });
 
   describe('localStorage への永続化', () => {
-    it.todo('ラベルモードに切り替えると localStorage["rail.labelMode"] に "label" が保存される');
-    it.todo(
-      'アイコンのみモードに切り替えると localStorage["rail.labelMode"] に "icon" が保存される',
-    );
-    it.todo('localStorage["rail.labelMode"] が "label" の場合、再訪時にラベルモードで表示される');
-    it.todo(
-      'localStorage["rail.labelMode"] が "icon" の場合、再訪時にアイコンのみモードで表示される',
-    );
-    it.todo(
-      'localStorage["rail.labelMode"] が不正な値の場合、デフォルト（アイコンのみ）にフォールバックする',
-    );
+    it('ラベルモードに切り替えると localStorage["rail.labelMode"] に "label" が保存される', async () => {
+      const userEvent = (await import('@testing-library/user-event')).default;
+      renderRail();
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'ラベル表示に切り替える' }));
+      });
+      expect(localStorage.getItem('rail.labelMode')).toBe('label');
+    });
+
+    it('アイコンのみモードに切り替えると localStorage["rail.labelMode"] に "icon" が保存される', async () => {
+      const userEvent = (await import('@testing-library/user-event')).default;
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'アイコンのみに切り替える' }));
+      });
+      expect(localStorage.getItem('rail.labelMode')).toBe('icon');
+    });
+
+    it('localStorage["rail.labelMode"] が "label" の場合、再訪時にラベルモードで表示される', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav).toHaveAttribute('data-labelmode', 'label');
+    });
+
+    it('localStorage["rail.labelMode"] が "icon" の場合、再訪時にアイコンのみモードで表示される', () => {
+      localStorage.setItem('rail.labelMode', 'icon');
+      renderRail();
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav).toHaveAttribute('data-labelmode', 'icon');
+    });
+
+    it('localStorage["rail.labelMode"] が不正な値の場合、デフォルト（アイコンのみ）にフォールバックする', () => {
+      localStorage.setItem('rail.labelMode', 'invalid');
+      renderRail();
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav).toHaveAttribute('data-labelmode', 'icon');
+    });
   });
 
   describe('既存の折り畳みモードとの共存', () => {
-    it.todo(
-      'collapsed=true のとき、ラベルモードに設定していてもナビゲーションリンクは表示されない',
-    );
-    it.todo('collapsed=true から展開すると、保存されたラベルモードが復元される');
-    it.todo('折り畳み状態の localStorage ("rail.collapsed") の挙動はラベルモードに影響されない');
+    it('collapsed=true のとき、ラベルモードに設定していてもナビゲーションリンクは表示されない', () => {
+      localStorage.setItem('rail.collapsed', 'true');
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      expect(screen.queryByRole('link', { name: '受信箱' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'チャット' })).not.toBeInTheDocument();
+    });
+
+    it('collapsed=true から展開すると、保存されたラベルモードが復元される', async () => {
+      const userEvent = (await import('@testing-library/user-event')).default;
+      localStorage.setItem('rail.collapsed', 'true');
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      // 折り畳み状態 → 展開
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'Rail を展開する' }));
+      });
+      // ラベルモードが復元されているはず
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav).toHaveAttribute('data-labelmode', 'label');
+      // ラベルも表示される
+      expect(screen.getAllByTestId('rail-item-label').length).toBeGreaterThan(0);
+    });
+
+    it('折り畳み状態の localStorage ("rail.collapsed") の挙動はラベルモードに影響されない', async () => {
+      const userEvent = (await import('@testing-library/user-event')).default;
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      // ラベルモードで展開中 → 折り畳みボタンをクリック
+      await act(async () => {
+        await userEvent.click(screen.getByRole('button', { name: 'Rail を折り畳む' }));
+      });
+      // rail.collapsed が "true" になる（ラベルモードに影響されない）
+      expect(localStorage.getItem('rail.collapsed')).toBe('true');
+      // rail.labelMode は変わらない
+      expect(localStorage.getItem('rail.labelMode')).toBe('label');
+    });
   });
 
   describe('Rail 幅の変化', () => {
-    it.todo('「アイコン + ラベル」モードでは Rail の幅がアイコンのみモードより広くなる');
-    it.todo('「アイコンのみ」モードの Rail の幅は従来どおり 64px である');
+    it('「アイコン + ラベル」モードでは Rail の幅がアイコンのみモードより広くなる', () => {
+      localStorage.setItem('rail.labelMode', 'label');
+      renderRail();
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      // data-labelmode="label" が付与されており、CSS で幅制御
+      expect(nav).toHaveAttribute('data-labelmode', 'label');
+      // アイコンのみの 64px ではなく wider な値が設定されている
+      // jsdom は実際のCSSを計算しないため、data属性でモード確認
+      expect(nav.getAttribute('data-labelmode')).toBe('label');
+    });
+
+    it('「アイコンのみ」モードの Rail の幅は従来どおり 64px である', () => {
+      renderRail();
+      const nav = screen.getByRole('navigation', { name: 'メインナビゲーション' });
+      expect(nav).toHaveAttribute('data-labelmode', 'icon');
+    });
   });
 });

--- a/packages/client/src/components/Layout/Rail.tsx
+++ b/packages/client/src/components/Layout/Rail.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useState } from 'react';
-import { Badge, Box, IconButton, Tooltip, Divider } from '@mui/material';
+import { Badge, Box, IconButton, Tooltip, Divider, Typography } from '@mui/material';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined';
@@ -13,6 +13,8 @@ import BookmarkBorderOutlinedIcon from '@mui/icons-material/BookmarkBorderOutlin
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined';
 import AdminPanelSettingsOutlinedIcon from '@mui/icons-material/AdminPanelSettingsOutlined';
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined';
+import LabelOutlinedIcon from '@mui/icons-material/LabelOutlined';
+import LabelOffOutlinedIcon from '@mui/icons-material/LabelOffOutlined';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useDmUnreadCount } from '../../hooks/useDmUnreadCount';
@@ -47,10 +49,47 @@ const ADMIN_ITEM: NavItem = {
   icon: <AdminPanelSettingsOutlinedIcon />,
 };
 
-function RailLink({ item, badgeCount = 0 }: { item: NavItem; badgeCount?: number }) {
+/** ラベル表示モード: "icon" = アイコンのみ, "label" = アイコン + ラベル */
+type LabelMode = 'icon' | 'label';
+
+const RAIL_COLLAPSED_KEY = 'rail.collapsed';
+const RAIL_LABEL_MODE_KEY = 'rail.labelMode';
+
+/** アイコンのみ幅 */
+const RAIL_WIDTH_ICON = 64;
+/** アイコン + ラベル幅 */
+const RAIL_WIDTH_LABEL = 120;
+
+function readCollapsedFromStorage(): boolean {
+  try {
+    return localStorage.getItem(RAIL_COLLAPSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function readLabelModeFromStorage(): LabelMode {
+  try {
+    const val = localStorage.getItem(RAIL_LABEL_MODE_KEY);
+    if (val === 'label' || val === 'icon') return val;
+    return 'icon';
+  } catch {
+    return 'icon';
+  }
+}
+
+function RailLink({
+  item,
+  badgeCount = 0,
+  showLabel = false,
+}: {
+  item: NavItem;
+  badgeCount?: number;
+  showLabel?: boolean;
+}) {
   const ariaLabel = badgeCount > 0 ? `${item.label} (${badgeCount} 件未読)` : item.label;
   return (
-    <Tooltip title={ariaLabel} placement="right">
+    <Tooltip title={showLabel ? '' : ariaLabel} placement="right" disableHoverListener={showLabel}>
       <Box
         component={NavLink}
         to={item.to}
@@ -59,10 +98,12 @@ function RailLink({ item, badgeCount = 0 }: { item: NavItem; badgeCount?: number
         sx={{
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
-          width: 40,
+          justifyContent: showLabel ? 'flex-start' : 'center',
+          gap: showLabel ? 1 : 0,
+          width: showLabel ? '100%' : 40,
           height: 40,
-          mx: 'auto',
+          mx: showLabel ? 0 : 'auto',
+          px: showLabel ? 1.5 : 0,
           my: 0.5,
           borderRadius: 'var(--radius-md)',
           color: 'var(--text-muted)',
@@ -81,6 +122,22 @@ function RailLink({ item, badgeCount = 0 }: { item: NavItem; badgeCount?: number
         <Badge badgeContent={badgeCount} max={9} color="error">
           {item.icon}
         </Badge>
+        {showLabel && (
+          <Typography
+            variant="caption"
+            component="span"
+            data-testid="rail-item-label"
+            sx={{
+              fontSize: '0.72rem',
+              fontWeight: 500,
+              lineHeight: 1,
+              userSelect: 'none',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {item.label}
+          </Typography>
+        )}
       </Box>
     </Tooltip>
   );
@@ -93,16 +150,6 @@ interface RailProps {
   onToggleSidebar?: () => void;
 }
 
-const RAIL_COLLAPSED_KEY = 'rail.collapsed';
-
-function readCollapsedFromStorage(): boolean {
-  try {
-    return localStorage.getItem(RAIL_COLLAPSED_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
-
 export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
@@ -110,6 +157,7 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
   const mentionUnreadCount = useMentionUnreadCount();
 
   const [collapsed, setCollapsed] = useState<boolean>(readCollapsedFromStorage);
+  const [labelMode, setLabelMode] = useState<LabelMode>(readLabelModeFromStorage);
 
   function toggleCollapsed() {
     setCollapsed((prev) => {
@@ -123,13 +171,29 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
     });
   }
 
+  function toggleLabelMode() {
+    setLabelMode((prev) => {
+      const next: LabelMode = prev === 'icon' ? 'label' : 'icon';
+      try {
+        localStorage.setItem(RAIL_LABEL_MODE_KEY, next);
+      } catch {
+        // localStorage が使えない環境では無視
+      }
+      return next;
+    });
+  }
+
+  const showLabel = labelMode === 'label';
+  const railWidth = showLabel ? RAIL_WIDTH_LABEL : RAIL_WIDTH_ICON;
+
   return (
     <Box
       component="nav"
       aria-label="メインナビゲーション"
       data-collapsed={collapsed ? 'true' : undefined}
+      data-labelmode={labelMode}
       sx={{
-        width: 64,
+        width: railWidth,
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
@@ -137,6 +201,7 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
         py: 1,
         background: 'var(--bg-elev)',
         borderRight: '1px solid var(--border)',
+        transition: 'width 150ms ease',
       }}
     >
       {/* ロゴ: 上部 3 つの円 (人の集合) + 下部三角形 (吹き出しの先端) で
@@ -220,13 +285,44 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
         </Tooltip>
       )}
 
+      {/* ラベル表示モード切替ボタン（展開時のみ表示） */}
+      {!collapsed && (
+        <Tooltip
+          title={showLabel ? 'アイコンのみに切り替える' : 'ラベル表示に切り替える'}
+          placement="right"
+        >
+          <IconButton
+            size="small"
+            aria-label={showLabel ? 'アイコンのみに切り替える' : 'ラベル表示に切り替える'}
+            onClick={toggleLabelMode}
+            sx={{
+              width: 36,
+              height: 32,
+              mx: 'auto',
+              mb: 1,
+              borderRadius: 'var(--radius-sm)',
+              color: 'var(--text-muted)',
+              '&:hover': { background: 'var(--surface-hover)', color: 'var(--text)' },
+            }}
+          >
+            {showLabel ? (
+              <LabelOffOutlinedIcon fontSize="small" />
+            ) : (
+              <LabelOutlinedIcon fontSize="small" />
+            )}
+          </IconButton>
+        </Tooltip>
+      )}
+
       {!collapsed && (
         <Box sx={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
           {TOP_ITEMS.map((item) => {
             let badgeCount = 0;
             if (item.to === '/dm') badgeCount = dmUnreadCount;
             else if (item.to === '/') badgeCount = mentionUnreadCount;
-            return <RailLink key={item.to} item={item} badgeCount={badgeCount} />;
+            return (
+              <RailLink key={item.to} item={item} badgeCount={badgeCount} showLabel={showLabel} />
+            );
           })}
         </Box>
       )}
@@ -235,9 +331,9 @@ export default function Rail({ sidebarOpen, onToggleSidebar }: RailProps = {}) {
           <Divider sx={{ width: 32, mx: 'auto', my: 1, borderColor: 'var(--border)' }} />
           <Box sx={{ display: 'flex', flexDirection: 'column' }}>
             {BOTTOM_ITEMS.map((item) => (
-              <RailLink key={item.to} item={item} />
+              <RailLink key={item.to} item={item} showLabel={showLabel} />
             ))}
-            {isAdmin && <RailLink item={ADMIN_ITEM} />}
+            {isAdmin && <RailLink item={ADMIN_ITEM} showLabel={showLabel} />}
           </Box>
           <SidebarFooter />
         </>


### PR DESCRIPTION
## 概要

Rail に「アイコン + 短いラベル」を常時表示する幅広モードを追加し、折り畳み Rail とは別のレイアウトとして選択できるようにする。初見ユーザーの学習コストを下げることが目的。

## 変更内容

- `packages/client/src/components/Layout/Rail.tsx`
  - `labelMode` state（`'icon'` / `'label'`）を追加
  - Rail 幅をアイコンのみ 64px / ラベルあり 120px で動的に切替（transition 付き）
  - `RailLink` コンポーネントに `showLabel` prop を追加し、ラベル表示時に `data-testid="rail-item-label"` の `<Typography>` を表示
  - 切替ボタン（`aria-label="ラベル表示に切り替える"` / `"アイコンのみに切り替える"`）を追加
  - 選択したモードを `localStorage["rail.labelMode"]` に永続化
  - 不正な値の場合はデフォルト（アイコンのみ）にフォールバック
- `packages/client/src/__tests__/RailLabelMode.test.tsx`
  - `it.todo` 26 項目をテストロジック付き `it()` に書き換え（全件パス）

## 影響範囲

- `packages/client/src/components/Layout/Rail.tsx`（変更）
- `packages/client/src/__tests__/RailLabelMode.test.tsx`（変更）
- 既存の `Rail.test.tsx` は無変更（65 件すべてパス確認済み）

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（Rail 関連 91 件）
- [ ] バックエンドユニットテストがすべてパスする（今回バックエンド変更なし）
- [x] ビルドが正常に完了すること（Rail.tsx の型エラーなし。ChatPage.tsx の既存エラーはこのブランチとは無関係）

## 関連Issue

Fixes #316

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [ ] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）