### PR TITLE
fix: vitest testTimeout を 10s に引き上げて flaky timeout を解消 (#347)

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],
+    // #347 並列実行時の負荷で findBy*/waitFor が 5 秒以内に解決せず flaky になるため 10 秒に引き上げる
+    testTimeout: 10000,
   },
   plugins: [react()],
   resolve: {


### PR DESCRIPTION
## 概要

`npm run test`（モノレポ全体実行）で断続的に発生していた frontend テストの timeout (5000ms) 失敗を解消する。Issue #347 のトリアージ結果として、対応案1（`testTimeout` を 10000ms に引き上げ）を採用。

## 変更内容

- `packages/client/vite.config.ts` の `test.testTimeout` に `10000` を設定（コメントで Issue 番号と理由を併記）

## 影響範囲

- フロントエンドの Vitest テスト全体（`packages/client/src/__tests__/**`）
- ロジック・実装コードへの変更は一切なし
- トレードオフ: 本当に遅い実装が混入した場合の検知が 5 秒 → 10 秒へ遅延するが、現状の flaky は並列実行時の負荷由来であり妥当な妥協点

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（連続3回実行で全件成功: 2301 passed / 34 skipped）
- [x] バックエンドユニットテストがすべてパスする（77 suites / 1669 tests passed）
- [x] ビルドが正常に完了すること（`npm run build` 成功）
- [x] (手動確認の場合) `npm run test` を 3 連続実行し、Issue #347 で報告された ExtendedProfile / ProfilePage.changePassword / InboxPage のテストを含めて flaky 失敗が再発しないことを確認

## 関連Issue
Fixes #347

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] `it.todo` / 空ボディの `it` が残っていない（テスト追加なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)