### PR TITLE
feat: カレンダーの週表示とアジェンダにタスク統合を追加

### DIFF
--- a/packages/client/src/__tests__/CalendarTaskDisplay.test.tsx
+++ b/packages/client/src/__tests__/CalendarTaskDisplay.test.tsx
@@ -9,16 +9,68 @@
  *     dueAt が null のタスクは表示されないこと、を中心に検証する
  *   - スタイル（色値）はイベントブロックとは別の固定色（タスク用）であることを style から確認する
  *
- *   今回スコープ: MonthView の 8 項目のみ実装。
- *   WeekView/AgendaView/CalendarPage 統合は it.skip + Issue #342 参照で残課題として追跡する。
+ *   Issue #342: WeekView/AgendaView/CalendarPage 統合のタスク表示も実装対象に含める。
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { MonthView } from '../components/Calendar/MonthView';
-import type { CalendarEvent, Task } from '@chat-app/shared';
+import { WeekView } from '../components/Calendar/WeekView';
+import { AgendaView } from '../components/Calendar/AgendaView';
+import type { CalendarEvent, Channel, Task, User } from '@chat-app/shared';
+
+const apiMocks = vi.hoisted(() => ({
+  eventsList: vi.fn(),
+  tasksList: vi.fn(),
+  tasksUpdate: vi.fn(),
+  channelsList: vi.fn(),
+  usersList: vi.fn(),
+  pollsList: vi.fn(),
+}));
+
+vi.mock('../api/client', () => ({
+  api: {
+    calendar: {
+      events: {
+        list: apiMocks.eventsList,
+        create: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+        rsvp: vi.fn(),
+      },
+      polls: {
+        list: apiMocks.pollsList,
+        castVote: vi.fn(),
+        confirm: vi.fn(),
+      },
+    },
+    tasks: {
+      list: apiMocks.tasksList,
+      update: apiMocks.tasksUpdate,
+      create: vi.fn(),
+      delete: vi.fn(),
+      updateOrder: vi.fn(),
+    },
+    channels: { list: apiMocks.channelsList },
+    auth: { users: apiMocks.usersList },
+  },
+}));
+
+vi.mock('../components/Layout/AppLayout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('../components/Channel/ChannelList', () => ({ default: () => <div /> }));
+vi.mock('../components/Layout/SidebarDmList', () => ({ default: () => <div /> }));
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 1, username: 'me', email: 'me@example.com' } }),
+}));
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({ showError: vi.fn(), showSuccess: vi.fn(), showInfo: vi.fn() }),
+}));
 
 const TODAY = new Date(2026, 4, 15);
 const CURSOR = new Date(2026, 4, 15);
@@ -77,6 +129,62 @@ function makeTask(id: number, dueAt: string | null, overrides: Partial<Task> = {
   };
 }
 
+function makeChannel(id: number, name: string): Channel {
+  return {
+    id,
+    name,
+    description: null,
+    topic: null,
+    createdBy: 1,
+    createdAt: '2026-04-30T00:00:00Z',
+    isPrivate: false,
+    postingPermission: 'everyone',
+    unreadCount: 0,
+  };
+}
+
+const users: User[] = [
+  {
+    id: 1,
+    username: 'me',
+    email: 'me@example.com',
+    avatarUrl: null,
+    displayName: 'Me',
+    location: null,
+    createdAt: '2026-04-30T00:00:00Z',
+    role: 'user',
+    isActive: true,
+    onboardingCompletedAt: '2026-04-30T00:00:00Z',
+  },
+  {
+    id: 2,
+    username: 'alice',
+    email: 'alice@example.com',
+    avatarUrl: null,
+    displayName: 'Alice',
+    location: null,
+    createdAt: '2026-04-30T00:00:00Z',
+    role: 'user',
+    isActive: true,
+    onboardingCompletedAt: '2026-04-30T00:00:00Z',
+  },
+];
+
+async function renderCalendarPage(initialDate = '2026-05-15') {
+  vi.resetModules();
+  const mod = await import('../pages/CalendarPage');
+  const CalendarPage = mod.default;
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[`/calendar?date=${initialDate}`]}>
+        <Routes>
+          <Route path="/calendar" element={<CalendarPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  });
+}
+
 const onEventClick = vi.fn();
 const onDayClick = vi.fn();
 const onTaskClick = vi.fn();
