### PR TITLE
feat: 管理ダッシュボード - グラフ機能拡張 (#341)

### DIFF
--- a/packages/client/src/__tests__/AdminCharts.test.tsx
+++ b/packages/client/src/__tests__/AdminCharts.test.tsx
@@ -64,12 +64,40 @@ const mockTimeseries = {
     { timestamp: '2024-06-09T00:00:00.000Z', count: 2 },
   ],
 };
+const mockChannelTimeseries = {
+  messagesByChannel: [
+    {
+      channelId: 1,
+      channelName: 'general',
+      points: [
+        { timestamp: '2024-06-07T00:00:00.000Z', count: 2 },
+        { timestamp: '2024-06-08T00:00:00.000Z', count: 4 },
+      ],
+    },
+    {
+      channelId: 2,
+      channelName: 'random',
+      points: [
+        { timestamp: '2024-06-07T00:00:00.000Z', count: 1 },
+        { timestamp: '2024-06-08T00:00:00.000Z', count: 3 },
+      ],
+    },
+  ],
+};
+const mockTopChannels = {
+  channels: [
+    { channelId: 1, channelName: 'general', count: 8 },
+    { channelId: 2, channelName: 'random', count: 3 },
+  ],
+};
 
 vi.mock('../api/client', () => ({
   api: {
     admin: {
       getStats: vi.fn(),
       getTimeseries: vi.fn(),
+      getChannelTimeseries: vi.fn(),
+      getTopChannels: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
       updateUserRole: vi.fn(),
@@ -115,6 +143,8 @@ const mockedApi = api as unknown as {
   admin: {
     getStats: ReturnType<typeof vi.fn>;
     getTimeseries: ReturnType<typeof vi.fn>;
+    getChannelTimeseries: ReturnType<typeof vi.fn>;
+    getTopChannels: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
     ngWords: { list: ReturnType<typeof vi.fn> };
@@ -141,6 +171,8 @@ beforeEach(() => {
   });
   mockedApi.admin.getStats.mockResolvedValue(mockStats);
   mockedApi.admin.getTimeseries.mockResolvedValue(mockTimeseries);
+  mockedApi.admin.getChannelTimeseries.mockResolvedValue(mockChannelTimeseries);
+  mockedApi.admin.getTopChannels.mockResolvedValue(mockTopChannels);
   mockedApi.admin.getUsers.mockResolvedValue({ users: [] });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.ngWords.list.mockResolvedValue({ ngWords: [] });
@@ -218,16 +250,87 @@ describe('AdminCharts: 管理ダッシュボードのグラフ表示（Issue #27
 
   // ── 次フェーズで実装する項目 ───────────────────────────────────────
   describe('チャンネル別投稿ボリューム（次フェーズ）', () => {
-    it.skip('チャンネル別の時系列を取得して同一グラフ上に複数系列で表示する', () => { /* see #341 */ });
-    it.skip('チャンネル数が多い場合でも凡例（legend）が表示される', () => { /* see #341 */ });
-    it.skip('対象チャンネルが 0 件の場合は空状態フォールバックを表示する', () => { /* see #341 */ });
+    it('チャンネル別の時系列を取得して同一グラフ上に複数系列で表示する', async () => {
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(mockedApi.admin.getChannelTimeseries).toHaveBeenCalledWith(
+          expect.objectContaining({ period: '7d' }),
+        );
+        expect(screen.getByTestId('admin-chart-channel-timeseries')).toBeInTheDocument();
+      });
+      expect(screen.getByText('general')).toBeInTheDocument();
+      expect(screen.getByText('random')).toBeInTheDocument();
+    });
+
+    it('チャンネル数が多い場合でも凡例（legend）が表示される', async () => {
+      mockedApi.admin.getChannelTimeseries.mockResolvedValue({
+        messagesByChannel: Array.from({ length: 6 }, (_, index) => ({
+          channelId: index + 1,
+          channelName: `channel-${index + 1}`,
+          points: [{ timestamp: '2024-06-07T00:00:00.000Z', count: index + 1 }],
+        })),
+      });
+
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByText('channel-1')).toBeInTheDocument();
+        expect(screen.getByText('channel-6')).toBeInTheDocument();
+      });
+    });
+
+    it('対象チャンネルが 0 件の場合は空状態フォールバックを表示する', async () => {
+      mockedApi.admin.getChannelTimeseries.mockResolvedValue({ messagesByChannel: [] });
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-chart-channel-timeseries')).toHaveTextContent(
+          'データがありません',
+        );
+      });
+    });
   });
 
   describe('チャンネル別 Top N 横棒グラフ（次フェーズ）', () => {
-    it.skip('上位 N チャンネルの投稿数が降順で横棒グラフに描画される', () => { /* see #341 */ });
-    it.skip('チャンネル名と件数が読み取り可能な形でラベル表示される', () => { /* see #341 */ });
-    it.skip('Top N の件数（N=10 など）が API 呼び出しの limit と一致する', () => { /* see #341 */ });
-    it.skip('期間内に投稿が無い場合は空状態フォールバックを表示する', () => { /* see #341 */ });
+    it('上位 N チャンネルの投稿数が降順で横棒グラフに描画される', async () => {
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-chart-top-channels')).toBeInTheDocument();
+      });
+      expect(screen.getByText('#general: 8')).toBeInTheDocument();
+      expect(screen.getByText('#random: 3')).toBeInTheDocument();
+    });
+
+    it('チャンネル名と件数が読み取り可能な形でラベル表示される', async () => {
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByText('#general: 8')).toBeInTheDocument();
+      });
+    });
+
+    it('Top N の件数（N=10 など）が API 呼び出しの limit と一致する', async () => {
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(mockedApi.admin.getTopChannels).toHaveBeenCalledWith(
+          expect.objectContaining({ period: '7d', limit: 10 }),
+        );
+      });
+    });
+
+    it('期間内に投稿が無い場合は空状態フォールバックを表示する', async () => {
+      mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-chart-top-channels')).toHaveTextContent(
+          'データがありません',
+        );
+      });
+    });
   });
 
   describe('レイアウト・アクセシビリティ', () => {
@@ -235,16 +338,68 @@ describe('AdminCharts: 管理ダッシュボードのグラフ表示（Issue #27
       await renderAdminPage('/?period=7d');
 
       await waitFor(() => {
-        expect(screen.getByText(/投稿数/)).toBeInTheDocument();
-        expect(screen.getByText(/アクティブユーザー/)).toBeInTheDocument();
+        expect(screen.getByText('投稿数の推移')).toBeInTheDocument();
+        expect(screen.getByText('アクティブユーザーの推移')).toBeInTheDocument();
       });
     });
 
-    it.skip('期間フィルタは統計タブ全体（数値カード・グラフ）で共有される（次フェーズで強化）', () => { /* see #341 */ });
+    it('期間フィルタは統計タブ全体（数値カード・グラフ）で共有される（次フェーズで強化）', async () => {
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+      await renderAdminPage('/?period=7d');
+
+      mockedApi.admin.getStats.mockClear();
+      mockedApi.admin.getTimeseries.mockClear();
+      mockedApi.admin.getChannelTimeseries.mockClear();
+      mockedApi.admin.getTopChannels.mockClear();
+      await user.click(screen.getByRole('button', { name: '30d' }));
+
+      await waitFor(() => {
+        expect(mockedApi.admin.getStats).toHaveBeenCalledWith(
+          expect.objectContaining({ period: '30d' }),
+        );
+        expect(mockedApi.admin.getTimeseries).toHaveBeenCalledWith(
+          expect.objectContaining({ period: '30d' }),
+        );
+        expect(mockedApi.admin.getChannelTimeseries).toHaveBeenCalledWith(
+          expect.objectContaining({ period: '30d' }),
+        );
+        expect(mockedApi.admin.getTopChannels).toHaveBeenCalledWith(
+          expect.objectContaining({ period: '30d', limit: 10 }),
+        );
+      });
+    });
   });
 
   describe('Promise の安定化（React 19）', () => {
-    it.skip('期間フィルタが変わらない限り時系列 API は再呼び出しされない（useMemo で安定化）', () => { /* see #341 */ });
-    it.skip('タブ切替で再マウントされても同じ期間なら追加の API 呼び出しは発生しない', () => { /* see #341 */ });
+    it('期間フィルタが変わらない限り時系列 API は再呼び出しされない（useMemo で安定化）', async () => {
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-chart-messages')).toBeInTheDocument();
+      });
+
+      expect(mockedApi.admin.getTimeseries).toHaveBeenCalledTimes(1);
+      expect(mockedApi.admin.getChannelTimeseries).toHaveBeenCalledTimes(1);
+      expect(mockedApi.admin.getTopChannels).toHaveBeenCalledTimes(1);
+    });
+
+    it('タブ切替で再マウントされても同じ期間なら追加の API 呼び出しは発生しない', async () => {
+      const user = userEvent.setup({ delay: null, pointerEventsCheck: 0 });
+      await renderAdminPage('/?period=7d');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('admin-chart-messages')).toBeInTheDocument();
+      });
+      mockedApi.admin.getTimeseries.mockClear();
+      mockedApi.admin.getChannelTimeseries.mockClear();
+      mockedApi.admin.getTopChannels.mockClear();
+
+      await user.click(screen.getByRole('tab', { name: 'ユーザー管理' }));
+      await user.click(screen.getByRole('tab', { name: '統計' }));
+
+      expect(mockedApi.admin.getTimeseries).not.toHaveBeenCalled();
+      expect(mockedApi.admin.getChannelTimeseries).not.toHaveBeenCalled();
+      expect(mockedApi.admin.getTopChannels).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/client/src/__tests__/AdminMonthlyCsvExport.test.tsx
+++ b/packages/client/src/__tests__/AdminMonthlyCsvExport.test.tsx
@@ -45,6 +45,8 @@ vi.mock('../api/client', () => ({
     admin: {
       getStats: vi.fn(),
       getTimeseries: vi.fn(),
+      getChannelTimeseries: vi.fn(),
+      getTopChannels: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
       updateUserRole: vi.fn(),
@@ -91,6 +93,8 @@ const mockedApi = api as unknown as {
   admin: {
     getStats: ReturnType<typeof vi.fn>;
     getTimeseries: ReturnType<typeof vi.fn>;
+    getChannelTimeseries: ReturnType<typeof vi.fn>;
+    getTopChannels: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
     exportMonthlyReport: ReturnType<typeof vi.fn>;
@@ -118,6 +122,8 @@ beforeEach(() => {
   });
   mockedApi.admin.getStats.mockResolvedValue(mockStats);
   mockedApi.admin.getTimeseries.mockResolvedValue({ messages: [], activeUsers: [] });
+  mockedApi.admin.getChannelTimeseries.mockResolvedValue({ messagesByChannel: [] });
+  mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.getUsers.mockResolvedValue({ users: [] });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.ngWords.list.mockResolvedValue({ ngWords: [] });

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -95,6 +95,8 @@ vi.mock('../api/client', () => ({
     admin: {
       getStats: vi.fn(),
       getTimeseries: vi.fn(),
+      getChannelTimeseries: vi.fn(),
+      getTopChannels: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
       updateUserRole: vi.fn(),
@@ -145,6 +147,8 @@ const mockedApi = api as unknown as {
   admin: {
     getStats: ReturnType<typeof vi.fn>;
     getTimeseries: ReturnType<typeof vi.fn>;
+    getChannelTimeseries: ReturnType<typeof vi.fn>;
+    getTopChannels: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
     updateUserRole: ReturnType<typeof vi.fn>;
@@ -192,6 +196,8 @@ beforeEach(() => {
   });
   mockedApi.admin.getStats.mockResolvedValue(mockStats);
   mockedApi.admin.getTimeseries.mockResolvedValue({ messages: [], activeUsers: [] });
+  mockedApi.admin.getChannelTimeseries.mockResolvedValue({ messagesByChannel: [] });
+  mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.getUsers.mockResolvedValue({ users: mockAdminUsers });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: mockAdminChannels });
   mockedApi.admin.updateUserRole.mockResolvedValue({ success: true });

--- a/packages/client/src/__tests__/AdminPagePeriodFilter.test.tsx
+++ b/packages/client/src/__tests__/AdminPagePeriodFilter.test.tsx
@@ -41,6 +41,8 @@ vi.mock('../api/client', () => ({
     admin: {
       getStats: vi.fn(),
       getTimeseries: vi.fn(),
+      getChannelTimeseries: vi.fn(),
+      getTopChannels: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
       updateUserRole: vi.fn(),
@@ -100,6 +102,8 @@ const mockedApi = api as unknown as {
   admin: {
     getStats: ReturnType<typeof vi.fn>;
     getTimeseries: ReturnType<typeof vi.fn>;
+    getChannelTimeseries: ReturnType<typeof vi.fn>;
+    getTopChannels: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
     ngWords: { list: ReturnType<typeof vi.fn> };
@@ -126,6 +130,8 @@ beforeEach(() => {
   });
   mockedApi.admin.getStats.mockResolvedValue(mockStats);
   mockedApi.admin.getTimeseries.mockResolvedValue({ messages: [], activeUsers: [] });
+  mockedApi.admin.getChannelTimeseries.mockResolvedValue({ messagesByChannel: [] });
+  mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.getUsers.mockResolvedValue({ users: [] });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.ngWords.list.mockResolvedValue({ ngWords: [] });

--- a/packages/client/src/__tests__/AuditLogView.test.tsx
+++ b/packages/client/src/__tests__/AuditLogView.test.tsx
@@ -32,6 +32,8 @@ vi.mock('../api/client', () => ({
     admin: {
       getStats: vi.fn(),
       getTimeseries: vi.fn(),
+      getChannelTimeseries: vi.fn(),
+      getTopChannels: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
       updateUserRole: vi.fn(),
@@ -65,6 +67,8 @@ const mockedApi = api as unknown as {
   admin: {
     getStats: ReturnType<typeof vi.fn>;
     getTimeseries: ReturnType<typeof vi.fn>;
+    getChannelTimeseries: ReturnType<typeof vi.fn>;
+    getTopChannels: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
     updateUserRole: ReturnType<typeof vi.fn>;
@@ -138,6 +142,8 @@ beforeEach(() => {
   });
   mockedApi.admin.getStats.mockResolvedValue(mockStats);
   mockedApi.admin.getTimeseries.mockResolvedValue({ messages: [], activeUsers: [] });
+  mockedApi.admin.getChannelTimeseries.mockResolvedValue({ messagesByChannel: [] });
+  mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.getUsers.mockResolvedValue({ users: mockAdminUsers });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: mockAdminChannels });
   mockedApi.admin.getAuditLogs.mockResolvedValue({ logs: mockAuditLogs, total: 2 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -564,6 +564,27 @@ export const api = {
       const qs = q.toString();
       return request<AdminTimeseriesResponse>(`/admin/timeseries${qs ? `?${qs}` : ''}`);
     },
+    getChannelTimeseries: (params?: { period?: string; from?: string; to?: string }) => {
+      const q = new URLSearchParams();
+      if (params?.period) q.set('period', params.period);
+      if (params?.from) q.set('from', params.from);
+      if (params?.to) q.set('to', params.to);
+      const qs = q.toString();
+      return request<Pick<AdminTimeseriesResponse, 'messagesByChannel'>>(
+        `/admin/timeseries/channels${qs ? `?${qs}` : ''}`,
+      );
+    },
+    getTopChannels: (params?: { period?: string; from?: string; to?: string; limit?: number }) => {
+      const q = new URLSearchParams();
+      if (params?.period) q.set('period', params.period);
+      if (params?.from) q.set('from', params.from);
+      if (params?.to) q.set('to', params.to);
+      if (params?.limit !== undefined) q.set('limit', String(params.limit));
+      const qs = q.toString();
+      return request<{ channels: import('../types/admin').TopChannelByMessageCount[] }>(
+        `/admin/top-channels${qs ? `?${qs}` : ''}`,
+      );
+    },
     getAuditLogs: (params?: {
       actionType?: string;
       actorUserId?: number;

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -40,7 +40,14 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { api } from '../api/client';
-import type { AdminUser, AdminChannel, AdminStats, AdminTimeseriesResponse } from '../types/admin';
+import type {
+  AdminUser,
+  AdminChannel,
+  AdminStats,
+  AdminTimeseriesResponse,
+  ChannelTimeseries,
+  TopChannelByMessageCount,
+} from '../types/admin';
 import {
   ResponsiveContainer,
   LineChart,
@@ -49,6 +56,9 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip as RechartsTooltip,
+  Legend,
+  BarChart,
+  Bar,
 } from 'recharts';
 import AuditLogView from '../components/AuditLogView';
 import ModerationContent from '../components/Admin/ModerationContent';
@@ -326,12 +336,146 @@ function ChartCard({
   );
 }
 
+const CHANNEL_COLORS = ['#1976d2', '#388e3c', '#f57c00', '#7b1fa2', '#00838f', '#c2185b'];
+
+function ChannelTimeseriesCard({ data }: { data: ChannelTimeseries[] }) {
+  const timestamps = Array.from(new Set(data.flatMap((channel) => channel.points.map((p) => p.timestamp))));
+  const rows = timestamps.map((timestamp) => {
+    const row: Record<string, string | number> = { timestamp, label: formatTimestamp(timestamp) };
+    for (const channel of data) {
+      const point = channel.points.find((p) => p.timestamp === timestamp);
+      row[`channel_${channel.channelId}`] = point?.count ?? 0;
+    }
+    return row;
+  });
+
+  return (
+    <Card
+      data-testid="admin-chart-channel-timeseries"
+      elevation={0}
+      sx={{
+        flex: '1 1 720px',
+        minWidth: 320,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+      }}
+    >
+      <CardContent>
+        <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+          チャンネル別投稿ボリューム
+        </Typography>
+        {data.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: 'center', color: 'text.secondary' }}>
+            <Typography variant="body2">データがありません</Typography>
+          </Box>
+        ) : (
+          <>
+          <Box sx={{ width: '100%', height: 280 }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={rows} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                <RechartsTooltip />
+                <Legend />
+                {data.map((channel, index) => (
+                  <Line
+                    key={channel.channelId}
+                    type="monotone"
+                    dataKey={`channel_${channel.channelId}`}
+                    name={channel.channelName}
+                    stroke={CHANNEL_COLORS[index % CHANNEL_COLORS.length]}
+                    strokeWidth={2}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                ))}
+              </LineChart>
+            </ResponsiveContainer>
+          </Box>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+            {data.map((channel) => (
+              <Chip key={channel.channelId} size="small" label={channel.channelName} />
+            ))}
+          </Box>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TopChannelsCard({ data }: { data: TopChannelByMessageCount[] }) {
+  const rows = data.map((channel) => ({
+    ...channel,
+    label: `#${channel.channelName}`,
+  }));
+  return (
+    <Card
+      data-testid="admin-chart-top-channels"
+      elevation={0}
+      sx={{
+        flex: '1 1 480px',
+        minWidth: 320,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+      }}
+    >
+      <CardContent>
+        <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+          投稿数 上位チャンネル
+        </Typography>
+        {rows.length === 0 ? (
+          <Box sx={{ p: 4, textAlign: 'center', color: 'text.secondary' }}>
+            <Typography variant="body2">データがありません</Typography>
+          </Box>
+        ) : (
+          <>
+            <Box sx={{ width: '100%', height: Math.max(220, rows.length * 36) }}>
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={rows}
+                  layout="vertical"
+                  margin={{ top: 8, right: 24, bottom: 8, left: 56 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#eee" />
+                  <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                  <YAxis type="category" dataKey="label" width={92} tick={{ fontSize: 11 }} />
+                  <RechartsTooltip />
+                  <Bar dataKey="count" name="投稿数" fill="#1976d2" isAnimationActive={false} />
+                </BarChart>
+              </ResponsiveContainer>
+            </Box>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mt: 1 }}>
+              {rows.map((channel) => (
+                <Chip
+                  key={channel.channelId}
+                  size="small"
+                  label={`${channel.label}: ${channel.count}`}
+                />
+              ))}
+            </Box>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 function TimeseriesContent({
   timeseriesPromise,
+  channelTimeseriesPromise,
+  topChannelsPromise,
 }: {
   timeseriesPromise: Promise<AdminTimeseriesResponse>;
+  channelTimeseriesPromise: Promise<{ messagesByChannel?: ChannelTimeseries[] }>;
+  topChannelsPromise: Promise<{ channels: TopChannelByMessageCount[] }>;
 }) {
   const ts = use(timeseriesPromise);
+  const channelTs = use(channelTimeseriesPromise);
+  const topChannels = use(topChannelsPromise);
   return (
     <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', p: 2 }}>
       <ChartCard
@@ -346,6 +490,8 @@ function TimeseriesContent({
         data={ts.activeUsers}
         color="#388e3c"
       />
+      <ChannelTimeseriesCard data={channelTs.messagesByChannel ?? []} />
+      <TopChannelsCard data={topChannels.channels} />
     </Box>
   );
 }
@@ -797,6 +943,32 @@ export default function AdminPage() {
     return api.admin.getTimeseries(params);
   }, [periodFilter]);
 
+  const channelTimeseriesPromise = useMemo(() => {
+    const params: { period?: string; from?: string; to?: string } = {};
+    if (periodFilter.from && periodFilter.to) {
+      params.from = periodFilter.from;
+      params.to = periodFilter.to;
+    } else if (periodFilter.period && periodFilter.period !== 'custom') {
+      params.period = periodFilter.period;
+    } else {
+      params.period = '7d';
+    }
+    return api.admin.getChannelTimeseries(params);
+  }, [periodFilter]);
+
+  const topChannelsPromise = useMemo(() => {
+    const params: { period?: string; from?: string; to?: string; limit?: number } = { limit: 10 };
+    if (periodFilter.from && periodFilter.to) {
+      params.from = periodFilter.from;
+      params.to = periodFilter.to;
+    } else if (periodFilter.period && periodFilter.period !== 'custom') {
+      params.period = periodFilter.period;
+    } else {
+      params.period = '7d';
+    }
+    return api.admin.getTopChannels(params);
+  }, [periodFilter]);
+
   const usersPromise = useMemo(() => api.admin.getUsers(), []);
   const channelsPromise = useMemo(() => api.admin.getChannels(), []);
   const actorsPromise = useMemo(
@@ -881,7 +1053,11 @@ export default function AdminPage() {
               </ErrorBoundary>
               <ErrorBoundary>
                 <Suspense fallback={fallback}>
-                  <TimeseriesContent timeseriesPromise={timeseriesPromise} />
+                  <TimeseriesContent
+                    timeseriesPromise={timeseriesPromise}
+                    channelTimeseriesPromise={channelTimeseriesPromise}
+                    topChannelsPromise={topChannelsPromise}
+                  />
                 </Suspense>
               </ErrorBoundary>
               <Box sx={{ p: 2 }}>

--- a/packages/client/src/types/admin.ts
+++ b/packages/client/src/types/admin.ts
@@ -32,9 +32,22 @@ export interface TimeseriesPoint {
   count: number;
 }
 
+export interface ChannelTimeseries {
+  channelId: number;
+  channelName: string;
+  points: TimeseriesPoint[];
+}
+
+export interface TopChannelByMessageCount {
+  channelId: number;
+  channelName: string;
+  count: number;
+}
+
 export interface AdminTimeseriesResponse {
   messages: TimeseriesPoint[];
   activeUsers: TimeseriesPoint[];
+  messagesByChannel?: ChannelTimeseries[];
 }
 
 export type {

--- a/packages/server/src/__tests__/unit/adminTimeseries.test.ts
+++ b/packages/server/src/__tests__/unit/adminTimeseries.test.ts
@@ -6,8 +6,7 @@
  *   - 集計粒度の自動決定（≤24h → hour、それ以外 → day）
  * を検証する。
  *
- * 備考: 本フェーズは最小スコープ実装。
- *   チャンネル別 Top N 等は it.skip + Issue #341 参照で残課題として追跡する。
+ * 備考: Issue #341 ではチャンネル別時系列・Top N 集計・管理 API も検証する。
  */
 
 import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
@@ -16,7 +15,22 @@ const testDb = createTestDatabase();
 
 jest.mock('../../db/database', () => testDb);
 
-import { getMessageTimeseries, getActiveUsersTimeseries } from '../../services/adminService';
+import request from 'supertest';
+import { createApp } from '../../app';
+import { registerUser } from '../__fixtures__/testHelpers';
+import {
+  getMessageTimeseries,
+  getActiveUsersTimeseries,
+  getMessagesByChannelTimeseries,
+  getTopChannelsByMessageCount,
+  getTopUsersByMessageCount,
+} from '../../services/adminService';
+
+const app = createApp();
+
+async function makeAdmin(userId: number): Promise<void> {
+  await testDb.execute("UPDATE users SET role = 'admin' WHERE id = $1", [userId]);
+}
 
 async function insertUserWithLastLogin(
   username: string,
@@ -161,29 +175,68 @@ describe('adminService 時系列集計（Issue #271）', () => {
     });
 
     describe('集計粒度の決定（追加）', () => {
-      it.skip('period=24h を指定した場合は1時間単位（hour）でバケット化される（次フェーズ）', () => {
-        /* see #341 */
+      it('period=24h を指定した場合は1時間単位（hour）でバケット化される（次フェーズ）', async () => {
+        const userId = await insertUserWithLastLogin('ts_period_24h', null);
+        const chId = await insertChannel('ts-period-24h', userId);
+        const to = new Date('2024-06-15T12:00:00.000Z');
+        await insertMessage(chId, userId, new Date('2024-06-15T11:30:00.000Z'));
+
+        const points = await getMessageTimeseries({ period: '24h', to });
+
+        expect(points).toHaveLength(25);
+        expect(points[0].timestamp).toBe('2024-06-14T12:00:00.000Z');
+        expect(points[points.length - 1].timestamp).toBe('2024-06-15T12:00:00.000Z');
+        expect(points.find((p) => p.timestamp === '2024-06-15T11:00:00.000Z')?.count).toBe(1);
       });
-      it.skip('period=7d を指定した場合は1日単位（day）でバケット化される（次フェーズ）', () => {
-        /* see #341 */
+      it('period=7d を指定した場合は1日単位（day）でバケット化される（次フェーズ）', async () => {
+        const userId = await insertUserWithLastLogin('ts_period_7d', null);
+        const chId = await insertChannel('ts-period-7d', userId);
+        const to = new Date('2024-06-15T12:00:00.000Z');
+        await insertMessage(chId, userId, new Date('2024-06-10T03:00:00.000Z'));
+
+        const points = await getMessageTimeseries({ period: '7d', to });
+
+        expect(points[0].timestamp).toBe('2024-06-08T00:00:00.000Z');
+        expect(points[points.length - 1].timestamp).toBe('2024-06-15T00:00:00.000Z');
+        expect(points.find((p) => p.timestamp === '2024-06-10T00:00:00.000Z')?.count).toBe(1);
       });
-      it.skip('period=30d を指定した場合は1日単位（day）でバケット化される（次フェーズ）', () => {
-        /* see #341 */
+      it('period=30d を指定した場合は1日単位（day）でバケット化される（次フェーズ）', async () => {
+        const points = await getMessageTimeseries({
+          period: '30d',
+          to: new Date('2024-06-30T12:00:00.000Z'),
+        });
+
+        expect(points).toHaveLength(31);
+        expect(points[0].timestamp).toBe('2024-05-31T00:00:00.000Z');
       });
-      it.skip('granularity を明示指定した場合は自動判定より優先される（次フェーズ）', () => {
-        /* see #341 */
+      it('granularity を明示指定した場合は自動判定より優先される（次フェーズ）', async () => {
+        const points = await getMessageTimeseries({
+          from: new Date('2024-06-01T00:00:00.000Z'),
+          to: new Date('2024-06-01T03:00:00.000Z'),
+          granularity: 'day',
+        });
+
+        expect(points).toHaveLength(1);
+        expect(points[0].timestamp).toBe('2024-06-01T00:00:00.000Z');
       });
     });
 
     describe('バリデーション（次フェーズ）', () => {
-      it.skip('不正な period 値（例: "1h"）を指定するとエラーになる（次フェーズ）', () => {
-        /* see #341 */
+      it('不正な period 値（例: "1h"）を指定するとエラーになる（次フェーズ）', async () => {
+        await expect(getMessageTimeseries({ period: '1h' as never })).rejects.toThrow();
       });
-      it.skip('from が不正な日付文字列だとエラーになる（次フェーズ）', () => {
-        /* see #341 */
+      it('from が不正な日付文字列だとエラーになる（次フェーズ）', async () => {
+        await expect(
+          getMessageTimeseries({ from: 'not-a-date', to: new Date('2024-06-01T00:00:00.000Z') }),
+        ).rejects.toThrow();
       });
-      it.skip('from > to を指定するとエラーになる（次フェーズ）', () => {
-        /* see #341 */
+      it('from > to を指定するとエラーになる（次フェーズ）', async () => {
+        await expect(
+          getMessageTimeseries({
+            from: new Date('2024-06-02T00:00:00.000Z'),
+            to: new Date('2024-06-01T00:00:00.000Z'),
+          }),
+        ).rejects.toThrow();
       });
     });
   });
@@ -232,65 +285,235 @@ describe('adminService 時系列集計（Issue #271）', () => {
       }
     });
 
-    it.skip('不正な period 値を指定するとエラーになる（次フェーズ）', () => {
-      /* see #341 */
+    it('不正な period 値を指定するとエラーになる（次フェーズ）', async () => {
+      await expect(getActiveUsersTimeseries({ period: '1h' as never })).rejects.toThrow();
     });
   });
 
   describe('getMessagesByChannelTimeseries: チャンネル別投稿ボリュームの時系列集計（次フェーズ）', () => {
-    it.skip('チャンネル別に時系列バケットへ集計される（次フェーズ）', () => {
-      /* see #341 */
+    it('チャンネル別に時系列バケットへ集計される（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('ch_ts_user1', null);
+      const ch1 = await insertChannel('general', userId);
+      const ch2 = await insertChannel('random', userId);
+      await insertMessage(ch1, userId, new Date('2024-06-10T01:00:00.000Z'));
+      await insertMessage(ch1, userId, new Date('2024-06-10T02:00:00.000Z'));
+      await insertMessage(ch2, userId, new Date('2024-06-11T01:00:00.000Z'));
+
+      const result = await getMessagesByChannelTimeseries({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-11T23:00:00.000Z'),
+        granularity: 'day',
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.find((c) => c.channelId === ch1)?.points[0].count).toBe(2);
+      expect(result.find((c) => c.channelId === ch2)?.points[1].count).toBe(1);
     });
-    it.skip('返り値は { channelId, channelName, points: [{ timestamp, count }] } 形式である（次フェーズ）', () => {
-      /* see #341 */
+    it('返り値は { channelId, channelName, points: [{ timestamp, count }] } 形式である（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('ch_ts_user2', null);
+      const chId = await insertChannel('shape', userId);
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+
+      const [channel] = await getMessagesByChannelTimeseries({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(channel).toMatchObject({ channelId: chId, channelName: 'shape' });
+      expect(channel.points[0]).toEqual(
+        expect.objectContaining({ timestamp: expect.any(String), count: expect.any(Number) }),
+      );
     });
-    it.skip('論理削除済みメッセージは集計から除外される（次フェーズ）', () => {
-      /* see #341 */
+    it('論理削除済みメッセージは集計から除外される（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('ch_ts_user3', null);
+      const chId = await insertChannel('deleted', userId);
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+      const deletedId = await insertMessage(chId, userId, new Date('2024-06-10T02:00:00.000Z'));
+      await testDb.execute('UPDATE messages SET is_deleted = true WHERE id = $1', [deletedId]);
+
+      const [channel] = await getMessagesByChannelTimeseries({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(channel.points.reduce((sum, p) => sum + p.count, 0)).toBe(1);
     });
-    it.skip('期間内に投稿が無いチャンネルは結果に含まれない（次フェーズ）', () => {
-      /* see #341 */
+    it('期間内に投稿が無いチャンネルは結果に含まれない（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('ch_ts_user4', null);
+      await insertChannel('empty', userId);
+
+      const result = await getMessagesByChannelTimeseries({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result).toEqual([]);
     });
   });
 
   describe('getTopChannelsByMessageCount: チャンネル別 Top N 投稿数（次フェーズ）', () => {
-    it.skip('指定期間内のメッセージ数降順で上位 N 件を返す（次フェーズ）', () => {
-      /* see #341 */
+    async function seedTopChannels() {
+      const userId = await insertUserWithLastLogin('top_ch_user', null);
+      const chA = await insertChannel('alpha', userId);
+      const chB = await insertChannel('beta', userId);
+      const chC = await insertChannel('gamma', userId);
+      const inRange = new Date('2024-06-10T01:00:00.000Z');
+      await insertMessage(chA, userId, inRange);
+      await insertMessage(chA, userId, inRange);
+      await insertMessage(chB, userId, inRange);
+      await insertMessage(chB, userId, inRange);
+      await insertMessage(chB, userId, inRange);
+      await insertMessage(chC, userId, inRange);
+      return { userId, chA, chB, chC };
+    }
+
+    it('指定期間内のメッセージ数降順で上位 N 件を返す（次フェーズ）', async () => {
+      await seedTopChannels();
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+        limit: 3,
+      });
+
+      expect(result.map((c) => c.count)).toEqual([3, 2, 1]);
+      expect(result.map((c) => c.channelName)).toEqual(['beta', 'alpha', 'gamma']);
     });
-    it.skip('limit パラメータで返り値の件数を制限できる（デフォルトは 10）（次フェーズ）', () => {
-      /* see #341 */
+    it('limit パラメータで返り値の件数を制限できる（デフォルトは 10）（次フェーズ）', async () => {
+      await seedTopChannels();
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+        limit: 2,
+      });
+
+      expect(result).toHaveLength(2);
     });
-    it.skip('limit が指定されない場合はデフォルト値で動作する（次フェーズ）', () => {
-      /* see #341 */
+    it('limit が指定されない場合はデフォルト値で動作する（次フェーズ）', async () => {
+      await seedTopChannels();
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result.length).toBeLessThanOrEqual(10);
+      expect(result[0].channelName).toBe('beta');
     });
-    it.skip('limit が 100 を超える場合はエラー、または 100 に丸める（次フェーズ）', () => {
-      /* see #341 */
+    it('limit が 100 を超える場合はエラー、または 100 に丸める（次フェーズ）', async () => {
+      await expect(
+        getTopChannelsByMessageCount({
+          from: new Date('2024-06-10T00:00:00.000Z'),
+          to: new Date('2024-06-10T23:00:00.000Z'),
+          limit: 101,
+        }),
+      ).rejects.toThrow();
     });
-    it.skip('期間外のメッセージは集計に含まれない（次フェーズ）', () => {
-      /* see #341 */
+    it('期間外のメッセージは集計に含まれない（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('top_ch_range', null);
+      const chId = await insertChannel('range', userId);
+      await insertMessage(chId, userId, new Date('2024-06-09T23:00:00.000Z'));
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result[0].count).toBe(1);
     });
-    it.skip('論理削除済みメッセージは集計から除外される（次フェーズ）', () => {
-      /* see #341 */
+    it('論理削除済みメッセージは集計から除外される（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('top_ch_deleted', null);
+      const chId = await insertChannel('deleted-top', userId);
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+      const deletedId = await insertMessage(chId, userId, new Date('2024-06-10T02:00:00.000Z'));
+      await testDb.execute('UPDATE messages SET is_deleted = true WHERE id = $1', [deletedId]);
+
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result[0].count).toBe(1);
     });
-    it.skip('返り値は { channelId, channelName, count } 形式である（次フェーズ）', () => {
-      /* see #341 */
+    it('返り値は { channelId, channelName, count } 形式である（次フェーズ）', async () => {
+      const { chA } = await seedTopChannels();
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result.find((c) => c.channelId === chA)).toEqual({
+        channelId: chA,
+        channelName: 'alpha',
+        count: 2,
+      });
     });
-    it.skip('集計対象が無い場合は空配列を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('集計対象が無い場合は空配列を返す（次フェーズ）', async () => {
+      const result = await getTopChannelsByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result).toEqual([]);
     });
   });
 
   describe('getTopUsersByMessageCount: ユーザー別 Top N 投稿数（次フェーズ）', () => {
-    it.skip('指定期間内のメッセージ数降順で上位 N 件を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('指定期間内のメッセージ数降順で上位 N 件を返す（次フェーズ）', async () => {
+      const userA = await insertUserWithLastLogin('top_user_a', null);
+      const userB = await insertUserWithLastLogin('top_user_b', null);
+      const chId = await insertChannel('top-users', userA);
+      await insertMessage(chId, userA, new Date('2024-06-10T01:00:00.000Z'));
+      await insertMessage(chId, userB, new Date('2024-06-10T01:00:00.000Z'));
+      await insertMessage(chId, userB, new Date('2024-06-10T02:00:00.000Z'));
+
+      const result = await getTopUsersByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result.map((u) => u.count)).toEqual([2, 1]);
+      expect(result[0].username).toBe('top_user_b');
     });
-    it.skip('limit パラメータで返り値の件数を制限できる（次フェーズ）', () => {
-      /* see #341 */
+    it('limit パラメータで返り値の件数を制限できる（次フェーズ）', async () => {
+      const userA = await insertUserWithLastLogin('top_user_limit_a', null);
+      const userB = await insertUserWithLastLogin('top_user_limit_b', null);
+      const chId = await insertChannel('top-users-limit', userA);
+      await insertMessage(chId, userA, new Date('2024-06-10T01:00:00.000Z'));
+      await insertMessage(chId, userB, new Date('2024-06-10T02:00:00.000Z'));
+
+      const result = await getTopUsersByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+        limit: 1,
+      });
+
+      expect(result).toHaveLength(1);
     });
-    it.skip('論理削除済みメッセージは集計から除外される（次フェーズ）', () => {
-      /* see #341 */
+    it('論理削除済みメッセージは集計から除外される（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('top_user_deleted', null);
+      const chId = await insertChannel('top-users-deleted', userId);
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+      const deletedId = await insertMessage(chId, userId, new Date('2024-06-10T02:00:00.000Z'));
+      await testDb.execute('UPDATE messages SET is_deleted = true WHERE id = $1', [deletedId]);
+
+      const result = await getTopUsersByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result[0].count).toBe(1);
     });
-    it.skip('返り値は { userId, username, count } 形式である（次フェーズ）', () => {
-      /* see #341 */
+    it('返り値は { userId, username, count } 形式である（次フェーズ）', async () => {
+      const userId = await insertUserWithLastLogin('top_user_shape', null);
+      const chId = await insertChannel('top-users-shape', userId);
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+
+      const result = await getTopUsersByMessageCount({
+        from: new Date('2024-06-10T00:00:00.000Z'),
+        to: new Date('2024-06-10T23:00:00.000Z'),
+      });
+
+      expect(result[0]).toEqual({ userId, username: 'top_user_shape', count: 1 });
     });
   });
 });
@@ -298,35 +521,112 @@ describe('adminService 時系列集計（Issue #271）', () => {
 describe('adminController 時系列エンドポイント（Issue #271）', () => {
   describe('GET /admin/stats/timeseries（次フェーズ・別パスで実装済み）', () => {
     // 本フェーズでは GET /admin/timeseries を実装する。
-    it.skip('admin 権限ユーザーが period=7d を指定するとメッセージ・アクティブユーザーの時系列を取得できる（次フェーズ）', () => {
-      /* see #341 */
+    it('admin 権限ユーザーが period=7d を指定するとメッセージ・アクティブユーザーの時系列を取得できる（次フェーズ）', async () => {
+      const { token, userId } = await registerUser(app, 'ts_api_admin', 'ts_api_admin@example.com');
+      await makeAdmin(userId);
+
+      const res = await request(app)
+        .get('/api/admin/stats/timeseries?period=7d')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.messages)).toBe(true);
+      expect(Array.isArray(res.body.activeUsers)).toBe(true);
+      expect(Array.isArray(res.body.messagesByChannel)).toBe(true);
     });
-    it.skip('一般ユーザーがアクセスすると 403 を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('一般ユーザーがアクセスすると 403 を返す（次フェーズ）', async () => {
+      await registerUser(app, 'ts_api_owner', 'ts_api_owner@example.com');
+      const { token } = await registerUser(app, 'ts_api_user', 'ts_api_user@example.com');
+
+      const res = await request(app)
+        .get('/api/admin/stats/timeseries?period=7d')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(403);
     });
-    it.skip('未認証アクセスは 401 を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('未認証アクセスは 401 を返す（次フェーズ）', async () => {
+      const res = await request(app).get('/api/admin/stats/timeseries?period=7d');
+      expect(res.status).toBe(401);
     });
-    it.skip('不正な period パラメータは 400 を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('不正な period パラメータは 400 を返す（次フェーズ）', async () => {
+      const { token, userId } = await registerUser(app, 'ts_api_bad', 'ts_api_bad@example.com');
+      await makeAdmin(userId);
+
+      const res = await request(app)
+        .get('/api/admin/stats/timeseries?period=1h')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(400);
     });
-    it.skip('from/to の併用が許可される（または明確に拒否される）（次フェーズ）', () => {
-      /* see #341 */
+    it('from/to の併用が許可される（または明確に拒否される）（次フェーズ）', async () => {
+      const { token, userId } = await registerUser(app, 'ts_api_range', 'ts_api_range@example.com');
+      await makeAdmin(userId);
+
+      const res = await request(app)
+        .get('/api/admin/stats/timeseries?from=2024-06-01T00:00:00.000Z&to=2024-06-02T00:00:00.000Z')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.messages[0]).toHaveProperty('timestamp');
     });
   });
 
   describe('GET /admin/stats/top-channels（次フェーズ）', () => {
-    it.skip('admin 権限ユーザーが期間とリミットを指定すると Top N チャンネルが取得できる（次フェーズ）', () => {
-      /* see #341 */
+    it('admin 権限ユーザーが期間とリミットを指定すると Top N チャンネルが取得できる（次フェーズ）', async () => {
+      const { token, userId } = await registerUser(
+        app,
+        'top_api_admin',
+        'top_api_admin@example.com',
+      );
+      await makeAdmin(userId);
+      const chId = await insertChannel('top-api', userId);
+      await insertMessage(chId, userId, new Date('2024-06-10T01:00:00.000Z'));
+
+      const res = await request(app)
+        .get('/api/admin/stats/top-channels?from=2024-06-10T00:00:00.000Z&to=2024-06-10T23:00:00.000Z&limit=1')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.channels).toEqual([{ channelId: chId, channelName: 'top-api', count: 1 }]);
     });
-    it.skip('limit のデフォルト値で動作する（次フェーズ）', () => {
-      /* see #341 */
+    it('limit のデフォルト値で動作する（次フェーズ）', async () => {
+      const { token, userId } = await registerUser(
+        app,
+        'top_api_default',
+        'top_api_default@example.com',
+      );
+      await makeAdmin(userId);
+
+      const res = await request(app)
+        .get('/api/admin/stats/top-channels?period=7d')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.channels)).toBe(true);
     });
-    it.skip('一般ユーザーがアクセスすると 403 を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('一般ユーザーがアクセスすると 403 を返す（次フェーズ）', async () => {
+      await registerUser(app, 'top_api_owner', 'top_api_owner@example.com');
+      const { token } = await registerUser(app, 'top_api_user', 'top_api_user@example.com');
+
+      const res = await request(app)
+        .get('/api/admin/stats/top-channels?period=7d')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(403);
     });
-    it.skip('limit が範囲外の場合は 400 を返す（次フェーズ）', () => {
-      /* see #341 */
+    it('limit が範囲外の場合は 400 を返す（次フェーズ）', async () => {
+      const { token, userId } = await registerUser(
+        app,
+        'top_api_limit',
+        'top_api_limit@example.com',
+      );
+      await makeAdmin(userId);
+
+      const res = await request(app)
+        .get('/api/admin/stats/top-channels?period=7d&limit=101')
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(400);
     });
   });
 });

--- a/packages/server/src/controllers/adminController.ts
+++ b/packages/server/src/controllers/adminController.ts
@@ -137,6 +137,7 @@ export async function deleteChannel(
 
 const VALID_PERIODS = ['24h', '7d', '30d'] as const;
 type PeriodKey = (typeof VALID_PERIODS)[number];
+const VALID_GRANULARITIES = ['hour', 'day'] as const;
 
 const PERIOD_HOURS: Record<PeriodKey, number> = {
   '24h': 24,
@@ -201,9 +202,16 @@ export async function getTimeseries(
     const periodParam = q.period;
     const fromParam = q.from;
     const toParam = q.to;
+    const granularityParam = q.granularity;
 
     if (periodParam !== undefined && !VALID_PERIODS.includes(periodParam as PeriodKey)) {
       throw createError(`Invalid period. Must be one of: ${VALID_PERIODS.join(', ')}`, 400);
+    }
+    if (
+      granularityParam !== undefined &&
+      !VALID_GRANULARITIES.includes(granularityParam as (typeof VALID_GRANULARITIES)[number])
+    ) {
+      throw createError('Invalid granularity. Must be one of: hour, day', 400);
     }
     if (fromParam !== undefined && isNaN(Date.parse(fromParam))) {
       throw createError('Invalid from date', 400);
@@ -233,11 +241,96 @@ export async function getTimeseries(
     }
 
     const [messages, activeUsers] = await Promise.all([
-      adminService.getMessageTimeseries({ from, to }),
-      adminService.getActiveUsersTimeseries({ from, to }),
+      adminService.getMessageTimeseries({
+        from,
+        to,
+        granularity: granularityParam as adminService.TimeseriesGranularity | undefined,
+      }),
+      adminService.getActiveUsersTimeseries({
+        from,
+        to,
+        granularity: granularityParam as adminService.TimeseriesGranularity | undefined,
+      }),
     ]);
 
     res.json({ messages, activeUsers });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getStatsTimeseries(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const q = req.query as Record<string, string | undefined>;
+    const period = q.period as PeriodKey | undefined;
+    const granularity = q.granularity as adminService.TimeseriesGranularity | undefined;
+
+    if (period !== undefined && !VALID_PERIODS.includes(period)) {
+      throw createError(`Invalid period. Must be one of: ${VALID_PERIODS.join(', ')}`, 400);
+    }
+    if (granularity !== undefined && !VALID_GRANULARITIES.includes(granularity)) {
+      throw createError('Invalid granularity. Must be one of: hour, day', 400);
+    }
+
+    const options = { period, from: q.from, to: q.to, granularity };
+    const [messages, activeUsers, messagesByChannel] = await Promise.all([
+      adminService.getMessageTimeseries(options),
+      adminService.getActiveUsersTimeseries(options),
+      adminService.getMessagesByChannelTimeseries(options),
+    ]);
+
+    res.json({ messages, activeUsers, messagesByChannel });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getMessagesByChannelTimeseries(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const q = req.query as Record<string, string | undefined>;
+    const period = q.period as PeriodKey | undefined;
+    if (period !== undefined && !VALID_PERIODS.includes(period)) {
+      throw createError(`Invalid period. Must be one of: ${VALID_PERIODS.join(', ')}`, 400);
+    }
+    const messagesByChannel = await adminService.getMessagesByChannelTimeseries({
+      period,
+      from: q.from,
+      to: q.to,
+      granularity: q.granularity as adminService.TimeseriesGranularity | undefined,
+    });
+    res.json({ messagesByChannel });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTopChannels(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const q = req.query as Record<string, string | undefined>;
+    const period = q.period as PeriodKey | undefined;
+    if (period !== undefined && !VALID_PERIODS.includes(period)) {
+      throw createError(`Invalid period. Must be one of: ${VALID_PERIODS.join(', ')}`, 400);
+    }
+    const limit = q.limit !== undefined ? Number(q.limit) : undefined;
+    const channels = await adminService.getTopChannelsByMessageCount({
+      period,
+      from: q.from,
+      to: q.to,
+      limit,
+    });
+    res.json({ channels });
   } catch (err) {
     next(err);
   }

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -39,9 +39,21 @@ router.delete('/channels/:id/archive', (req, res, next) =>
 router.get('/stats', (req, res, next) =>
   controller.getStats(req as unknown as AuthenticatedRequest, res, next),
 );
+router.get('/stats/timeseries', (req, res, next) =>
+  controller.getStatsTimeseries(req as unknown as AuthenticatedRequest, res, next),
+);
+router.get('/stats/top-channels', (req, res, next) =>
+  controller.getTopChannels(req as unknown as AuthenticatedRequest, res, next),
+);
 
 router.get('/timeseries', (req, res, next) =>
   controller.getTimeseries(req as unknown as AuthenticatedRequest, res, next),
+);
+router.get('/timeseries/channels', (req, res, next) =>
+  controller.getMessagesByChannelTimeseries(req as unknown as AuthenticatedRequest, res, next),
+);
+router.get('/top-channels', (req, res, next) =>
+  controller.getTopChannels(req as unknown as AuthenticatedRequest, res, next),
 );
 
 router.get('/audit-logs/export', (req, res, next) =>

--- a/packages/server/src/services/adminService.ts
+++ b/packages/server/src/services/adminService.ts
@@ -44,9 +44,30 @@ export interface TimeseriesPoint {
 }
 
 export interface GetTimeseriesOptions {
-  from: Date;
-  to: Date;
+  from?: Date | string;
+  to?: Date | string;
+  period?: PeriodKey;
   granularity?: TimeseriesGranularity;
+}
+
+export type PeriodKey = '24h' | '7d' | '30d';
+
+export interface ChannelTimeseries {
+  channelId: number;
+  channelName: string;
+  points: TimeseriesPoint[];
+}
+
+export interface TopChannelByMessageCount {
+  channelId: number;
+  channelName: string;
+  count: number;
+}
+
+export interface TopUserByMessageCount {
+  userId: number | null;
+  username: string | null;
+  count: number;
 }
 
 interface AdminUserRow {
@@ -272,6 +293,12 @@ export async function getStats(options: GetStatsOptions = {}): Promise<AdminStat
 }
 
 // ─── 時系列集計（Issue #271） ─────────────────────────────────────
+const PERIOD_HOURS: Record<PeriodKey, number> = {
+  '24h': 24,
+  '7d': 7 * 24,
+  '30d': 30 * 24,
+};
+
 function determineGranularity(from: Date, to: Date): TimeseriesGranularity {
   const diffHours = (to.getTime() - from.getTime()) / (60 * 60 * 1000);
   return diffHours <= 24 ? 'hour' : 'day';
@@ -298,16 +325,59 @@ function generateBuckets(from: Date, to: Date, granularity: TimeseriesGranularit
   return buckets;
 }
 
+function coerceDate(value: Date | string | undefined, name: 'from' | 'to'): Date | undefined {
+  if (value === undefined) return undefined;
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date.getTime())) {
+    throw createError(`Invalid ${name} date`, 400);
+  }
+  return date;
+}
+
+function resolveTimeseriesRange(options: GetTimeseriesOptions): {
+  from: Date;
+  to: Date;
+  granularity: TimeseriesGranularity;
+} {
+  const { period } = options;
+  if (period !== undefined && !Object.prototype.hasOwnProperty.call(PERIOD_HOURS, period)) {
+    throw createError('Invalid period', 400);
+  }
+
+  let from = coerceDate(options.from, 'from');
+  let to = coerceDate(options.to, 'to');
+
+  if (period) {
+    to = to ?? new Date();
+    from = from ?? new Date(to.getTime() - PERIOD_HOURS[period] * 60 * 60 * 1000);
+  }
+
+  if (!from || !to) {
+    to = to ?? new Date();
+    from = from ?? new Date(to.getTime() - PERIOD_HOURS['7d'] * 60 * 60 * 1000);
+  }
+
+  validateRange(from, to);
+  return { from, to, granularity: options.granularity ?? determineGranularity(from, to) };
+}
+
 function validateRange(from: Date, to: Date): void {
-  if (!(from instanceof Date) || isNaN(from.getTime())) {
+  if (isNaN(from.getTime())) {
     throw createError('Invalid from date', 400);
   }
-  if (!(to instanceof Date) || isNaN(to.getTime())) {
+  if (isNaN(to.getTime())) {
     throw createError('Invalid to date', 400);
   }
   if (from > to) {
     throw createError('from must be before to', 400);
   }
+}
+
+function validateLimit(limit = 10): number {
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw createError('limit must be between 1 and 100', 400);
+  }
+  return limit;
 }
 
 /**
@@ -321,9 +391,7 @@ function validateRange(from: Date, to: Date): void {
 export async function getMessageTimeseries(
   options: GetTimeseriesOptions,
 ): Promise<TimeseriesPoint[]> {
-  const { from, to } = options;
-  validateRange(from, to);
-  const granularity = options.granularity ?? determineGranularity(from, to);
+  const { from, to, granularity } = resolveTimeseriesRange(options);
 
   const rows = await query<{ created_at: string }>(
     `SELECT created_at
@@ -455,9 +523,7 @@ export async function buildMonthlyReportCsv(input: BuildMonthlyReportInput): Pro
 export async function getActiveUsersTimeseries(
   options: GetTimeseriesOptions,
 ): Promise<TimeseriesPoint[]> {
-  const { from, to } = options;
-  validateRange(from, to);
-  const granularity = options.granularity ?? determineGranularity(from, to);
+  const { from, to, granularity } = resolveTimeseriesRange(options);
 
   const rows = await query<{ id: number; last_login_at: string }>(
     `SELECT id, last_login_at
@@ -481,4 +547,89 @@ export async function getActiveUsersTimeseries(
     const key = b.toISOString();
     return { timestamp: key, count: bucketUsers.get(key)?.size ?? 0 };
   });
+}
+
+export async function getMessagesByChannelTimeseries(
+  options: GetTimeseriesOptions,
+): Promise<ChannelTimeseries[]> {
+  const { from, to, granularity } = resolveTimeseriesRange(options);
+  const rows = await query<{ channel_id: number; channel_name: string; created_at: string }>(
+    `SELECT m.channel_id, c.name AS channel_name, m.created_at
+     FROM messages m
+     JOIN channels c ON c.id = m.channel_id
+     WHERE m.is_deleted = false
+       AND m.created_at >= $1
+       AND m.created_at <= $2
+     ORDER BY c.name ASC, m.created_at ASC`,
+    [from.toISOString(), to.toISOString()],
+  );
+
+  const buckets = generateBuckets(from, to, granularity);
+  const byChannel = new Map<number, { channelName: string; counts: Map<string, number> }>();
+  for (const row of rows) {
+    const bucket = truncateToBucket(new Date(row.created_at), granularity).toISOString();
+    const entry = byChannel.get(row.channel_id) ?? {
+      channelName: row.channel_name,
+      counts: new Map<string, number>(),
+    };
+    entry.counts.set(bucket, (entry.counts.get(bucket) ?? 0) + 1);
+    byChannel.set(row.channel_id, entry);
+  }
+
+  return Array.from(byChannel.entries()).map(([channelId, entry]) => ({
+    channelId,
+    channelName: entry.channelName,
+    points: buckets.map((bucket) => {
+      const key = bucket.toISOString();
+      return { timestamp: key, count: entry.counts.get(key) ?? 0 };
+    }),
+  }));
+}
+
+export async function getTopChannelsByMessageCount(
+  options: GetTimeseriesOptions & { limit?: number },
+): Promise<TopChannelByMessageCount[]> {
+  const { from, to } = resolveTimeseriesRange(options);
+  const limit = validateLimit(options.limit);
+  const rows = await query<{ channel_id: number; channel_name: string; cnt: string }>(
+    `SELECT m.channel_id, c.name AS channel_name, COUNT(*) AS cnt
+     FROM messages m
+     JOIN channels c ON c.id = m.channel_id
+     WHERE m.is_deleted = false
+       AND m.created_at >= $1
+       AND m.created_at <= $2
+     GROUP BY m.channel_id, c.name
+     ORDER BY COUNT(*) DESC, c.name ASC
+     LIMIT $3`,
+    [from.toISOString(), to.toISOString(), limit],
+  );
+  return rows.map((row) => ({
+    channelId: row.channel_id,
+    channelName: row.channel_name,
+    count: Number(row.cnt),
+  }));
+}
+
+export async function getTopUsersByMessageCount(
+  options: GetTimeseriesOptions & { limit?: number },
+): Promise<TopUserByMessageCount[]> {
+  const { from, to } = resolveTimeseriesRange(options);
+  const limit = validateLimit(options.limit);
+  const rows = await query<{ user_id: number | null; username: string | null; cnt: string }>(
+    `SELECT m.user_id, u.username, COUNT(*) AS cnt
+     FROM messages m
+     LEFT JOIN users u ON u.id = m.user_id
+     WHERE m.is_deleted = false
+       AND m.created_at >= $1
+       AND m.created_at <= $2
+     GROUP BY m.user_id, u.username
+     ORDER BY COUNT(*) DESC, u.username ASC
+     LIMIT $3`,
+    [from.toISOString(), to.toISOString(), limit],
+  );
+  return rows.map((row) => ({
+    userId: row.user_id,
+    username: row.username,
+    count: Number(row.cnt),
+  }));
 }


### PR DESCRIPTION
## 概要

管理ダッシュボードの時系列グラフ機能を拡張する。Issue #341 で残されていた `it.skip` 43 件を実装し、必要な API・サービス関数を追加する。

## 変更内容

### フロントエンド (`packages/client`)
- `AdminCharts`: チャンネル別投稿ボリュームの複数系列グラフを追加
- `AdminCharts`: Top N チャンネル横棒グラフを追加
- 期間フィルタを統計タブ全体で共有
- React 19 の `useMemo` で `use(promise)` に渡す Promise を安定化

### バックエンド (`packages/server`)
- `getMessageTimeseries` を `period` / `granularity` 対応に拡張
- `getMessagesByChannelTimeseries`: チャンネル別時系列集計を追加
- `getTopChannelsByMessageCount`: Top N チャンネル集計を追加
- `getTopUsersByMessageCount`: Top N ユーザー集計を追加
- 新規エンドポイント:
  - `GET /admin/stats/timeseries`
  - `GET /admin/stats/top-channels`
  - `GET /admin/timeseries/channels`
  - `GET /admin/top-channels`

### テスト
- `AdminCharts.test.tsx`: `it.skip` 10 件を実装
- `adminTimeseries.test.ts`: `it.skip` 33 件を実装
- 既存の Admin 系テスト（AdminPage / PeriodFilter / AuditLogView / MonthlyCsvExport）に新 API のモックを追加

## 影響範囲

- 管理ダッシュボード画面（`/admin` 配下の統計タブ）
- 既存 API (`/admin/timeseries`) は後方互換を維持
- 通常ユーザー機能には影響なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（対象テスト 17 件、関連 87 件 成功）
- [x] バックエンドユニットテストがすべてパスする（対象 41 件 / 全体 1669 件 成功）
- [x] ビルドが正常に完了すること（`npm run build` 成功）

> 全体 `npm run test` 実行時、本ブランチの変更とは無関係な既存 flaky テスト（`ExtendedProfile.test.tsx` / `ProfilePage.changePassword.test.tsx` / `InboxPage.test.tsx`、いずれも単独実行では成功・実行ごとに失敗内容が変動する timeout 系）の失敗が確認された。本 PR の差分はこれらのファイルを変更していない。

## 関連Issue
Fixes #341

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（対象 `it.skip` を全て実装済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)