### PR TITLE
feat: タスクボードのインライン作成UXを改善

### DIFF
--- a/packages/client/src/__tests__/TaskBoardInlineCreate.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardInlineCreate.test.tsx
@@ -11,7 +11,7 @@
  *       変換して残課題として追跡する（フォーカス喪失時の挙動・エラー時 UX 等）。
  */
 
-import { render, screen, waitFor, act, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, act, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -56,6 +56,7 @@ const mockTasksDelete = vi.fn();
 const mockTasksUpdateOrder = vi.fn();
 const mockAuthUsers = vi.fn();
 const mockChannelsList = vi.fn();
+const mockShowError = vi.fn();
 
 vi.mock('../api/client', () => ({
   api: {
@@ -116,6 +117,14 @@ vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => null,
 }));
 
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({
+    showSuccess: vi.fn(),
+    showError: mockShowError,
+    showInfo: vi.fn(),
+  }),
+}));
+
 vi.mock('../components/Channel/ChannelList', () => ({
   default: () => <div data-testid="channel-list-stub" />,
 }));
@@ -171,6 +180,7 @@ async function importTaskBoardPage() {
 beforeEach(() => {
   vi.resetAllMocks();
   mockNavigate.mockReset();
+  mockShowError.mockReset();
   mockTasksList.mockResolvedValue({ tasks: makeTasks() });
   mockTasksCreate.mockResolvedValue({
     task: {
@@ -259,14 +269,42 @@ describe('TaskBoardPage インライン作成 (Issue #268)', () => {
       expect(screen.queryByTestId('inline-create-input-done')).not.toBeInTheDocument();
     });
 
-    it.skip('入力フィールド表示中はそのカラムの「+ タスク追加」ボタンが非表示になる', () => {
-      /* see #343 */
+    it('入力フィールド表示中はそのカラムの「+ タスク追加」ボタンが非表示になる', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      expect(within(col).queryByRole('button', { name: /タスク追加/ })).not.toBeInTheDocument();
     });
-    it.skip('別カラムの「+ タスク追加」ボタンをクリックしても他カラムの入力フィールドは閉じない（独立して開閉できる）', () => {
-      /* see #343 */
+    it('別カラムの「+ タスク追加」ボタンをクリックしても他カラムの入力フィールドは閉じない（独立して開閉できる）', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      await userEvent.click(
+        within(screen.getByTestId('column-todo')).getByRole('button', { name: /タスク追加/ }),
+      );
+      await userEvent.click(
+        within(screen.getByTestId('column-in_progress')).getByRole('button', {
+          name: /タスク追加/,
+        }),
+      );
+      expect(screen.getByTestId('inline-create-input-todo')).toBeInTheDocument();
+      expect(screen.getByTestId('inline-create-input-in_progress')).toBeInTheDocument();
     });
-    it.skip('入力フィールドにオートフォーカスが当たる', () => {
-      /* see #343 */
+    it('入力フィールドにオートフォーカスが当たる', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen
+        .getByTestId('inline-create-input-todo')
+        .querySelector('input') as HTMLInputElement;
+      expect(input).toHaveFocus();
     });
   });
 
@@ -443,8 +481,17 @@ describe('TaskBoardPage インライン作成 (Issue #268)', () => {
       });
     });
 
-    it.skip('IME 変換確定の Enter（isComposing: true）では作成が実行されない', () => {
-      /* see #343 */
+    it('IME 変換確定の Enter（isComposing: true）では作成が実行されない', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen.getByTestId('inline-create-input-todo').querySelector('input')!;
+      await userEvent.type(input, '入力中');
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', isComposing: true });
+      expect(mockTasksCreate).not.toHaveBeenCalled();
     });
   });
 
@@ -479,26 +526,107 @@ describe('TaskBoardPage インライン作成 (Issue #268)', () => {
       expect(mockTasksCreate).not.toHaveBeenCalled();
     });
 
-    it.skip('Esc キーを押すと入力中のテキストが破棄される（再度開いたとき空になる）', () => {
-      /* see #343 */
+    it('Esc キーを押すと入力中のテキストが破棄される（再度開いたとき空になる）', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen.getByTestId('inline-create-input-todo').querySelector('input')!;
+      await userEvent.type(input, '破棄されるテキスト');
+      await userEvent.keyboard('{Escape}');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const reopenedInput = screen
+        .getByTestId('inline-create-input-todo')
+        .querySelector('input') as HTMLInputElement;
+      expect(reopenedInput.value).toBe('');
     });
   });
 
   describe('フォーカス喪失時の挙動', () => {
-    it.skip('入力フィールドからフォーカスが外れたとき、空のままなら入力フィールドを閉じる', () => {
-      /* see #343 */
+    it('入力フィールドからフォーカスが外れたとき、空のままなら入力フィールドを閉じる', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen.getByTestId('inline-create-input-todo').querySelector('input')!;
+      input.focus();
+      await userEvent.click(screen.getByRole('button', { name: /新規タスク作成/ }));
+      await waitFor(() => {
+        expect(screen.queryByTestId('inline-create-input-todo')).not.toBeInTheDocument();
+      });
     });
-    it.skip('入力フィールドからフォーカスが外れても、入力テキストがあれば閉じずに残る', () => {
-      /* see #343 */
+    it('入力フィールドからフォーカスが外れても、入力テキストがあれば閉じずに残る', async () => {
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen.getByTestId('inline-create-input-todo').querySelector('input')!;
+      await userEvent.type(input, '残すテキスト');
+      await userEvent.click(screen.getByRole('button', { name: /新規タスク作成/ }));
+      expect(screen.getByTestId('inline-create-input-todo')).toBeInTheDocument();
     });
   });
 
   describe('エラー時の挙動', () => {
-    it.skip('api.tasks.create が失敗してもクラッシュせずエラーが UI に表示される', () => {
-      /* see #343 */
+    it('api.tasks.create が失敗してもクラッシュせずエラーが UI に表示される', async () => {
+      mockTasksCreate.mockRejectedValueOnce(new Error('作成できませんでした'));
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen.getByTestId('inline-create-input-todo').querySelector('input')!;
+      await userEvent.type(input, '失敗タスク{Enter}');
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith('作成できませんでした');
+      });
+      expect(screen.getByTestId('inline-create-input-todo')).toBeInTheDocument();
     });
-    it.skip('作成失敗時は入力テキストがクリアされず、再 Enter で再送信できる', () => {
-      /* see #343 */
+    it('作成失敗時は入力テキストがクリアされず、再 Enter で再送信できる', async () => {
+      mockTasksCreate
+        .mockRejectedValueOnce(new Error('一時エラー'))
+        .mockResolvedValueOnce({
+          task: {
+            id: 100,
+            title: 'retry',
+            description: null,
+            status: 'todo',
+            assigneeId: null,
+            dueAt: null,
+            sourceMessageId: null,
+            sourceChannelId: null,
+            createdBy: 1,
+            position: 0,
+            isHidden: false,
+            createdAt: '2024-01-01T00:00:00Z',
+            updatedAt: '2024-01-01T00:00:00Z',
+          },
+        });
+      await renderBoard();
+      await waitFor(() => {
+        expect(screen.getByTestId('column-todo')).toBeInTheDocument();
+      });
+      const col = screen.getByTestId('column-todo');
+      await userEvent.click(within(col).getByRole('button', { name: /タスク追加/ }));
+      const input = screen
+        .getByTestId('inline-create-input-todo')
+        .querySelector('input') as HTMLInputElement;
+      await userEvent.type(input, '再送タスク{Enter}');
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith('一時エラー');
+      });
+      expect(input.value).toBe('再送タスク');
+      await userEvent.type(input, '{Enter}');
+      await waitFor(() => {
+        expect(mockTasksCreate).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -49,6 +49,7 @@ import { useNavigate } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
 import SidebarDmList from '../components/Layout/SidebarDmList';
+import { useSnackbar } from '../contexts/SnackbarContext';
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
   todo: '未着手',
@@ -246,9 +247,20 @@ function KanbanColumn({
     try {
       await onInlineCreate(status, trimmed);
       setInlineTitle('');
+    } catch {
+      // エラー通知は親側で行い、入力内容は再送信できるよう保持する。
     } finally {
       setInlineSubmitting(false);
     }
+  };
+
+  const handleBlur = () => {
+    window.setTimeout(() => {
+      if (!inputRef.current) return;
+      if (inlineTitle.trim()) return;
+      if (document.activeElement?.closest('[data-kanban-board="true"]')) return;
+      setInlineOpen(false);
+    }, 0);
   };
 
   return (
@@ -298,6 +310,7 @@ function KanbanColumn({
           value={inlineTitle}
           disabled={inlineSubmitting}
           onChange={(e) => setInlineTitle(e.target.value)}
+          onBlur={handleBlur}
           onKeyDown={(e) => {
             // IME 変換確定の Enter は無視
             if (
@@ -356,6 +369,7 @@ function TaskBoardContent({
   const [activeId, setActiveId] = useState<number | null>(null);
   const isMobile = useMediaQuery('(max-width: 767px)');
   const navigate = useNavigate();
+  const { showError } = useSnackbar();
 
   // Issue #267: タスクからカレンダーへジャンプ
   const handleJumpToCalendar = (task: Task) => {
@@ -496,8 +510,9 @@ function TaskBoardContent({
       // 一覧再取得
       const { tasks: fresh } = await api.tasks.list(includeHidden ? { includeHidden: true } : {});
       setTasks(fresh);
-    } catch {
-      // エラーは黙殺（残課題: UI へのエラー表示）
+    } catch (err) {
+      showError(err instanceof Error ? err.message : 'タスクの作成に失敗しました');
+      throw err;
     }
   };
 
@@ -582,6 +597,7 @@ function TaskBoardContent({
       {/* カンバンボード: 横スクロール対応 */}
       <Box
         data-testid="kanban-container"
+        data-kanban-board="true"
         sx={{ flexGrow: 1, overflow: 'auto', overflowX: 'auto', px: 2, pb: 2 }}
       >
         <DndContext


### PR DESCRIPTION
## 概要

タスクボードのインライン作成機能について、Issue #343 で残っていた UX 細部の対応を実装しました。

## 変更内容

- `TaskBoardInlineCreate.test.tsx` の Issue #343 対象 9 件の `it.skip` を実テストへ変更
- 入力フィールド表示中の追加ボタン非表示、別カラム独立開閉、オートフォーカスを検証・実装
- IME 変換確定中の Enter 無視、Esc キャンセル時の入力破棄を検証・実装
- blur 時に空入力なら閉じ、入力ありなら保持する挙動を検証・実装
- 作成失敗時にスナックバーでエラー通知し、入力を保持して再 Enter で再送信できるように変更

## 影響範囲

- `packages/client/src/pages/TaskBoardPage.tsx`
- `packages/client/src/__tests__/TaskBoardInlineCreate.test.tsx`
- タスクボードのインライン作成 UX

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする
  - `npm run test`（権限付き実行）: client 140 files / 2314 passed / 19 skipped
  - `npm run test --workspace=packages/client -- TaskBoardInlineCreate.test.tsx`: 27 passed
- [x] バックエンドユニットテストがすべてパスする
  - `npm run test`（権限付き実行）: server 77 suites / 1669 passed
- [x] ビルドが正常に完了すること
  - `npm run build`: 成功
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue

Fixes #343

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）

補足: 通常権限の `npm run test` はサーバーテストのローカル listen がサンドボックス制限に当たり `listen EPERM` で失敗したため、権限付きで再実行して全件成功を確認しました。