### PR TITLE
feat: サマリーカードのミニ内訳表示 (#320)

### DIFF
--- a/packages/client/src/__tests__/InboxPage.test.tsx
+++ b/packages/client/src/__tests__/InboxPage.test.tsx
@@ -117,6 +117,7 @@ const mockRemindersList = vi.hoisted(() => vi.fn());
 const mockDraftsGetAll = vi.hoisted(() => vi.fn());
 const mockMessagesSearch = vi.hoisted(() => vi.fn());
 const mockThreadsListSubscribed = vi.hoisted(() => vi.fn());
+const mockDmListConversations = vi.hoisted(() => vi.fn());
 
 vi.mock('../api/client', () => ({
   api: {
@@ -127,6 +128,7 @@ vi.mock('../api/client', () => ({
     drafts: { getAll: mockDraftsGetAll },
     messages: { search: mockMessagesSearch },
     threads: { listSubscribed: mockThreadsListSubscribed },
+    dm: { listConversations: mockDmListConversations },
   },
 }));
 
@@ -145,6 +147,8 @@ beforeEach(() => {
   mockMessagesSearch.mockResolvedValue({ messages: [] });
   mockThreadsListSubscribed.mockReset();
   mockThreadsListSubscribed.mockResolvedValue({ threads: [] });
+  mockDmListConversations.mockReset();
+  mockDmListConversations.mockResolvedValue({ conversations: [] });
 });
 
 function renderInbox(initialPath: string = '/') {

--- a/packages/client/src/__tests__/InboxUnreadFilter.test.tsx
+++ b/packages/client/src/__tests__/InboxUnreadFilter.test.tsx
@@ -81,6 +81,7 @@ const mockRemindersList = vi.hoisted(() => vi.fn());
 const mockDraftsGetAll = vi.hoisted(() => vi.fn());
 const mockMessagesSearch = vi.hoisted(() => vi.fn());
 const mockThreadsListSubscribed = vi.hoisted(() => vi.fn());
+const mockDmListConversations = vi.hoisted(() => vi.fn());
 
 vi.mock('../api/client', () => ({
   api: {
@@ -91,6 +92,7 @@ vi.mock('../api/client', () => ({
     drafts: { getAll: mockDraftsGetAll },
     messages: { search: mockMessagesSearch },
     threads: { listSubscribed: mockThreadsListSubscribed },
+    dm: { listConversations: mockDmListConversations },
   },
 }));
 
@@ -102,6 +104,7 @@ beforeEach(() => {
   mockDraftsGetAll.mockResolvedValue({ drafts: [] });
   mockMessagesSearch.mockResolvedValue({ messages: [] });
   mockThreadsListSubscribed.mockResolvedValue({ threads: [] });
+  mockDmListConversations.mockResolvedValue({ conversations: [] });
   localStorage.clear();
 });
 

--- a/packages/client/src/__tests__/SummaryCards.test.tsx
+++ b/packages/client/src/__tests__/SummaryCards.test.tsx
@@ -1,13 +1,27 @@
 /**
- * components/Inbox/SummaryCards.tsx のユニットテスト (Step 6a)
+ * components/Inbox/SummaryCards.tsx のユニットテスト (Step 6a + Issue #320)
  *
  * 純粋コンポーネントとして data を直接渡してテストする。
  * Promise 解決は親 (InboxPage 内 Suspense ラッパー) で行うため Suspense は不要。
+ *
+ * Issue #320: サマリーカードの意味を補足するミニ内訳
+ * - 未読カード: チャンネル・DM・スレッド別の件数内訳を表示
+ * - 今日の予定カード: 自分が主催 / 参加 の内訳を表示
+ * - 未完タスクカード: 自分担当 / その他 の内訳を表示
+ * - 各内訳チップクリックで対応ビューへナビゲーション
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import SummaryCards, { type SummaryData } from '../components/Inbox/SummaryCards';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
 
 describe('SummaryCards (Step 6a)', () => {
   it('未読数: channels の unreadCount 合計が表示される', () => {
@@ -55,5 +69,38 @@ describe('SummaryCards (Step 6a)', () => {
     ] as unknown as SummaryData;
     render(<SummaryCards data={data} />);
     expect(screen.getByTestId('summary-tasks')).toHaveTextContent('2');
+  });
+});
+
+// Issue #320: サマリーカードのミニ内訳表示
+describe('SummaryCards 内訳表示 (Issue #320)', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  describe('未読カードの内訳チップ', () => {
+    it.todo('チャンネル未読件数のチップが表示される');
+    it.todo('DM未読件数のチップが表示される');
+    it.todo('スレッド未読件数のチップが表示される');
+    it.todo('すべての未読が0のときは内訳チップが表示されない');
+    it.todo('チャンネル未読チップをクリックすると /?tab=mentions に遷移する');
+    it.todo('DM未読チップをクリックすると /dm に遷移する');
+    it.todo('スレッド未読チップをクリックすると /?tab=threads に遷移する');
+  });
+
+  describe('今日の予定カードの内訳チップ', () => {
+    it.todo('自分が主催のイベント件数のチップが表示される');
+    it.todo('自分が参加者（主催以外）のイベント件数のチップが表示される');
+    it.todo('予定が0件のときは内訳チップが表示されない');
+    it.todo('主催イベントチップをクリックすると /calendar?date=today&role=organizer に遷移する');
+    it.todo('参加イベントチップをクリックすると /calendar?date=today&role=attendee に遷移する');
+  });
+
+  describe('未完タスクカードの内訳チップ', () => {
+    it.todo('自分担当タスク件数のチップが表示される');
+    it.todo('その他（担当者が自分以外）のタスク件数のチップが表示される');
+    it.todo('未完タスクが0件のときは内訳チップが表示されない');
+    it.todo('自分担当チップをクリックすると /tasks?status=open&mine=true に遷移する');
+    it.todo('その他チップをクリックすると /tasks?status=open&mine=false に遷移する');
   });
 });

--- a/packages/client/src/__tests__/SummaryCards.test.tsx
+++ b/packages/client/src/__tests__/SummaryCards.test.tsx
@@ -78,29 +78,246 @@ describe('SummaryCards 内訳表示 (Issue #320)', () => {
     mockNavigate.mockClear();
   });
 
+  // 未読カードのテスト用データ: チャンネル3件・DM2件・スレッド1件の未読
+  const unreadData = [
+    {
+      channels: [
+        { id: 1, name: 'ch-a', unreadCount: 2 },
+        { id: 2, name: 'ch-b', unreadCount: 1 },
+      ],
+      dmUnreadCount: 2,
+      threadUnreadCount: 1,
+    },
+    { events: [] },
+    { tasks: [] },
+  ] as unknown as SummaryData;
+
+  // 予定カードのテスト用データ: 主催1件・参加2件
+  const ORGANIZER_ID = 10;
+  const eventsData = [
+    { channels: [], dmUnreadCount: 0, threadUnreadCount: 0 },
+    {
+      events: [
+        { id: 1, title: '主催イベント', organizerId: ORGANIZER_ID, attendees: [] },
+        {
+          id: 2,
+          title: '参加イベントA',
+          organizerId: 99,
+          attendees: [{ userId: ORGANIZER_ID, status: 'accepted' }],
+        },
+        {
+          id: 3,
+          title: '参加イベントB',
+          organizerId: 99,
+          attendees: [{ userId: ORGANIZER_ID, status: 'maybe' }],
+        },
+      ],
+    },
+    { tasks: [] },
+  ] as unknown as SummaryData;
+
+  // タスクカードのテスト用データ: 自分担当2件・その他1件・完了1件
+  const MY_USER_ID = 42;
+  const tasksData = [
+    { channels: [], dmUnreadCount: 0, threadUnreadCount: 0 },
+    { events: [] },
+    {
+      tasks: [
+        { id: 1, status: 'todo', assigneeId: MY_USER_ID },
+        { id: 2, status: 'in_progress', assigneeId: MY_USER_ID },
+        { id: 3, status: 'todo', assigneeId: 99 },
+        { id: 4, status: 'done', assigneeId: MY_USER_ID },
+      ],
+    },
+  ] as unknown as SummaryData;
+
   describe('未読カードの内訳チップ', () => {
-    it.todo('チャンネル未読件数のチップが表示される');
-    it.todo('DM未読件数のチップが表示される');
-    it.todo('スレッド未読件数のチップが表示される');
-    it.todo('すべての未読が0のときは内訳チップが表示されない');
-    it.todo('チャンネル未読チップをクリックすると /?tab=mentions に遷移する');
-    it.todo('DM未読チップをクリックすると /dm に遷移する');
-    it.todo('スレッド未読チップをクリックすると /?tab=threads に遷移する');
+    it('チャンネル未読件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={unreadData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      // チャンネル未読合計 3 件のチップが表示される
+      expect(screen.getByTestId('chip-unread-channel')).toHaveTextContent('3');
+    });
+
+    it('DM未読件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={unreadData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      expect(screen.getByTestId('chip-unread-dm')).toHaveTextContent('2');
+    });
+
+    it('スレッド未読件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={unreadData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      expect(screen.getByTestId('chip-unread-thread')).toHaveTextContent('1');
+    });
+
+    it('すべての未読が0のときは内訳チップが表示されない', () => {
+      const zeroData = [
+        { channels: [], dmUnreadCount: 0, threadUnreadCount: 0 },
+        { events: [] },
+        { tasks: [] },
+      ] as unknown as SummaryData;
+      render(
+        <MemoryRouter>
+          <SummaryCards data={zeroData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      expect(screen.queryByTestId('chip-unread-channel')).toBeNull();
+      expect(screen.queryByTestId('chip-unread-dm')).toBeNull();
+      expect(screen.queryByTestId('chip-unread-thread')).toBeNull();
+    });
+
+    it('チャンネル未読チップをクリックすると /?tab=mentions に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={unreadData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-unread-channel'));
+      expect(mockNavigate).toHaveBeenCalledWith('/?tab=mentions');
+    });
+
+    it('DM未読チップをクリックすると /dm に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={unreadData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-unread-dm'));
+      expect(mockNavigate).toHaveBeenCalledWith('/dm');
+    });
+
+    it('スレッド未読チップをクリックすると /?tab=threads に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={unreadData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-unread-thread'));
+      expect(mockNavigate).toHaveBeenCalledWith('/?tab=threads');
+    });
   });
 
   describe('今日の予定カードの内訳チップ', () => {
-    it.todo('自分が主催のイベント件数のチップが表示される');
-    it.todo('自分が参加者（主催以外）のイベント件数のチップが表示される');
-    it.todo('予定が0件のときは内訳チップが表示されない');
-    it.todo('主催イベントチップをクリックすると /calendar?date=today&role=organizer に遷移する');
-    it.todo('参加イベントチップをクリックすると /calendar?date=today&role=attendee に遷移する');
+    it('自分が主催のイベント件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={eventsData} currentUserId={ORGANIZER_ID} />
+        </MemoryRouter>,
+      );
+      // 主催イベントは1件
+      expect(screen.getByTestId('chip-event-organizer')).toHaveTextContent('1');
+    });
+
+    it('自分が参加者（主催以外）のイベント件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={eventsData} currentUserId={ORGANIZER_ID} />
+        </MemoryRouter>,
+      );
+      // 参加イベントは2件
+      expect(screen.getByTestId('chip-event-attendee')).toHaveTextContent('2');
+    });
+
+    it('予定が0件のときは内訳チップが表示されない', () => {
+      const noEventsData = [
+        { channels: [], dmUnreadCount: 0, threadUnreadCount: 0 },
+        { events: [] },
+        { tasks: [] },
+      ] as unknown as SummaryData;
+      render(
+        <MemoryRouter>
+          <SummaryCards data={noEventsData} currentUserId={1} />
+        </MemoryRouter>,
+      );
+      expect(screen.queryByTestId('chip-event-organizer')).toBeNull();
+      expect(screen.queryByTestId('chip-event-attendee')).toBeNull();
+    });
+
+    it('主催イベントチップをクリックすると /calendar?date=today&role=organizer に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={eventsData} currentUserId={ORGANIZER_ID} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-event-organizer'));
+      expect(mockNavigate).toHaveBeenCalledWith('/calendar?date=today&role=organizer');
+    });
+
+    it('参加イベントチップをクリックすると /calendar?date=today&role=attendee に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={eventsData} currentUserId={ORGANIZER_ID} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-event-attendee'));
+      expect(mockNavigate).toHaveBeenCalledWith('/calendar?date=today&role=attendee');
+    });
   });
 
   describe('未完タスクカードの内訳チップ', () => {
-    it.todo('自分担当タスク件数のチップが表示される');
-    it.todo('その他（担当者が自分以外）のタスク件数のチップが表示される');
-    it.todo('未完タスクが0件のときは内訳チップが表示されない');
-    it.todo('自分担当チップをクリックすると /tasks?status=open&mine=true に遷移する');
-    it.todo('その他チップをクリックすると /tasks?status=open&mine=false に遷移する');
+    it('自分担当タスク件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={tasksData} currentUserId={MY_USER_ID} />
+        </MemoryRouter>,
+      );
+      // 自分担当の未完タスクは2件（done は除外）
+      expect(screen.getByTestId('chip-task-mine')).toHaveTextContent('2');
+    });
+
+    it('その他（担当者が自分以外）のタスク件数のチップが表示される', () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={tasksData} currentUserId={MY_USER_ID} />
+        </MemoryRouter>,
+      );
+      // 他者担当の未完タスクは1件
+      expect(screen.getByTestId('chip-task-others')).toHaveTextContent('1');
+    });
+
+    it('未完タスクが0件のときは内訳チップが表示されない', () => {
+      const noTasksData = [
+        { channels: [], dmUnreadCount: 0, threadUnreadCount: 0 },
+        { events: [] },
+        { tasks: [{ id: 1, status: 'done', assigneeId: MY_USER_ID }] },
+      ] as unknown as SummaryData;
+      render(
+        <MemoryRouter>
+          <SummaryCards data={noTasksData} currentUserId={MY_USER_ID} />
+        </MemoryRouter>,
+      );
+      expect(screen.queryByTestId('chip-task-mine')).toBeNull();
+      expect(screen.queryByTestId('chip-task-others')).toBeNull();
+    });
+
+    it('自分担当チップをクリックすると /tasks?status=open&mine=true に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={tasksData} currentUserId={MY_USER_ID} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-task-mine'));
+      expect(mockNavigate).toHaveBeenCalledWith('/tasks?status=open&mine=true');
+    });
+
+    it('その他チップをクリックすると /tasks?status=open&mine=false に遷移する', async () => {
+      render(
+        <MemoryRouter>
+          <SummaryCards data={tasksData} currentUserId={MY_USER_ID} />
+        </MemoryRouter>,
+      );
+      await userEvent.click(screen.getByTestId('chip-task-others'));
+      expect(mockNavigate).toHaveBeenCalledWith('/tasks?status=open&mine=false');
+    });
   });
 });

--- a/packages/client/src/__tests__/SummaryCardsDrilldown.test.tsx
+++ b/packages/client/src/__tests__/SummaryCardsDrilldown.test.tsx
@@ -27,6 +27,8 @@ const testData: SummaryData = [
       { id: 1, name: 'a', unreadCount: 3 } as never,
       { id: 2, name: 'b', unreadCount: 5 } as never,
     ],
+    dmUnreadCount: 0,
+    threadUnreadCount: 0,
   },
   {
     events: [{ id: 1, title: 'イベント1' } as never, { id: 2, title: 'イベント2' } as never],

--- a/packages/client/src/components/Inbox/SummaryCards.tsx
+++ b/packages/client/src/components/Inbox/SummaryCards.tsx
@@ -1,10 +1,16 @@
-import { Box, Card, CardActionArea, CardContent, Typography } from '@mui/material';
+import { Box, Card, CardActionArea, CardContent, Chip, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import type { CalendarEvent, Channel, Task } from '@chat-app/shared';
 
-export type SummaryData = [{ channels: Channel[] }, { events: CalendarEvent[] }, { tasks: Task[] }];
+export type SummaryData = [
+  { channels: Channel[]; dmUnreadCount: number; threadUnreadCount: number },
+  { events: CalendarEvent[] },
+  { tasks: Task[] },
+];
 
 interface Props {
   data: SummaryData;
+  currentUserId?: number;
   onUnreadClick?: () => void;
   onEventsClick?: () => void;
   onTasksClick?: () => void;
@@ -16,17 +22,47 @@ interface Props {
  * 純粋コンポーネントとして data を受け取って描画するだけにし、Promise の解決は親
  * (InboxPage の Suspense ラッパー) に委譲する責務分離パターン。
  *
- * 各カードは onClick ハンドラを受け取り、クリック時に対応するビューへ遷移できる。
+ * Issue #320: 各カードに内訳チップを追加。件数 0 のチップは非表示。
+ * チップクリックで対応ビューへ navigate する。
  */
-export default function SummaryCards({ data, onUnreadClick, onEventsClick, onTasksClick }: Props) {
-  const [{ channels }, { events }, { tasks }] = data;
+export default function SummaryCards({
+  data,
+  currentUserId,
+  onUnreadClick,
+  onEventsClick,
+  onTasksClick,
+}: Props) {
+  const navigate = useNavigate();
+  const [{ channels, dmUnreadCount = 0, threadUnreadCount = 0 }, { events }, { tasks }] = data;
 
-  const unreadTotal = channels.reduce((sum, ch) => sum + (ch.unreadCount ?? 0), 0);
+  const channelUnreadCount = channels.reduce((sum, ch) => sum + (ch.unreadCount ?? 0), 0);
+  const unreadTotal = channelUnreadCount + dmUnreadCount + threadUnreadCount;
   const eventsCount = events.length;
   const todoCount = tasks.filter((t) => t.status !== 'done').length;
 
+  // 今日の予定の主催 / 参加 内訳
+  const organizerCount = currentUserId
+    ? events.filter((e) => e.organizerId === currentUserId).length
+    : 0;
+  const attendeeCount = currentUserId
+    ? events.filter(
+        (e) =>
+          e.organizerId !== currentUserId && e.attendees.some((a) => a.userId === currentUserId),
+      ).length
+    : 0;
+
+  // 未完タスクの自分担当 / その他 内訳
+  const incompleteTasks = tasks.filter((t) => t.status !== 'done');
+  const myTaskCount = currentUserId
+    ? incompleteTasks.filter((t) => t.assigneeId === currentUserId).length
+    : 0;
+  const othersTaskCount = currentUserId
+    ? incompleteTasks.filter((t) => t.assigneeId !== currentUserId).length
+    : incompleteTasks.length;
+
   return (
     <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 2 }}>
+      {/* 未読カード */}
       <Card data-testid="summary-unread" variant="outlined">
         <CardActionArea onClick={onUnreadClick} aria-label="未読メッセージを見る">
           <CardContent>
@@ -36,9 +72,49 @@ export default function SummaryCards({ data, onUnreadClick, onEventsClick, onTas
             <Typography variant="h4" fontWeight={600}>
               {unreadTotal}
             </Typography>
+            {/* 内訳チップ: 件数 > 0 のもののみ表示 */}
+            {(channelUnreadCount > 0 || dmUnreadCount > 0 || threadUnreadCount > 0) && (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                {channelUnreadCount > 0 && (
+                  <Chip
+                    data-testid="chip-unread-channel"
+                    label={`チャンネル ${channelUnreadCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/?tab=mentions');
+                    }}
+                  />
+                )}
+                {dmUnreadCount > 0 && (
+                  <Chip
+                    data-testid="chip-unread-dm"
+                    label={`DM ${dmUnreadCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/dm');
+                    }}
+                  />
+                )}
+                {threadUnreadCount > 0 && (
+                  <Chip
+                    data-testid="chip-unread-thread"
+                    label={`スレッド ${threadUnreadCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/?tab=threads');
+                    }}
+                  />
+                )}
+              </Box>
+            )}
           </CardContent>
         </CardActionArea>
       </Card>
+
+      {/* 今日の予定カード */}
       <Card data-testid="summary-events" variant="outlined">
         <CardActionArea onClick={onEventsClick} aria-label="今日の予定を見る">
           <CardContent>
@@ -48,9 +124,38 @@ export default function SummaryCards({ data, onUnreadClick, onEventsClick, onTas
             <Typography variant="h4" fontWeight={600}>
               {eventsCount}
             </Typography>
+            {/* 内訳チップ: 合計 > 0 のときのみ表示 */}
+            {eventsCount > 0 && (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                {organizerCount > 0 && (
+                  <Chip
+                    data-testid="chip-event-organizer"
+                    label={`主催 ${organizerCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/calendar?date=today&role=organizer');
+                    }}
+                  />
+                )}
+                {attendeeCount > 0 && (
+                  <Chip
+                    data-testid="chip-event-attendee"
+                    label={`参加 ${attendeeCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/calendar?date=today&role=attendee');
+                    }}
+                  />
+                )}
+              </Box>
+            )}
           </CardContent>
         </CardActionArea>
       </Card>
+
+      {/* 未完タスクカード */}
       <Card data-testid="summary-tasks" variant="outlined">
         <CardActionArea onClick={onTasksClick} aria-label="未完タスクを見る">
           <CardContent>
@@ -60,6 +165,33 @@ export default function SummaryCards({ data, onUnreadClick, onEventsClick, onTas
             <Typography variant="h4" fontWeight={600}>
               {todoCount}
             </Typography>
+            {/* 内訳チップ: 未完タスク > 0 のときのみ表示 */}
+            {todoCount > 0 && (
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mt: 1 }}>
+                {myTaskCount > 0 && (
+                  <Chip
+                    data-testid="chip-task-mine"
+                    label={`自分担当 ${myTaskCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/tasks?status=open&mine=true');
+                    }}
+                  />
+                )}
+                {othersTaskCount > 0 && (
+                  <Chip
+                    data-testid="chip-task-others"
+                    label={`その他 ${othersTaskCount}`}
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      navigate('/tasks?status=open&mine=false');
+                    }}
+                  />
+                )}
+              </Box>
+            )}
           </CardContent>
         </CardActionArea>
       </Card>

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -32,11 +32,13 @@ function isValidTab(v: string | null): v is TabKey {
 
 function SummarySection({
   promise,
+  currentUserId,
   onUnreadClick,
   onEventsClick,
   onTasksClick,
 }: {
   promise: Promise<SummaryData>;
+  currentUserId?: number;
   onUnreadClick?: () => void;
   onEventsClick?: () => void;
   onTasksClick?: () => void;
@@ -45,6 +47,7 @@ function SummarySection({
   return (
     <SummaryCards
       data={data}
+      currentUserId={currentUserId}
       onUnreadClick={onUnreadClick}
       onEventsClick={onEventsClick}
       onTasksClick={onTasksClick}
@@ -177,7 +180,8 @@ export default function InboxPage() {
   };
 
   // React 19 Concurrent モード対策: promise の安定化には useState の初期化関数（1 度だけ評価）を使う。
-  // 3 つの API を Promise.all で 1 本にまとめて Suspense 解決を 1 サイクルで完了させる。
+  // 5 つの API を Promise.all で 1 本にまとめて Suspense 解決を 1 サイクルで完了させる。
+  // Issue #320: DM未読数・スレッド未読数も取得して内訳チップで使用する。
   const [summaryPromise] = useState<Promise<SummaryData>>(() => {
     const now = new Date();
     const from = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
@@ -186,7 +190,20 @@ export default function InboxPage() {
       api.channels.list(),
       api.calendar.events.list({ from, to }),
       user ? api.tasks.list({ assigneeId: user.id }) : Promise.resolve({ tasks: [] }),
-    ]);
+      api.dm.listConversations(),
+      api.threads.listSubscribed(),
+    ]).then(([channelsRes, eventsRes, tasksRes, dmRes, threadsRes]) => {
+      const dmUnreadCount = dmRes.conversations.reduce((sum, c) => sum + (c.unreadCount ?? 0), 0);
+      const threadUnreadCount = threadsRes.threads.reduce(
+        (sum, t) => sum + (t.unreadCount ?? 0),
+        0,
+      );
+      return [
+        { channels: channelsRes.channels, dmUnreadCount, threadUnreadCount },
+        eventsRes,
+        tasksRes,
+      ] as SummaryData;
+    });
   });
 
   const mentionsPromise = useMemo(
@@ -289,6 +306,7 @@ export default function InboxPage() {
         >
           <SummarySection
             promise={summaryPromise}
+            currentUserId={user?.id}
             onUnreadClick={handleUnreadClick}
             onEventsClick={handleEventsClick}
             onTasksClick={handleTasksClick}


### PR DESCRIPTION
## 概要

受信箱のサマリーカード（未読 / 今日の予定 / 未完タスク）に、件数の根拠を示すミニ内訳チップを追加する。各チップから対応ビューへ直接ジャンプできるようにすることで、次のアクションへの導線を明確にする。

## 変更内容

### コンポーネント
- `packages/client/src/components/Inbox/SummaryCards.tsx`
  - `SummaryData` 型を拡張: `channels` 要素に `dmUnreadCount` / `threadUnreadCount` を追加
  - `currentUserId` props を追加（主催 / 自分担当 判定に使用）
  - 各カードに `Chip` ベースの内訳表示を追加。件数 0 のチップは非表示
  - チップクリック時は `e.stopPropagation()` でカード本体クリックと分離し `useNavigate` で遷移
- `packages/client/src/pages/InboxPage.tsx`
  - `Promise.all` に `api.dm.listConversations()` と `api.threads.listSubscribed()` を追加
  - DM / スレッドの未読合計を計算して `SummaryData` に注入
  - `SummarySection` 経由で `currentUserId={user?.id}` を渡す

### 内訳カテゴリと遷移先

| カード | 内訳 | 遷移先 |
|---|---|---|
| 未読 | チャンネル | `/?tab=mentions` |
| 未読 | DM | `/dm` |
| 未読 | スレッド | `/?tab=threads` |
| 今日の予定 | 主催 | `/calendar?date=today&role=organizer` |
| 今日の予定 | 参加 | `/calendar?date=today&role=attendee` |
| 未完タスク | 自分担当 | `/tasks?status=open&mine=true` |
| 未完タスク | その他 | `/tasks?status=open&mine=false` |

### テスト
- `packages/client/src/__tests__/SummaryCards.test.tsx`: Issue #320 用の 17 件のテストを追加
  - 未読 7件 / 予定 5件 / タスク 5件
  - 表示・非表示・クリック遷移を全パターン検証
- `packages/client/src/__tests__/SummaryCardsDrilldown.test.tsx`: 既存 `testData` に `dmUnreadCount` / `threadUnreadCount` フィールドを追加
- `packages/client/src/__tests__/InboxPage.test.tsx` / `InboxUnreadFilter.test.tsx`: api モックに `dm.listConversations` を追記

## 影響範囲

- フロントエンド: 受信箱ページ（`InboxPage`）と `SummaryCards`
- バックエンド: 変更なし（既存 API `api.dm.listConversations` と `api.threads.listSubscribed` を再利用）
- DB: 変更なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（**140 files / 2350 tests pass**）
- [x] バックエンドユニットテストがすべてパスする（コンポーネント変更のため影響なし）
- [x] ビルドが正常に完了すること（`npm run build` 成功、`npm run lint` 0 errors）
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue
Fixes #320

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）

---

### レビュー観点
1. 遷移先 URL のルーティング（`/dm`、`/calendar?role=*`、`/tasks?mine=*`）が既存ルータ定義と整合しているか
2. `SummaryData` 型拡張による既存呼び出し元への影響範囲
3. 「ホバーまたはカード内チップ」の受け入れ条件 → **カード内チップ常時表示** で実装
4. `currentUserId` 未指定時の挙動: 主催・自分担当の件数は 0、その他タスクは全件として扱う