### PR TITLE
feat: 検索結果グルーピングのエッジケース対応 (#344)

### DIFF
--- a/packages/client/src/__tests__/BookmarkPageJump.test.tsx
+++ b/packages/client/src/__tests__/BookmarkPageJump.test.tsx
@@ -150,12 +150,8 @@ describe('BookmarkPage ジャンプ機能', () => {
     });
   });
 
-  describe('DM メッセージへのジャンプ', () => {
-    // Bookmark 型に DM 識別情報（dmUserId 等）が存在しないため、DM ジャンプは未実装
-    it.skip('DM のブックマーク行をクリックすると /dm/{dmUserId}?message={messageId} へ遷移する', () => { /* see #344 */ });
-
-    it.skip('dmUserId が取得できない DM ブックマークをクリックしても遷移しない', () => { /* see #344 */ });
-  });
+  // DM ブックマーク機能自体が未実装（bookmarks テーブルが messages のみ参照する設計）のため、
+  // #344 ではテスト項目を削除した。DM ブックマーク対応は DB スキーマ変更を伴うため別 Issue で扱う。
 
   describe('遷移先でのハイライト', () => {
     it('チャンネルジャンプ時に message パラメータが URL に含まれる（ChatPage の highlightMessageId 連携前提）', async () => {

--- a/packages/client/src/__tests__/SearchResultsGrouping.test.tsx
+++ b/packages/client/src/__tests__/SearchResultsGrouping.test.tsx
@@ -9,9 +9,14 @@
 
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MessageSearchResult } from '@chat-app/shared';
 import SearchResults from '../components/Chat/SearchResults';
+
+beforeEach(() => {
+  // localStorage 永続化が他テストに影響しないようリセット
+  window.localStorage.clear();
+});
 
 function makeResult(overrides: Partial<MessageSearchResult> = {}): MessageSearchResult {
   return {
@@ -312,9 +317,63 @@ describe('検索結果グルーピング', () => {
       expect(screen.getAllByTestId('group-header')).toHaveLength(1);
     });
 
-    it.skip('検索結果が 0 件のときグルーピング切替 UI が表示されないかグレーアウト（仕様未定）', () => { /* see #344 */ });
-    it.skip('グルーピング状態が localStorage に保存されて次回も維持される（優先度低）', () => { /* see #344 */ });
-    it.skip('全メッセージが同一送信者の場合、送信者別でグループが1つになる', () => { /* see #344 */ });
-    it.skip('全メッセージが同一日付の場合、日付別でグループが1つになる', () => { /* see #344 */ });
+    it('検索結果が 0 件のときグルーピング切替 UI は表示されない', () => {
+      // 仕様確定（#344）: 0 件時は「見つかりませんでした」のみ表示し、
+      // グルーピング切替ボタンは描画しない（ボタンを押す対象が無いため）。
+      render(<SearchResults results={[]} onNavigate={vi.fn()} />);
+
+      expect(screen.getByText('見つかりませんでした')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /フラット/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /チャンネル/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /送信者/ })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /日付/ })).not.toBeInTheDocument();
+    });
+
+    it('グルーピング状態が localStorage に保存されて次回も維持される', async () => {
+      const { unmount } = render(
+        <SearchResults results={multiChannelResults} onNavigate={vi.fn()} />,
+      );
+      await userEvent.click(screen.getByRole('button', { name: /送信者/ }));
+      unmount();
+
+      // 再マウント時に localStorage から状態が復元される
+      render(<SearchResults results={multiChannelResults} onNavigate={vi.fn()} />);
+
+      expect(screen.getByRole('button', { name: /送信者/ })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+      expect(screen.getByRole('button', { name: /フラット/ })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('全メッセージが同一送信者の場合、送信者別でグループが1つになる', async () => {
+      const singleSenderResults = [
+        makeResult({ id: 1, userId: 1, username: 'alice' }),
+        makeResult({ id: 2, userId: 1, username: 'alice' }),
+      ];
+      render(<SearchResults results={singleSenderResults} onNavigate={vi.fn()} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /送信者/ }));
+
+      expect(screen.getAllByTestId('group-header')).toHaveLength(1);
+    });
+
+    it('全メッセージが同一日付の場合、日付別でグループが1つになる', async () => {
+      // formatDateOnly はローカル時刻ベースで判定するため、JST(+09:00)・UTC のどちらでも
+      // 同一日付になる時刻帯（UTC 朝〜昼）を選んで日付境界をまたがないようにする
+      const sameDateResults = [
+        makeResult({ id: 1, createdAt: '2024-01-15T01:00:00Z', username: 'alice' }),
+        makeResult({ id: 2, createdAt: '2024-01-15T03:00:00Z', username: 'bob' }),
+        makeResult({ id: 3, createdAt: '2024-01-15T05:00:00Z', username: 'carol' }),
+      ];
+      render(<SearchResults results={sameDateResults} onNavigate={vi.fn()} />);
+
+      await userEvent.click(screen.getByRole('button', { name: /日付/ }));
+
+      expect(screen.getAllByTestId('group-header')).toHaveLength(1);
+    });
   });
 });