@@ -85,6 +193,19 @@ beforeEach(() => {
   onEventClick.mockClear();
   onDayClick.mockClear();
   onTaskClick.mockClear();
+  apiMocks.eventsList.mockReset();
+  apiMocks.tasksList.mockReset();
+  apiMocks.tasksUpdate.mockReset();
+  apiMocks.channelsList.mockReset();
+  apiMocks.usersList.mockReset();
+  apiMocks.pollsList.mockReset();
+  apiMocks.eventsList.mockResolvedValue({ events: [] });
+  apiMocks.tasksList.mockResolvedValue({ tasks: [] });
+  apiMocks.channelsList.mockResolvedValue({
+    channels: [makeChannel(10, 'general'), makeChannel(11, 'random')],
+  });
+  apiMocks.usersList.mockResolvedValue({ users });
+  apiMocks.pollsList.mockResolvedValue({ polls: [] });
 });
 
 describe('カレンダーへのタスク表示（Issue #267）', () => {
@@ -304,81 +425,300 @@ describe('カレンダーへのタスク表示（Issue #267）', () => {
 
   describe('WeekView', () => {
     describe('期限付きタスクの描画', () => {
-      it.skip('dueAt の日付・時刻に対応する位置に task-week-block-{id} が描画される', () => {
-        /* see #342 */
+      it('dueAt の日付・時刻に対応する位置に task-week-block-{id} が描画される', () => {
+        const task = makeTask(701, '2026-05-14T10:30:00Z', { title: 'Week task' });
+        render(
+          <WeekView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        const due = new Date(task.dueAt!);
+        const column = screen.getByTestId(
+          `week-column-${due.getFullYear()}-${due.getMonth()}-${due.getDate()}`,
+        );
+        const block = within(column).getByTestId('task-week-block-701');
+        expect(block).toHaveTextContent('Week task');
+        expect(Number(block.getAttribute('data-top'))).toBeGreaterThan(0);
       });
-      it.skip('時刻指定なし（00:00 等）のタスクは終日エリアまたは固定位置に描画される', () => {
-        /* see #342 */
+      it('時刻指定なし（00:00 等）のタスクは終日エリアまたは固定位置に描画される', () => {
+        const task = makeTask(702, new Date(2026, 4, 14, 0, 0, 0).toISOString(), {
+          title: 'All day task',
+        });
+        render(
+          <WeekView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        const block = screen.getByTestId('task-week-block-702');
+        expect(block).toHaveTextContent('All day task');
+        expect(Number(block.getAttribute('data-top'))).toBe(0);
       });
-      it.skip('週外のタスクは描画されない', () => {
-        /* see #342 */
+      it('週外のタスクは描画されない', () => {
+        const task = makeTask(703, '2026-05-30T10:00:00Z');
+        render(
+          <WeekView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        expect(screen.queryByTestId('task-week-block-703')).toBeNull();
       });
     });
 
     describe('色分け', () => {
-      it.skip('タスクブロックはイベントとは異なる色で描画される', () => {
-        /* see #342 */
+      it('タスクブロックはイベントとは異なる色で描画される', () => {
+        const ev = makeEvent(71, 10, '2026-05-14T10:00:00Z');
+        const task = makeTask(704, '2026-05-14T10:30:00Z');
+        render(
+          <WeekView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        expect(window.getComputedStyle(screen.getByTestId('task-week-block-704')).backgroundColor)
+          .not.toBe(window.getComputedStyle(screen.getByTestId('week-event-71')).backgroundColor);
       });
     });
 
     describe('クリック動作', () => {
-      it.skip('タスクブロックをクリックすると onTaskClick が該当タスクで呼ばれる', () => {
-        /* see #342 */
+      it('タスクブロックをクリックすると onTaskClick が該当タスクで呼ばれる', async () => {
+        const task = makeTask(705, '2026-05-14T10:30:00Z');
+        render(
+          <WeekView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        await userEvent.click(screen.getByTestId('task-week-block-705'));
+        expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: 705 }));
       });
     });
   });
 
   describe('AgendaView', () => {
     describe('期限付きタスクの描画', () => {
-      it.skip('期限日のグループにタスク行（agenda-task-{id}）が混在表示される', () => {
-        /* see #342 */
+      it('期限日のグループにタスク行（agenda-task-{id}）が混在表示される', () => {
+        const task = makeTask(801, new Date(2026, 4, 10, 15, 0, 0).toISOString(), {
+          title: 'Agenda task',
+        });
+        render(
+          <AgendaView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channels={[makeChannel(10, 'general')]}
+            channelColors={channelColors}
+            users={users}
+            currentUserId={1}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        const group = screen.getByTestId('agenda-group-2026-4-10');
+        expect(within(group).getByTestId('agenda-task-801')).toHaveTextContent('Agenda task');
       });
-      it.skip('日付グループはイベント＋タスクをまとめてソート（時刻昇順、時刻なしタスクは末尾）して並ぶ', () => {
-        /* see #342 */
+      it('日付グループはイベント＋タスクをまとめてソート（時刻昇順、時刻なしタスクは末尾）して並ぶ', () => {
+        const ev = makeEvent(81, 10, new Date(2026, 4, 10, 9, 0, 0).toISOString(), 'Morning event');
+        const task = makeTask(802, new Date(2026, 4, 10, 11, 0, 0).toISOString(), {
+          title: 'Mid task',
+        });
+        const allDayTask = makeTask(803, new Date(2026, 4, 10, 0, 0, 0).toISOString(), {
+          title: 'All day task',
+        });
+        render(
+          <AgendaView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            tasks={[allDayTask, task]}
+            channels={[makeChannel(10, 'general')]}
+            channelColors={channelColors}
+            users={users}
+            currentUserId={1}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        const group = screen.getByTestId('agenda-group-2026-4-10');
+        const rows = within(group)
+          .getAllByTestId(/agenda-(event|task)-/)
+          .map((row) => row.getAttribute('data-testid'))
+          .filter((id) => id && !id.startsWith('agenda-task-color-'));
+        expect(rows).toEqual([
+          'agenda-event-81',
+          'agenda-task-802',
+          'agenda-task-803',
+        ]);
       });
-      it.skip('cursor 月外の期限タスクはグルーピング対象外', () => {
-        /* see #342 */
+      it('cursor 月外の期限タスクはグルーピング対象外', () => {
+        const task = makeTask(804, '2026-06-01T10:00:00Z');
+        render(
+          <AgendaView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channels={[]}
+            channelColors={channelColors}
+            users={users}
+            currentUserId={1}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        expect(screen.queryByTestId('agenda-task-804')).toBeNull();
       });
     });
 
     describe('表示内容', () => {
-      it.skip('タスク行にはタイトル・担当者・「タスク」種別ラベル（チップ等）が表示される', () => {
-        /* see #342 */
+      it('タスク行にはタイトル・担当者・「タスク」種別ラベル（チップ等）が表示される', () => {
+        const task = makeTask(805, new Date(2026, 4, 10, 15, 0, 0).toISOString(), {
+          title: 'Review task',
+          assigneeUsername: 'alice',
+        });
+        render(
+          <AgendaView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channels={[]}
+            channelColors={channelColors}
+            users={users}
+            currentUserId={1}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        const row = screen.getByTestId('agenda-task-805');
+        expect(row).toHaveTextContent('Review task');
+        expect(row).toHaveTextContent('alice');
+        expect(row).toHaveTextContent('タスク');
       });
-      it.skip('タスク行のサイドバー色はタスク用カラーで描画される', () => {
-        /* see #342 */
+      it('タスク行のサイドバー色はタスク用カラーで描画される', () => {
+        const task = makeTask(806, new Date(2026, 4, 10, 15, 0, 0).toISOString());
+        render(
+          <AgendaView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channels={[]}
+            channelColors={channelColors}
+            users={users}
+            currentUserId={1}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        expect(window.getComputedStyle(screen.getByTestId('agenda-task-color-806')).backgroundColor)
+          .not.toBe('');
       });
     });
 
     describe('クリック動作', () => {
-      it.skip('タスク行をクリックすると onTaskClick が呼ばれる', () => {
-        /* see #342 */
+      it('タスク行をクリックすると onTaskClick が呼ばれる', async () => {
+        const task = makeTask(807, new Date(2026, 4, 10, 15, 0, 0).toISOString());
+        render(
+          <AgendaView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channels={[]}
+            channelColors={channelColors}
+            users={users}
+            currentUserId={1}
+            onEventClick={onEventClick}
+            onTaskClick={onTaskClick}
+          />,
+        );
+        await userEvent.click(screen.getByTestId('agenda-task-807'));
+        expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: 807 }));
       });
     });
   });
 
   describe('CalendarPage 統合', () => {
     describe('タスクのフェッチ', () => {
-      it.skip('カレンダー描画時に api.tasks.list が呼ばれて期限ありタスクが取得される', () => {
-        /* see #342 */
+      it('カレンダー描画時に api.tasks.list が呼ばれて期限ありタスクが取得される', async () => {
+        apiMocks.tasksList.mockResolvedValue({
+          tasks: [makeTask(901, '2026-05-15T10:00:00Z', { title: 'Fetched task' })],
+        });
+        await renderCalendarPage();
+        expect(apiMocks.tasksList).toHaveBeenCalledTimes(1);
+        expect(await screen.findByTestId('task-block-901')).toHaveTextContent('Fetched task');
       });
-      it.skip('タスク取得失敗時もイベントは正常に表示される（エラーで全体クラッシュしない）', () => {
-        /* see #342 */
+      it('タスク取得失敗時もイベントは正常に表示される（エラーで全体クラッシュしない）', async () => {
+        apiMocks.eventsList.mockResolvedValue({
+          events: [makeEvent(91, 10, '2026-05-15T10:00:00Z', 'Visible event')],
+        });
+        apiMocks.tasksList.mockRejectedValue(new Error('500'));
+        await renderCalendarPage();
+        expect(await screen.findByTestId('event-block-91')).toHaveTextContent('Visible event');
       });
     });
 
     describe('チャンネルフィルタ連携', () => {
-      it.skip('チャンネルフィルタ適用時、sourceChannelId が一致するタスクのみ表示される', () => {
-        /* see #342 */
+      it('チャンネルフィルタ適用時、sourceChannelId が一致するタスクのみ表示される', async () => {
+        apiMocks.tasksList.mockResolvedValue({
+          tasks: [
+            makeTask(902, '2026-05-15T10:00:00Z', { title: 'General', sourceChannelId: 10 }),
+            makeTask(903, '2026-05-15T11:00:00Z', { title: 'Random', sourceChannelId: 11 }),
+          ],
+        });
+        await renderCalendarPage();
+        await screen.findByTestId('task-block-902');
+        await userEvent.click(screen.getByLabelText('channel-filter-random'));
+        await waitFor(() => expect(screen.queryByTestId('task-block-903')).toBeNull());
+        expect(screen.getByTestId('task-block-902')).toBeInTheDocument();
       });
-      it.skip('未操作（全選択）時は sourceChannelId が null のタスクも表示される', () => {
-        /* see #342 */
+      it('未操作（全選択）時は sourceChannelId が null のタスクも表示される', async () => {
+        apiMocks.tasksList.mockResolvedValue({
+          tasks: [makeTask(904, '2026-05-15T10:00:00Z', { sourceChannelId: null })],
+        });
+        await renderCalendarPage();
+        expect(await screen.findByTestId('task-block-904')).toBeInTheDocument();
       });
     });
 
     describe('タスククリック時の挙動', () => {
-      it.skip('カレンダー上のタスククリックで EditTaskDialog が開く', () => {
-        /* see #342 */
+      it('カレンダー上のタスククリックで EditTaskDialog が開く', async () => {
+        apiMocks.tasksList.mockResolvedValue({
+          tasks: [makeTask(905, '2026-05-15T10:00:00Z', { title: 'Open dialog' })],
+        });
+        await renderCalendarPage();
+        fireEvent.click(await screen.findByTestId('task-block-905'));
+        expect(await screen.findByText('タスクを編集')).toBeInTheDocument();
+        expect(screen.getByDisplayValue('Open dialog')).toBeInTheDocument();
       });
     });
   });

--- a/packages/client/src/__tests__/CalendarTaskDragDrop.test.tsx
+++ b/packages/client/src/__tests__/CalendarTaskDragDrop.test.tsx
@@ -10,8 +10,7 @@
  *   - 失敗時ロールバック：API が reject されたら元の日付セルに戻ること
  *   - 成功時：api.tasks.update が { dueAt: <ISO of dropped day> } で呼ばれること
  *
- *   今回スコープ: MonthView の 8 項目 + PATCH 連携 4 項目を実装。
- *   WeekView は it.skip + Issue #342 参照で残課題として追跡する。
+ *   Issue #342: WeekView の Droppable 登録とドラッグによる dueAt 更新も検証対象に含める。
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -358,17 +357,60 @@ describe('カレンダー上でのタスクドラッグによる期限変更（I
 
   describe('WeekView 上のドラッグ', () => {
     describe('Droppable 登録', () => {
-      it.skip('各日付カラムが useDroppable の id として登録される（week-day-YYYY-M-D 形式）', () => {
-        /* see #342 */
+      it('各日付カラムが useDroppable の id として登録される（week-day-YYYY-M-D 形式）', async () => {
+        await renderPage('2026-05-15');
+        await act(async () => {
+          screen.getByLabelText('week').click();
+        });
+        const weekDayIds = droppableRegistrations.filter((id) => id.startsWith('week-day-'));
+        expect(weekDayIds).toHaveLength(7);
+        expect(weekDayIds).toContain('week-day-2026-4-15');
       });
     });
 
     describe('ドラッグ完了時の挙動', () => {
-      it.skip('別日カラムへドロップすると dueAt が更新される', () => {
-        /* see #342 */
+      it('別日カラムへドロップすると dueAt が更新される', async () => {
+        const task = makeTask(301, '2026-05-15T10:30:00Z');
+        tasksListMock.mockResolvedValue({ tasks: [task] });
+        tasksUpdateMock.mockResolvedValue({
+          task: { ...task, dueAt: '2026-05-17T10:30:00Z' },
+        });
+        await renderPage('2026-05-15');
+        await act(async () => {
+          screen.getByLabelText('week').click();
+        });
+
+        await act(async () => {
+          capturedOnDragEnd?.({
+            active: { id: 'task-301' },
+            over: { id: 'week-day-2026-4-17' },
+          });
+        });
+
+        expect(tasksUpdateMock).toHaveBeenCalledTimes(1);
+        expect(tasksUpdateMock.mock.calls[0][0]).toBe(301);
+        const payload = tasksUpdateMock.mock.calls[0][1] as { dueAt: string };
+        const due = new Date(payload.dueAt);
+        expect(due.getFullYear()).toBe(2026);
+        expect(due.getMonth()).toBe(4);
+        expect(due.getDate()).toBe(17);
       });
-      it.skip('同日カラムへドロップしても時刻は変更しない（日付のみ更新する仕様）', () => {
-        /* see #342 */
+      it('同日カラムへドロップしても時刻は変更しない（日付のみ更新する仕様）', async () => {
+        const task = makeTask(302, '2026-05-15T10:30:00Z');
+        tasksListMock.mockResolvedValue({ tasks: [task] });
+        await renderPage('2026-05-15');
+        await act(async () => {
+          screen.getByLabelText('week').click();
+        });
+
+        await act(async () => {
+          capturedOnDragEnd?.({
+            active: { id: 'task-302' },
+            over: { id: 'week-day-2026-4-15' },
+          });
+        });
+
+        expect(tasksUpdateMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/client/src/components/Calendar/AgendaView.tsx
+++ b/packages/client/src/components/Calendar/AgendaView.tsx
@@ -8,22 +8,42 @@ import RepeatIcon from '@mui/icons-material/Repeat';
 
 import { endOfMonth, fmtDateLong, fmtTime, sameDay, startOfMonth } from '../../utils/calendar';
 import { getAvatarColor } from '../../utils/avatarColor';
-import type { CalendarEvent, Channel, User } from '@chat-app/shared';
+import type { CalendarEvent, Channel, Task, User } from '@chat-app/shared';
 
 interface Props {
   cursor: Date;
   today: Date;
   events: CalendarEvent[];
+  tasks?: Task[];
   channels: Channel[];
   channelColors: Map<number, string>;
   users: User[];
   currentUserId: number;
   onEventClick: (event: CalendarEvent) => void;
+  onTaskClick?: (task: Task) => void;
 }
 
 interface Group {
   date: Date;
-  events: CalendarEvent[];
+  items: AgendaItem[];
+}
+
+type AgendaItem =
+  | { kind: 'event'; event: CalendarEvent; time: number }
+  | { kind: 'task'; task: Task; time: number; hasTime: boolean };
+
+const TASK_COLOR_BG = '#9c27b0';
+const TASK_COLOR_DONE = '#9e9e9e';
+const TASK_COLOR_IN_PROGRESS = '#ed6c02';
+
+function taskColorByStatus(status: Task['status']): string {
+  if (status === 'done') return TASK_COLOR_DONE;
+  if (status === 'in_progress') return TASK_COLOR_IN_PROGRESS;
+  return TASK_COLOR_BG;
+}
+
+function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
 }
 
 function rsvpChipColor(status: string): 'success' | 'warning' | 'error' | 'default' {
@@ -44,37 +64,62 @@ export function AgendaView({
   cursor,
   today,
   events,
+  tasks = [],
   channels,
   channelColors,
   users,
   currentUserId,
   onEventClick,
+  onTaskClick,
 }: Props) {
   const groups: Group[] = useMemo(() => {
     const start = startOfMonth(cursor).getTime();
     const end = endOfMonth(cursor).getTime();
-    const filtered = events
+    const eventItems: AgendaItem[] = events
       .filter((e) => {
         const t = Date.parse(e.startsAt);
         return t >= start && t <= end;
       })
-      .sort((a, b) => Date.parse(a.startsAt) - Date.parse(b.startsAt));
+      .map((event) => ({ kind: 'event' as const, event, time: Date.parse(event.startsAt) }));
+
+    const taskItems: AgendaItem[] = tasks
+      .filter((task) => {
+        if (!task.dueAt) return false;
+        const t = Date.parse(task.dueAt);
+        return t >= start && t <= end;
+      })
+      .map((task) => {
+        const due = new Date(task.dueAt!);
+        const hasTime =
+          due.getHours() !== 0 ||
+          due.getMinutes() !== 0 ||
+          due.getSeconds() !== 0 ||
+          due.getMilliseconds() !== 0;
+        return {
+          kind: 'task' as const,
+          task,
+          time: hasTime ? due.getTime() : Number.POSITIVE_INFINITY,
+          hasTime,
+        };
+      });
 
     const map = new Map<string, Group>();
-    for (const e of filtered) {
-      const d = new Date(e.startsAt);
-      const key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+    for (const item of [...eventItems, ...taskItems]) {
+      const d = new Date(item.kind === 'event' ? item.event.startsAt : item.task.dueAt!);
+      const key = dayKey(d);
       const existing = map.get(key);
       if (existing) {
-        existing.events.push(e);
+        existing.items.push(item);
       } else {
-        // 日付の正規化: 時刻 0 にして比較しやすくする
         const groupDate = new Date(d.getFullYear(), d.getMonth(), d.getDate());
-        map.set(key, { date: groupDate, events: [e] });
+        map.set(key, { date: groupDate, items: [item] });
       }
     }
-    return Array.from(map.values());
-  }, [events, cursor]);
+    for (const group of map.values()) {
+      group.items.sort((a, b) => a.time - b.time);
+    }
+    return Array.from(map.values()).sort((a, b) => a.date.getTime() - b.date.getTime());
+  }, [events, tasks, cursor]);
 
   const channelById = useMemo(() => {
     const m = new Map<number, Channel>();
@@ -144,12 +189,81 @@ export function AgendaView({
                   />
                 )}
                 <Typography variant="caption" color="text.secondary">
-                  {group.events.length} 件
+                  {group.items.length} 件
                 </Typography>
               </Box>
 
               <Stack spacing={1}>
-                {group.events.map((ev) => {
+                {group.items.map((item) => {
+                  if (item.kind === 'task') {
+                    const task = item.task;
+                    const due = task.dueAt ? new Date(task.dueAt) : null;
+                    const color = taskColorByStatus(task.status);
+                    return (
+                      <Box
+                        key={`task-${task.id}`}
+                        data-testid={`agenda-task-${task.id}`}
+                        onClick={() => onTaskClick?.(task)}
+                        sx={{
+                          display: 'flex',
+                          gap: 2,
+                          p: 1.5,
+                          borderRadius: 1.5,
+                          border: 1,
+                          borderColor: 'divider',
+                          cursor: 'pointer',
+                          transition: 'all 0.15s',
+                          '&:hover': {
+                            borderColor: 'primary.main',
+                            bgcolor: (t) =>
+                              t.palette.mode === 'dark'
+                                ? 'rgba(255,255,255,0.03)'
+                                : 'rgba(0,0,0,0.02)',
+                          },
+                        }}
+                      >
+                        <Box
+                          data-testid={`agenda-task-color-${task.id}`}
+                          sx={{
+                            width: 4,
+                            alignSelf: 'stretch',
+                            bgcolor: color,
+                            borderRadius: 2,
+                          }}
+                        />
+                        <Box sx={{ minWidth: 80 }}>
+                          <Typography sx={{ fontSize: 13, fontWeight: 600 }}>
+                            {due && item.hasTime ? fmtTime(due) : '終日'}
+                          </Typography>
+                        </Box>
+                        <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                          <Typography
+                            sx={{
+                              fontSize: 14,
+                              fontWeight: 600,
+                              mb: 0.5,
+                              textDecoration: task.status === 'done' ? 'line-through' : 'none',
+                            }}
+                          >
+                            {task.title}
+                          </Typography>
+                          <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                            <Chip
+                              label="タスク"
+                              size="small"
+                              sx={{ height: 20, fontSize: 11, bgcolor: color, color: '#fff' }}
+                            />
+                            {task.assigneeUsername && (
+                              <Typography variant="caption" color="text.secondary">
+                                {task.assigneeUsername}
+                              </Typography>
+                            )}
+                          </Stack>
+                        </Box>
+                      </Box>
+                    );
+                  }
+                  const ev = item.event;
                   const start = new Date(ev.startsAt);
                   const end = new Date(ev.endsAt);
                   const myAttendee = ev.attendees.find((a) => a.userId === currentUserId);
@@ -161,7 +275,7 @@ export function AgendaView({
                       : '#1976d2';
                   return (
                     <Box
-                      key={ev.id}
+                      key={`event-${ev.id}`}
                       data-testid={`agenda-event-${ev.id}`}
                       onClick={() => onEventClick(ev)}
                       sx={{

--- a/packages/client/src/components/Calendar/WeekView.tsx
+++ b/packages/client/src/components/Calendar/WeekView.tsx
@@ -3,9 +3,10 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { Box, Typography } from '@mui/material';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
 
 import { fmtTime, sameDay, startOfWeek, WEEKDAYS_JA } from '../../utils/calendar';
-import type { CalendarEvent } from '@chat-app/shared';
+import type { CalendarEvent, Task } from '@chat-app/shared';
 
 const HOUR_HEIGHT = 48;
 const START_HOUR = 7;
@@ -15,11 +16,228 @@ interface Props {
   cursor: Date;
   today: Date;
   events: CalendarEvent[];
+  tasks?: Task[];
   channelColors: Map<number, string>;
   onEventClick: (event: CalendarEvent) => void;
+  onTaskClick?: (task: Task) => void;
 }
 
-export function WeekView({ cursor, today, events, channelColors, onEventClick }: Props) {
+const TASK_COLOR_BG = '#9c27b0';
+const TASK_COLOR_DONE = '#9e9e9e';
+const TASK_COLOR_IN_PROGRESS = '#ed6c02';
+
+function taskColorByStatus(status: Task['status']): string {
+  if (status === 'done') return TASK_COLOR_DONE;
+  if (status === 'in_progress') return TASK_COLOR_IN_PROGRESS;
+  return TASK_COLOR_BG;
+}
+
+function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+interface WeekDayColumnProps {
+  day: Date;
+  dayIdx: number;
+  today: Date;
+  dayEvents: CalendarEvent[];
+  dayTasks: Task[];
+  channelColors: Map<number, string>;
+  nowTop: number | null;
+  onEventClick: (event: CalendarEvent) => void;
+  onTaskClick?: (task: Task) => void;
+  hours: number[];
+}
+
+function WeekDayColumn({
+  day,
+  dayIdx,
+  today,
+  dayEvents,
+  dayTasks,
+  channelColors,
+  nowTop,
+  onEventClick,
+  onTaskClick,
+  hours,
+}: WeekDayColumnProps) {
+  const key = dayKey(day);
+  const { setNodeRef } = useDroppable({ id: `week-day-${key}` });
+  const isToday = sameDay(day, today);
+
+  return (
+    <Box
+      ref={setNodeRef}
+      key={dayIdx}
+      data-testid={`week-column-${key}`}
+      sx={{
+        position: 'relative',
+        borderLeft: 1,
+        borderColor: 'divider',
+        bgcolor: isToday
+          ? (t) =>
+              t.palette.mode === 'dark'
+                ? 'rgba(25,118,210,0.08)'
+                : 'rgba(25,118,210,0.04)'
+          : 'transparent',
+      }}
+    >
+      {hours.map((h) => (
+        <Box
+          key={h}
+          sx={{
+            height: HOUR_HEIGHT,
+            borderBottom: 1,
+            borderColor: 'divider',
+          }}
+        />
+      ))}
+
+      {dayEvents.map((ev) => {
+        const start = new Date(ev.startsAt);
+        const end = new Date(ev.endsAt);
+        const startMin = (start.getHours() - START_HOUR) * 60 + start.getMinutes();
+        const endMin = (end.getHours() - START_HOUR) * 60 + end.getMinutes();
+        const top = (startMin / 60) * HOUR_HEIGHT;
+        const height = Math.max(22, ((endMin - startMin) / 60) * HOUR_HEIGHT);
+        const color =
+          ev.channelId !== null ? (channelColors.get(ev.channelId) ?? '#1976d2') : '#1976d2';
+        return (
+          <Box
+            key={ev.id}
+            data-testid={`week-event-${ev.id}`}
+            data-top={top}
+            data-height={height}
+            onClick={() => onEventClick(ev)}
+            sx={{
+              position: 'absolute',
+              left: 4,
+              right: 4,
+              top,
+              height,
+              bgcolor: color,
+              color: '#fff',
+              borderRadius: 0.75,
+              px: 0.75,
+              py: 0.25,
+              cursor: 'pointer',
+              overflow: 'hidden',
+              boxShadow: 1,
+              borderLeft: `3px solid ${color}`,
+              '&:hover': { opacity: 0.9 },
+            }}
+          >
+            <Typography sx={{ fontSize: 11, opacity: 0.9, lineHeight: 1.2 }}>
+              {fmtTime(start)}–{fmtTime(end)}
+            </Typography>
+            <Typography sx={{ fontSize: 12, fontWeight: 600, lineHeight: 1.3, mt: 0.25 }}>
+              {(ev.recurrenceRule !== null || ev.recurrenceMasterId !== null) && (
+                <RepeatIcon
+                  data-testid={`week-event-recurrence-icon-${ev.id}`}
+                  sx={{ fontSize: 11, mr: 0.25, verticalAlign: 'text-bottom' }}
+                />
+              )}
+              {ev.title}
+            </Typography>
+          </Box>
+        );
+      })}
+
+      {dayTasks.map((task) => (
+        <DraggableWeekTaskBlock key={task.id} task={task} onTaskClick={onTaskClick} />
+      ))}
+
+      {isToday && nowTop !== null && (
+        <Box
+          data-testid={`week-now-line-${key}`}
+          sx={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: nowTop,
+            height: 2,
+            bgcolor: 'error.main',
+            zIndex: 5,
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
+function DraggableWeekTaskBlock({
+  task,
+  onTaskClick,
+}: {
+  task: Task;
+  onTaskClick?: (task: Task) => void;
+}) {
+  const { setNodeRef, attributes, listeners, isDragging } = useDraggable({ id: `task-${task.id}` });
+  const due = task.dueAt ? new Date(task.dueAt) : null;
+  const minutes = due ? due.getHours() * 60 + due.getMinutes() : 0;
+  const top = due
+    ? Math.max(0, ((minutes - START_HOUR * 60) / 60) * HOUR_HEIGHT)
+    : 0;
+  const titleAttr = [
+    task.title,
+    task.assigneeUsername ?? '',
+    due ? `${due.getFullYear()}/${due.getMonth() + 1}/${due.getDate()} ${fmtTime(due)}` : '',
+  ]
+    .filter(Boolean)
+    .join(' / ');
+
+  return (
+    <Box
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      data-testid={`task-week-block-${task.id}`}
+      data-task-status={task.status}
+      data-top={top}
+      title={titleAttr}
+      onClick={(e) => {
+        e.stopPropagation();
+        onTaskClick?.(task);
+      }}
+      sx={{
+        position: 'absolute',
+        left: 8,
+        right: 8,
+        top,
+        minHeight: 24,
+        bgcolor: taskColorByStatus(task.status),
+        color: '#fff',
+        borderRadius: 0.75,
+        px: 0.75,
+        py: 0.25,
+        cursor: 'grab',
+        overflow: 'hidden',
+        boxShadow: 1,
+        opacity: isDragging ? 0.5 : 1,
+        textDecoration: task.status === 'done' ? 'line-through' : 'none',
+        zIndex: 4,
+        '&:hover': { opacity: 0.9 },
+      }}
+    >
+      <Typography sx={{ fontSize: 11, opacity: 0.9, lineHeight: 1.2 }}>
+        {due ? fmtTime(due) : 'タスク'}
+      </Typography>
+      <Typography sx={{ fontSize: 12, fontWeight: 600, lineHeight: 1.3 }}>
+        {task.title}
+      </Typography>
+    </Box>
+  );
+}
+
+export function WeekView({
+  cursor,
+  today,
+  events,
+  tasks = [],
+  channelColors,
+  onEventClick,
+  onTaskClick,
+}: Props) {
   const weekStart = useMemo(() => startOfWeek(cursor), [cursor]);
   const days = useMemo(() => {
     const out: Date[] = [];
@@ -38,6 +256,22 @@ export function WeekView({ cursor, today, events, channelColors, onEventClick }:
   }, []);
 
   const todayInWeek = useMemo(() => days.some((d) => sameDay(d, today)), [days, today]);
+
+  const tasksByDay = useMemo(() => {
+    const map = new Map<string, Task[]>();
+    for (const task of tasks) {
+      if (!task.dueAt) continue;
+      const due = new Date(task.dueAt);
+      const key = dayKey(due);
+      const list = map.get(key) ?? [];
+      list.push(task);
+      map.set(key, list);
+    }
+    for (const list of map.values()) {
+      list.sort((a, b) => Date.parse(a.dueAt ?? '') - Date.parse(b.dueAt ?? ''));
+    }
+    return map;
+  }, [tasks]);
 
   const nowTop = useMemo(() => {
     if (today.getHours() < START_HOUR || today.getHours() >= END_HOUR) return null;
@@ -154,103 +388,21 @@ export function WeekView({ cursor, today, events, channelColors, onEventClick }:
           {/* 各日のカラム */}
           {days.map((day, dayIdx) => {
             const dayEvents = events.filter((e) => sameDay(new Date(e.startsAt), day));
-            const isToday = sameDay(day, today);
+            const dayTasks = tasksByDay.get(dayKey(day)) ?? [];
             return (
-              <Box
+              <WeekDayColumn
                 key={dayIdx}
-                data-testid={`week-column-${day.getFullYear()}-${day.getMonth()}-${day.getDate()}`}
-                sx={{
-                  position: 'relative',
-                  borderLeft: 1,
-                  borderColor: 'divider',
-                  bgcolor: isToday
-                    ? (t) =>
-                        t.palette.mode === 'dark'
-                          ? 'rgba(25,118,210,0.08)'
-                          : 'rgba(25,118,210,0.04)'
-                    : 'transparent',
-                }}
-              >
-                {hours.map((h) => (
-                  <Box
-                    key={h}
-                    sx={{
-                      height: HOUR_HEIGHT,
-                      borderBottom: 1,
-                      borderColor: 'divider',
-                    }}
-                  />
-                ))}
-
-                {/* イベントブロック */}
-                {dayEvents.map((ev) => {
-                  const start = new Date(ev.startsAt);
-                  const end = new Date(ev.endsAt);
-                  const startMin = (start.getHours() - START_HOUR) * 60 + start.getMinutes();
-                  const endMin = (end.getHours() - START_HOUR) * 60 + end.getMinutes();
-                  const top = (startMin / 60) * HOUR_HEIGHT;
-                  const height = Math.max(22, ((endMin - startMin) / 60) * HOUR_HEIGHT);
-                  const color =
-                    ev.channelId !== null
-                      ? (channelColors.get(ev.channelId) ?? '#1976d2')
-                      : '#1976d2';
-                  return (
-                    <Box
-                      key={ev.id}
-                      data-testid={`week-event-${ev.id}`}
-                      data-top={top}
-                      data-height={height}
-                      onClick={() => onEventClick(ev)}
-                      sx={{
-                        position: 'absolute',
-                        left: 4,
-                        right: 4,
-                        top,
-                        height,
-                        bgcolor: color,
-                        color: '#fff',
-                        borderRadius: 0.75,
-                        px: 0.75,
-                        py: 0.25,
-                        cursor: 'pointer',
-                        overflow: 'hidden',
-                        boxShadow: 1,
-                        borderLeft: `3px solid ${color}`,
-                        '&:hover': { opacity: 0.9 },
-                      }}
-                    >
-                      <Typography sx={{ fontSize: 11, opacity: 0.9, lineHeight: 1.2 }}>
-                        {fmtTime(start)}–{fmtTime(end)}
-                      </Typography>
-                      <Typography sx={{ fontSize: 12, fontWeight: 600, lineHeight: 1.3, mt: 0.25 }}>
-                        {(ev.recurrenceRule !== null || ev.recurrenceMasterId !== null) && (
-                          <RepeatIcon
-                            data-testid={`week-event-recurrence-icon-${ev.id}`}
-                            sx={{ fontSize: 11, mr: 0.25, verticalAlign: 'text-bottom' }}
-                          />
-                        )}
-                        {ev.title}
-                      </Typography>
-                    </Box>
-                  );
-                })}
-
-                {/* now line */}
-                {isToday && nowTop !== null && (
-                  <Box
-                    data-testid={`week-now-line-${day.getFullYear()}-${day.getMonth()}-${day.getDate()}`}
-                    sx={{
-                      position: 'absolute',
-                      left: 0,
-                      right: 0,
-                      top: nowTop,
-                      height: 2,
-                      bgcolor: 'error.main',
-                      zIndex: 5,
-                    }}
-                  />
-                )}
-              </Box>
+                day={day}
+                dayIdx={dayIdx}
+                today={today}
+                dayEvents={dayEvents}
+                dayTasks={dayTasks}
+                channelColors={channelColors}
+                nowTop={nowTop}
+                onEventClick={onEventClick}
+                onTaskClick={onTaskClick}
+                hours={hours}
+              />
             );
           })}
         </Box>

--- a/packages/client/src/pages/CalendarPage.tsx
+++ b/packages/client/src/pages/CalendarPage.tsx
@@ -153,14 +153,14 @@ function CalendarContent({
     const activeStr = String(activeId);
     const overStr = String(overId);
     if (!activeStr.startsWith('task-')) return;
-    if (!overStr.startsWith('day-')) return;
+    if (!overStr.startsWith('day-') && !overStr.startsWith('week-day-')) return;
 
     const taskId = Number(activeStr.replace('task-', ''));
     const target = tasks.find((t) => t.id === taskId);
     if (!target || !target.dueAt) return;
 
-    // day-YYYY-M-D を分解（M は 0-based、D は 1-based）
-    const m = overStr.match(/^day-(\d+)-(\d+)-(\d+)$/);
+    // day-YYYY-M-D / week-day-YYYY-M-D を分解（M は 0-based、D は 1-based）
+    const m = overStr.match(/^(?:week-)?day-(\d+)-(\d+)-(\d+)$/);
     if (!m) return;
     const year = Number(m[1]);
     const month = Number(m[2]);
@@ -329,24 +329,30 @@ function CalendarContent({
             </DndContext>
           )}
           {view === 'week' && (
-            <WeekView
-              cursor={cursor}
-              today={today}
-              events={filteredEvents}
-              channelColors={channelColors}
-              onEventClick={handleEventClick}
-            />
+            <DndContext onDragEnd={(e) => void handleTaskDragEnd(e)}>
+              <WeekView
+                cursor={cursor}
+                today={today}
+                events={filteredEvents}
+                tasks={filteredTasks}
+                channelColors={channelColors}
+                onEventClick={handleEventClick}
+                onTaskClick={(t) => setEditingTask(t)}
+              />
+            </DndContext>
           )}
           {view === 'agenda' && (
             <AgendaView
               cursor={cursor}
               today={today}
               events={filteredEvents}
+              tasks={filteredTasks}
               channels={channels}
               channelColors={channelColors}
               users={users}
               currentUserId={currentUserId}
               onEventClick={handleEventClick}
+              onTaskClick={(t) => setEditingTask(t)}
             />
           )}
         </Box>


### PR DESCRIPTION
## 概要
Issue #342 の対応として、カレンダーの WeekView / AgendaView / CalendarPage に期限付きタスクの表示・クリック・ドラッグ更新を統合しました。

## 変更内容
- WeekView に tasks prop と onTaskClick を追加し、期限付きタスクを task-week-block-{id} として表示
- WeekView の各日付カラムを week-day-YYYY-M-D Droppable として登録し、ドラッグによる dueAt 更新に対応
- AgendaView にイベント＋タスクの混在グルーピングと時刻順ソートを追加
- CalendarPage で api.tasks.list の結果を Week / Agenda に連携し、チャンネルフィルタとタスク編集ダイアログ起動を統合
- PR #340 で it.skip として残っていた対象19件を実テスト化

## 影響範囲
- packages/client/src/components/Calendar/WeekView.tsx
- packages/client/src/components/Calendar/AgendaView.tsx
- packages/client/src/pages/CalendarPage.tsx
- カレンダーのタスク表示・タスククリック・期限日ドラッグ更新の UI 挙動

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする
  - npm run test: client 2333件成功
  - 対象テスト: CalendarTaskDisplay.test.tsx / CalendarTaskDragDrop.test.tsx 41件成功
- [x] バックエンドユニットテストがすべてパスする
  - npm run test: server 1669件成功
- [x] ビルドが正常に完了すること
  - npm run build 成功
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue
Fixes #342

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] it.todo / 空ボディの it が残っていない（it.skip の場合は別 issue 参照コメントを残す）