--- a/packages/client/src/components/Chat/SearchResults.tsx
+++ b/packages/client/src/components/Chat/SearchResults.tsx
@@ -24,6 +24,22 @@ import { buildSnippet } from '../../utils/buildSnippet';
 
 type GroupBy = 'flat' | 'channel' | 'sender' | 'date';
 
+const GROUP_BY_STORAGE_KEY = 'search-results-group-by';
+const GROUP_BY_VALUES: GroupBy[] = ['flat', 'channel', 'sender', 'date'];
+
+function readStoredGroupBy(): GroupBy {
+  if (typeof window === 'undefined') return 'flat';
+  try {
+    const stored = window.localStorage.getItem(GROUP_BY_STORAGE_KEY);
+    if (stored !== null && (GROUP_BY_VALUES as string[]).includes(stored)) {
+      return stored as GroupBy;
+    }
+  } catch {
+    // localStorage 利用不可（SSR / プライベートモード等）はデフォルト値にフォールバック
+  }
+  return 'flat';
+}
+
 interface Props {
   results: MessageSearchResult[];
   onNavigate: (channelId: number, messageId: number) => void;
@@ -204,7 +220,7 @@ export default function SearchResults({
   keyword = '',
   hasSearched = true,
 }: Props) {
-  const [groupBy, setGroupBy] = useState<GroupBy>('flat');
+  const [groupBy, setGroupBy] = useState<GroupBy>(() => readStoredGroupBy());
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
 
   const handleCopy = (result: MessageSearchResult) => {
@@ -215,6 +231,11 @@ export default function SearchResults({
   const handleGroupByChange = useCallback((newGroupBy: GroupBy) => {
     setGroupBy(newGroupBy);
     setCollapsedGroups(new Set()); // 切り替え時に全展開
+    try {
+      window.localStorage.setItem(GROUP_BY_STORAGE_KEY, newGroupBy);
+    } catch {
+      // localStorage 書き込み失敗は無視（UI 状態は維持される）
+    }
   }, []);
 
   const toggleGroup = useCallback((key: string) => {


### PR DESCRIPTION
## 概要

PR #340 で `it.skip` として残された Issue #344 の 6 件のテスト項目を解消する。
SearchResults のエッジケース 4 件を本実装し、DM ブックマーク 2 件はスコープ外として削除した。

## 変更内容

### SearchResults（4 件 it.skip → 本実装）
- **groupBy 状態を localStorage に永続化** — リロード後も最後に選んだグルーピングが復元される。`window.localStorage` 利用不可（SSR / プライベートモード）はサイレントに無視。
- **0 件時のグルーピング切替 UI 仕様確定** — `results.length === 0` で「見つかりませんでした」のみ表示し、切替ボタンは描画しない。既存の早期 return で実現済みのためテストのみ追加。
- **全メッセージ同一送信者で 1 グループ** — テストのみ追加（既存ロジックで満たされる）。
- **全メッセージ同一日付で 1 グループ** — テストのみ追加。`formatDateOnly` がローカル時刻ベースのため、UTC 朝〜昼の時刻を使い JST/UTC のいずれでも日付境界をまたがないようにした。

### BookmarkPageJump（2 件 it.skip → 削除）
- DM ブックマーク機能は `bookmarks` テーブルが `messages.id` のみを FK 参照する設計のため未実装。DB スキーマ変更を伴うため本 Issue スコープ外と判断し、`describe('DM メッセージへのジャンプ')` ブロックごと削除（理由コメントは残置）。

## 影響範囲

- `packages/client/src/components/Chat/SearchResults.tsx` — `useState` 初期化と `handleGroupByChange` で localStorage 連携。
- `packages/client/src/__tests__/SearchResultsGrouping.test.tsx` — `beforeEach` で `localStorage.clear()` を追加し他テストへの影響を遮断。
- `packages/client/src/__tests__/BookmarkPageJump.test.tsx` — DM ジャンプ describe を削除。

サーバ・型・他のクライアント機能には影響なし。

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする（2305 passed, 28 skipped — 残 skip はすべて #341/#342/#343 参照）
- [x] バックエンドユニットテストがすべてパスする（1669 passed）
- [x] ビルドが正常に完了すること（`npm run build` 成功）

## 関連Issue

Fixes #344

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)