### PR TITLE
feat: 通知許可状態に応じた CTA の出し分け (#321)

### DIFF
--- a/packages/client/src/__tests__/SidebarFooter.test.tsx
+++ b/packages/client/src/__tests__/SidebarFooter.test.tsx
@@ -3,15 +3,18 @@
  *
  * テスト対象: Sidebar 列フッター（ステータス + 表示名 / テーマ切替 / 通知 / プロフィール / ログアウト）
  * 戦略:
- *   - AuthContext / ThemeContext / usePushNotifications をモックする
+ *   - AuthContext / ThemeContext / usePushNotifications / useNotificationPermission /
+ *     useChannelNotifications をモックする
  *   - useNavigate を vi.fn() で差し替え、プロフィール遷移を検証する
  *   - StatusEditDialog は jsdom で開閉確認可能なため、ダイアログタイトル等で検証
+ *   - #321 通知許可状態に応じた CTA 出し分けは mockPermission を差し替えて検証
  */
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChannelNotificationSetting } from '@chat-app/shared';
 import SidebarFooter from '../components/Layout/SidebarFooter';
 
 const mockToggleTheme = vi.fn();
@@ -19,6 +22,8 @@ const mockLogout = vi.fn();
 const mockSubscribe = vi.fn();
 const mockUnsubscribe = vi.fn();
 const mockNavigate = vi.fn();
+const mockRequestPermission = vi.fn();
+const mockFetchSettings = vi.fn().mockResolvedValue(undefined);
 const mockMe = vi.fn().mockResolvedValue({
   user: { id: 1, username: 'alice', email: 'a@test.com', displayName: null, role: 'user' },
 });
@@ -34,11 +39,27 @@ vi.mock('../contexts/ThemeContext', () => ({
 vi.mock('../hooks/usePushNotifications', () => ({
   usePushNotifications: () => ({
     supported: mockPushSupported,
-    subscribed: false,
+    subscribed: mockSubscribed,
     loading: false,
     error: null,
     subscribe: mockSubscribe,
     unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+vi.mock('../hooks/useNotificationPermission', () => ({
+  useNotificationPermission: () => ({
+    permission: mockPermission,
+    requestPermission: mockRequestPermission,
+  }),
+}));
+
+vi.mock('../hooks/useChannelNotifications', () => ({
+  useChannelNotifications: () => ({
+    settings: mockChannelSettings,
+    getLevel: () => 'all',
+    setLevel: vi.fn(),
+    fetchSettings: mockFetchSettings,
   }),
 }));
 
@@ -76,17 +97,25 @@ const mockUser: {
 
 let mockMode: 'light' | 'dark' = 'light';
 let mockPushSupported = false;
+let mockSubscribed = false;
+let mockPermission: 'default' | 'granted' | 'denied' | 'unsupported' = 'granted';
+let mockChannelSettings = new Map<number, ChannelNotificationSetting>();
 
 beforeEach(() => {
   mockUser.displayName = null;
   mockUser.status = null;
   mockMode = 'light';
   mockPushSupported = false;
+  mockSubscribed = false;
+  mockPermission = 'granted';
+  mockChannelSettings = new Map();
   mockToggleTheme.mockClear();
   mockLogout.mockClear();
   mockSubscribe.mockClear();
   mockUnsubscribe.mockClear();
   mockNavigate.mockClear();
+  mockRequestPermission.mockClear();
+  mockFetchSettings.mockClear();
 });
 
 function renderFooter() {
@@ -133,17 +162,23 @@ describe('SidebarFooter', () => {
       expect(screen.getByRole('button', { name: 'ログアウト' })).toBeInTheDocument();
     });
 
-    it('Push 通知サポート時、通知トグルボタンが表示される', () => {
+    it('Push 通知サポート時 (permission=granted)、通知設定ボタンが表示される', () => {
       mockPushSupported = true;
+      mockPermission = 'granted';
       renderFooter();
-      expect(screen.getByRole('button', { name: '通知を有効にする' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '通知設定' })).toBeInTheDocument();
     });
 
-    it('Push 通知未対応時、通知トグルボタンが表示されない', () => {
+    it('Push 通知未対応時、通知ボタンが表示されない', () => {
       mockPushSupported = false;
       renderFooter();
-      expect(screen.queryByRole('button', { name: '通知を有効にする' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: '通知を無効にする' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: '通知設定' })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'ブラウザ通知を有効化' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: '通知がブロックされています' }),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -178,6 +213,102 @@ describe('SidebarFooter', () => {
     });
   });
 
+  // #321 通知許可 CTA の状態別ガイダンス
+  describe('#321 通知許可状態に応じた CTA の出し分け', () => {
+    describe('default (未設定)', () => {
+      it('「ブラウザ通知を有効化」CTA ラベルのボタンが表示される', () => {
+        mockPushSupported = true;
+        mockPermission = 'default';
+        renderFooter();
+        expect(screen.getByRole('button', { name: 'ブラウザ通知を有効化' })).toBeInTheDocument();
+      });
+
+      it('クリックすると Notification.requestPermission が呼ばれる', async () => {
+        mockPushSupported = true;
+        mockPermission = 'default';
+        mockRequestPermission.mockResolvedValue('granted');
+        renderFooter();
+        const button = screen.getByRole('button', { name: 'ブラウザ通知を有効化' });
+        await userEvent.click(button);
+        expect(mockRequestPermission).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('denied (拒否済み)', () => {
+      it('「通知がブロックされています」状態のボタンが表示される', () => {
+        mockPushSupported = true;
+        mockPermission = 'denied';
+        renderFooter();
+        expect(
+          screen.getByRole('button', { name: '通知がブロックされています' }),
+        ).toBeInTheDocument();
+      });
+
+      it('クリックするとブラウザ設定変更の手順案内 Popover が開く', async () => {
+        mockPushSupported = true;
+        mockPermission = 'denied';
+        renderFooter();
+        const button = screen.getByRole('button', { name: '通知がブロックされています' });
+        await userEvent.click(button);
+        // Popover 内に「ブラウザ設定」「通知を許可」など手順案内のキーワードが含まれる
+        expect(await screen.findByText(/ブラウザの設定/)).toBeInTheDocument();
+      });
+    });
+
+    describe('granted (有効)', () => {
+      it('Push 購読/未購読のサマリーをポップオーバーで表示する', async () => {
+        mockPushSupported = true;
+        mockPermission = 'granted';
+        mockSubscribed = false;
+        renderFooter();
+        const button = screen.getByRole('button', { name: '通知設定' });
+        await userEvent.click(button);
+        expect(await screen.findByText(/Push 通知: 未購読/)).toBeInTheDocument();
+      });
+
+      it('通知レベル別チャンネル件数（メンションのみ N 件 / ミュート M 件）をポップオーバーで表示する', async () => {
+        mockPushSupported = true;
+        mockPermission = 'granted';
+        mockSubscribed = true;
+        mockChannelSettings = new Map([
+          [1, { channelId: 1, level: 'mentions', updatedAt: '2026-01-01T00:00:00.000Z' }],
+          [2, { channelId: 2, level: 'mentions', updatedAt: '2026-01-01T00:00:00.000Z' }],
+          [3, { channelId: 3, level: 'muted', updatedAt: '2026-01-01T00:00:00.000Z' }],
+        ]);
+        renderFooter();
+        const button = screen.getByRole('button', { name: '通知設定' });
+        await userEvent.click(button);
+        // 取得トリガが Popover を開いたタイミングなので、表示は非同期
+        expect(await screen.findByText(/メンションのみ: 2 件/)).toBeInTheDocument();
+        expect(screen.getByText(/ミュート中: 1 件/)).toBeInTheDocument();
+      });
+    });
+
+    describe('permission 変化への追従', () => {
+      it('permission が default → granted に変化すると CTA から購読サマリー表示に切り替わる', () => {
+        mockPushSupported = true;
+        mockPermission = 'default';
+        const { rerender } = render(
+          <MemoryRouter>
+            <SidebarFooter />
+          </MemoryRouter>,
+        );
+        expect(screen.getByRole('button', { name: 'ブラウザ通知を有効化' })).toBeInTheDocument();
+
+        mockPermission = 'granted';
+        rerender(
+          <MemoryRouter>
+            <SidebarFooter />
+          </MemoryRouter>,
+        );
+        expect(screen.getByRole('button', { name: '通知設定' })).toBeInTheDocument();
+        expect(
+          screen.queryByRole('button', { name: 'ブラウザ通知を有効化' }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
   // Step 9c: variant prop でドロワー底部用の ListItem 形式表示に切替
   describe('Step 9c: variant="drawer" 表示', () => {
     function renderDrawerFooter() {
@@ -190,13 +321,14 @@ describe('SidebarFooter', () => {
 
     it('variant="drawer" のとき各機能 (テーマ / プロフィール / ログアウト) のラベル文字列が表示される', () => {
       mockPushSupported = true;
+      mockPermission = 'granted';
       renderDrawerFooter();
       // ステータス: ユーザー名込みのラベル
       expect(screen.getByText('alice のステータスを設定')).toBeInTheDocument();
       // テーマ
       expect(screen.getByText('ダークモードに切り替える')).toBeInTheDocument();
-      // 通知
-      expect(screen.getByText('通知を有効にする')).toBeInTheDocument();
+      // 通知 (granted 時のラベル)
+      expect(screen.getByText('通知設定')).toBeInTheDocument();
       // プロフィール
       expect(screen.getByText('プロフィール設定')).toBeInTheDocument();
       // ログアウト

--- a/packages/client/src/components/Layout/SidebarFooter.tsx
+++ b/packages/client/src/components/Layout/SidebarFooter.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   IconButton,
@@ -11,10 +11,15 @@ import {
   ListItemButton,
   ListItemIcon,
   ListItemText,
+  Popover,
+  Button,
+  Divider,
 } from '@mui/material';
 import LogoutIcon from '@mui/icons-material/Logout';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import NotificationsOffIcon from '@mui/icons-material/NotificationsOff';
+import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
+import NotificationAddIcon from '@mui/icons-material/NotificationAdd';
 import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LightModeIcon from '@mui/icons-material/LightMode';
@@ -22,6 +27,8 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { usePushNotifications } from '../../hooks/usePushNotifications';
+import { useNotificationPermission } from '../../hooks/useNotificationPermission';
+import { useChannelNotifications } from '../../hooks/useChannelNotifications';
 import { api } from '../../api/client';
 import StatusEditDialog from '../User/StatusEditDialog';
 
@@ -38,18 +45,118 @@ interface Props {
  * ステータス / テーマ切替 / Push 通知 / プロフィール / ログアウトを集約するフッター。
  * Rail 最下部 (variant='rail') とモバイル Sidebar ドロワー底部 (variant='drawer') で
  * 表示形式を切り替える。ユーザー名は幅不足のため Rail 上には直接表示せず Tooltip に集約。
+ *
+ * #321 通知ボタンは `Notification.permission` 状態に応じて表示と挙動を出し分ける：
+ *   - default : 「ブラウザ通知を有効化」CTA、クリックで requestPermission
+ *   - denied  : 「通知がブロックされています」、クリックで手順案内 Popover
+ *   - granted : 「通知設定」、クリックで Push 購読状態 + チャンネル別件数 Popover
  */
 export default function SidebarFooter({ variant = 'rail' }: Props = {}) {
   const [statusDialogOpen, setStatusDialogOpen] = useState(false);
   const { user, logout, updateUser } = useAuth();
   const { mode, toggleTheme } = useTheme();
   const { supported, subscribed, loading, error, subscribe, unsubscribe } = usePushNotifications();
+  const { permission, requestPermission } = useNotificationPermission();
+  const { settings, fetchSettings } = useChannelNotifications();
   const navigate = useNavigate();
 
+  const [notifPopoverAnchor, setNotifPopoverAnchor] = useState<HTMLElement | null>(null);
+
+  // Popover を開いた時にチャンネル通知設定を取得（granted のときのみ意味がある）
+  useEffect(() => {
+    if (notifPopoverAnchor && permission === 'granted') {
+      void fetchSettings();
+    }
+  }, [notifPopoverAnchor, permission, fetchSettings]);
+
   const themeLabel = mode === 'dark' ? 'ライトモードに切り替える' : 'ダークモードに切り替える';
-  const notificationLabel = subscribed ? '通知を無効にする' : '通知を有効にする';
   const userLabel = user?.displayName ?? user?.username ?? '';
   const statusTooltip = userLabel ? `${userLabel} のステータスを設定` : 'ステータスを設定';
+
+  const notificationLabel =
+    permission === 'default'
+      ? 'ブラウザ通知を有効化'
+      : permission === 'denied'
+        ? '通知がブロックされています'
+        : '通知設定';
+
+  const showNotificationButton = supported && permission !== 'unsupported';
+
+  const { mentionsOnlyCount, mutedCount } = useMemo(() => {
+    let m = 0;
+    let mu = 0;
+    for (const s of settings.values()) {
+      if (s.level === 'mentions') m++;
+      else if (s.level === 'muted') mu++;
+    }
+    return { mentionsOnlyCount: m, mutedCount: mu };
+  }, [settings]);
+
+  function notificationIcon() {
+    if (loading) return <CircularProgress size={16} />;
+    if (permission === 'denied') return <NotificationsOffIcon fontSize="small" />;
+    if (permission === 'default') return <NotificationAddIcon fontSize="small" />;
+    // granted
+    return subscribed ? (
+      <NotificationsIcon fontSize="small" />
+    ) : (
+      <NotificationsNoneIcon fontSize="small" />
+    );
+  }
+
+  async function handleNotificationClick(e: MouseEvent<HTMLElement>) {
+    if (permission === 'default') {
+      await requestPermission();
+      return;
+    }
+    // denied / granted は Popover を開く
+    setNotifPopoverAnchor(e.currentTarget);
+  }
+
+  const notificationPopover = (
+    <Popover
+      open={Boolean(notifPopoverAnchor)}
+      anchorEl={notifPopoverAnchor}
+      onClose={() => setNotifPopoverAnchor(null)}
+      anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      transformOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+    >
+      {permission === 'denied' && (
+        <Box sx={{ p: 2, maxWidth: 320 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            通知がブロックされています
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            ブラウザの設定から通知を許可する必要があります。
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+            アドレスバー左の鍵アイコンをクリックし、「通知」項目を「許可」に変更してください。
+          </Typography>
+        </Box>
+      )}
+      {permission === 'granted' && (
+        <Box sx={{ p: 2, minWidth: 240 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            通知設定
+          </Typography>
+          <Typography variant="body2">Push 通知: {subscribed ? '購読中' : '未購読'}</Typography>
+          <Box sx={{ mt: 1, mb: 1 }}>
+            <Button
+              size="small"
+              variant="outlined"
+              disabled={loading}
+              onClick={() => void (subscribed ? unsubscribe() : subscribe())}
+            >
+              {subscribed ? 'Push を無効にする' : 'Push を有効にする'}
+            </Button>
+          </Box>
+          <Divider sx={{ my: 1 }} />
+          <Typography variant="body2">メンションのみ: {mentionsOnlyCount} 件</Typography>
+          <Typography variant="body2">ミュート中: {mutedCount} 件</Typography>
+        </Box>
+      )}
+    </Popover>
+  );
 
   const statusDialog = (
     <StatusEditDialog
@@ -103,21 +210,13 @@ export default function SidebarFooter({ variant = 'rail' }: Props = {}) {
               <ListItemText primary={themeLabel} />
             </ListItemButton>
 
-            {supported && (
+            {showNotificationButton && (
               <ListItemButton
                 aria-label={notificationLabel}
                 disabled={loading}
-                onClick={() => void (subscribed ? unsubscribe() : subscribe())}
+                onClick={(e) => void handleNotificationClick(e)}
               >
-                <ListItemIcon sx={{ minWidth: 40 }}>
-                  {loading ? (
-                    <CircularProgress size={16} />
-                  ) : subscribed ? (
-                    <NotificationsIcon fontSize="small" />
-                  ) : (
-                    <NotificationsOffIcon fontSize="small" />
-                  )}
-                </ListItemIcon>
+                <ListItemIcon sx={{ minWidth: 40 }}>{notificationIcon()}</ListItemIcon>
                 <ListItemText primary={notificationLabel} />
               </ListItemButton>
             )}
@@ -144,6 +243,7 @@ export default function SidebarFooter({ variant = 'rail' }: Props = {}) {
           </Alert>
         </Snackbar>
 
+        {notificationPopover}
         {statusDialog}
       </>
     );
@@ -200,23 +300,17 @@ export default function SidebarFooter({ variant = 'rail' }: Props = {}) {
           </IconButton>
         </Tooltip>
 
-        {supported && (
+        {showNotificationButton && (
           <Tooltip title={notificationLabel} placement="right">
             <span>
               <IconButton
                 size="small"
                 aria-label={notificationLabel}
                 disabled={loading}
-                onClick={() => void (subscribed ? unsubscribe() : subscribe())}
+                onClick={(e) => void handleNotificationClick(e)}
                 sx={{ width: 36, height: 32 }}
               >
-                {loading ? (
-                  <CircularProgress size={16} />
-                ) : subscribed ? (
-                  <NotificationsIcon fontSize="small" />
-                ) : (
-                  <NotificationsOffIcon fontSize="small" />
-                )}
+                {notificationIcon()}
               </IconButton>
             </span>
           </Tooltip>
@@ -251,6 +345,7 @@ export default function SidebarFooter({ variant = 'rail' }: Props = {}) {
         </Alert>
       </Snackbar>
 
+      {notificationPopover}
       {statusDialog}
     </>
   );

--- a/packages/client/src/hooks/__tests__/useNotificationPermission.test.tsx
+++ b/packages/client/src/hooks/__tests__/useNotificationPermission.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * テスト対象: hooks/useNotificationPermission.ts
+ * 戦略:
+ *   - グローバル Notification を差し替え、permission の初期値・requestPermission 結果を制御する
+ *   - navigator.permissions.query をモックし、PermissionStatus の change イベント発火で UI 更新を検証する
+ *   - 非対応環境では 'unsupported' を返すフォールバックを検証する
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useNotificationPermission } from '../useNotificationPermission';
+
+type ChangeHandler = (this: PermissionStatus, ev: Event) => unknown;
+
+interface FakePermissionStatus {
+  state: PermissionState;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  triggerChange: (newState: PermissionState) => void;
+}
+
+function setNotification(
+  perm: NotificationPermission | undefined,
+  requestPermission?: ReturnType<typeof vi.fn>,
+) {
+  const g = globalThis as unknown as { Notification?: unknown };
+  if (perm === undefined) {
+    delete g.Notification;
+    return;
+  }
+  g.Notification = {
+    permission: perm,
+    requestPermission: requestPermission ?? vi.fn().mockResolvedValue(perm),
+  };
+}
+
+function setPermissionsQuery(initialState: PermissionState | null): FakePermissionStatus | null {
+  if (initialState === null) {
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: undefined,
+    });
+    return null;
+  }
+  const handlers: ChangeHandler[] = [];
+  const status: FakePermissionStatus = {
+    state: initialState,
+    addEventListener: vi.fn((event: string, handler: ChangeHandler) => {
+      if (event === 'change') handlers.push(handler);
+    }),
+    removeEventListener: vi.fn((event: string, handler: ChangeHandler) => {
+      if (event === 'change') {
+        const idx = handlers.indexOf(handler);
+        if (idx >= 0) handlers.splice(idx, 1);
+      }
+    }),
+    triggerChange(newState: PermissionState) {
+      this.state = newState;
+      for (const h of handlers) h.call(this as unknown as PermissionStatus, new Event('change'));
+    },
+  };
+  Object.defineProperty(navigator, 'permissions', {
+    configurable: true,
+    value: {
+      query: vi.fn().mockResolvedValue(status),
+    },
+  });
+  return status;
+}
+
+afterEach(() => {
+  setNotification(undefined);
+  Object.defineProperty(navigator, 'permissions', {
+    configurable: true,
+    value: undefined,
+  });
+});
+
+describe('useNotificationPermission', () => {
+  describe('初期値', () => {
+    it('Notification.permission が "default" のとき "default" を返す', () => {
+      setNotification('default');
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      expect(result.current.permission).toBe('default');
+    });
+
+    it('Notification.permission が "granted" のとき "granted" を返す', () => {
+      setNotification('granted');
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      expect(result.current.permission).toBe('granted');
+    });
+
+    it('Notification.permission が "denied" のとき "denied" を返す', () => {
+      setNotification('denied');
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      expect(result.current.permission).toBe('denied');
+    });
+
+    it('Notification API が存在しない環境では "unsupported" を返す', () => {
+      setNotification(undefined);
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      expect(result.current.permission).toBe('unsupported');
+    });
+  });
+
+  describe('変更の追従', () => {
+    it('navigator.permissions.query で取得した PermissionStatus の change イベントで state が更新される', async () => {
+      setNotification('default');
+      const status = setPermissionsQuery('prompt');
+      const { result } = renderHook(() => useNotificationPermission());
+      await waitFor(() => {
+        expect(status!.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+      });
+      act(() => {
+        // ブラウザで granted に変更されたケースをエミュレート
+        status!.triggerChange('granted');
+      });
+      await waitFor(() => expect(result.current.permission).toBe('granted'));
+    });
+
+    it('Permissions API 非対応環境では change 購読を行わず初期値のみ返す', () => {
+      setNotification('default');
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      expect(result.current.permission).toBe('default');
+      // navigator.permissions が undefined のため、query が呼ばれないこと自体は型上保証
+      expect((navigator as unknown as { permissions?: unknown }).permissions).toBeUndefined();
+    });
+  });
+
+  describe('requestPermission', () => {
+    it('ユーザーが許可した場合、state が "granted" に更新される', async () => {
+      const reqFn = vi.fn().mockResolvedValue('granted');
+      setNotification('default', reqFn);
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+      expect(reqFn).toHaveBeenCalled();
+      expect(result.current.permission).toBe('granted');
+    });
+
+    it('ユーザーが拒否した場合、state が "denied" に更新される', async () => {
+      const reqFn = vi.fn().mockResolvedValue('denied');
+      setNotification('default', reqFn);
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      await act(async () => {
+        await result.current.requestPermission();
+      });
+      expect(result.current.permission).toBe('denied');
+    });
+
+    it('Notification API 未対応環境では何もせず "unsupported" を返す', async () => {
+      setNotification(undefined);
+      setPermissionsQuery(null);
+      const { result } = renderHook(() => useNotificationPermission());
+      let returned: string | undefined;
+      await act(async () => {
+        returned = await result.current.requestPermission();
+      });
+      expect(returned).toBe('unsupported');
+      expect(result.current.permission).toBe('unsupported');
+    });
+  });
+});

--- a/packages/client/src/hooks/useNotificationPermission.ts
+++ b/packages/client/src/hooks/useNotificationPermission.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+export type NotificationPermissionState = NotificationPermission | 'unsupported';
+
+export interface UseNotificationPermissionResult {
+  permission: NotificationPermissionState;
+  requestPermission: () => Promise<NotificationPermissionState>;
+}
+
+function readInitialPermission(): NotificationPermissionState {
+  if (typeof Notification === 'undefined') return 'unsupported';
+  return Notification.permission;
+}
+
+function permissionStateToNotificationPermission(state: PermissionState): NotificationPermission {
+  return state === 'prompt' ? 'default' : state;
+}
+
+/**
+ * ブラウザ通知許可状態を購読するフック。
+ *
+ * - 初期値は `Notification.permission`（未対応環境では 'unsupported'）
+ * - Permissions API (`navigator.permissions.query({ name: 'notifications' })`) を
+ *   購読し、ユーザーがブラウザ設定で許可状態を変更した際に再描画する
+ * - `requestPermission()` で許可リクエストを発火し、結果に応じて state を更新する
+ */
+export function useNotificationPermission(): UseNotificationPermissionResult {
+  const [permission, setPermission] = useState<NotificationPermissionState>(readInitialPermission);
+
+  useEffect(() => {
+    if (typeof Notification === 'undefined') return;
+    if (typeof navigator === 'undefined' || !navigator.permissions?.query) return;
+
+    let cancelled = false;
+    let status: PermissionStatus | null = null;
+    const handleChange = () => {
+      if (cancelled || !status) return;
+      setPermission(permissionStateToNotificationPermission(status.state));
+    };
+
+    navigator.permissions
+      .query({ name: 'notifications' as PermissionName })
+      .then((s) => {
+        if (cancelled) return;
+        status = s;
+        setPermission(permissionStateToNotificationPermission(s.state));
+        s.addEventListener('change', handleChange);
+      })
+      .catch(() => {
+        // Permissions API が 'notifications' を未サポートな環境ではフォールバック
+        // （Notification.permission の初期値のみ使う）
+      });
+
+    return () => {
+      cancelled = true;
+      if (status) status.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  const requestPermission = async (): Promise<NotificationPermissionState> => {
+    if (typeof Notification === 'undefined') return 'unsupported';
+    const result = await Notification.requestPermission();
+    setPermission(result);
+    return result;
+  };
+
+  return { permission, requestPermission };
+}


### PR DESCRIPTION
## 概要

Rail 下部の通知アイコンを、ブラウザ通知権限の状態（未設定 / 拒否済み / 有効）に応じて文言と導線を切り替える。

## 変更内容

- `hooks/useNotificationPermission.ts` (新規)
  - `Notification.permission` を state 化し、`navigator.permissions.query({ name: 'notifications' })` の `change` イベントを購読して許可状態の変化に追従する。
  - Notification API 未対応環境では `'unsupported'` を返してフォールバック。
  - `requestPermission()` を提供し、結果を state にも反映する。
- `components/Layout/SidebarFooter.tsx`
  - 通知ボタンを `permission` 状態で出し分け：
    - **default**: aria-label `ブラウザ通知を有効化`、クリックで `requestPermission` を発火。
    - **denied**: aria-label `通知がブロックされています`、クリックで Popover を開きブラウザ設定変更の手順を案内。
    - **granted**: aria-label `通知設定`、クリックで Popover を開き「Push 通知購読状態」「メンションのみ N 件 / ミュート中 M 件」のサマリーと Push ON/OFF ボタンを表示。
  - Popover を開いたタイミングで `useChannelNotifications.fetchSettings()` を呼び、件数表示用に最新化。
  - `variant='drawer'` でも同じ 3 状態ロジックを適用。
- テスト
  - `hooks/__tests__/useNotificationPermission.test.tsx` (新規): 初期値・change 追従・requestPermission の挙動を検証。
  - `__tests__/SidebarFooter.test.tsx`: `#321` ブロックを追加し、3 状態の表示とクリック挙動、permission 変化への追従を検証。既存の通知ボタン表示テストは新ラベル（`通知設定`）に合わせて更新。

### 既存テストの変更

| ファイル | 変更箇所 | 変更理由 |
|---|---|---|
| `packages/client/src/__tests__/SidebarFooter.test.tsx` | 既存の `'Push 通知サポート時、通知トグルボタンが表示される'` 系テストの期待ラベルを `通知を有効にする` → `通知設定` に変更。`variant='drawer'` のラベル期待も同様に変更。`useNotificationPermission` / `useChannelNotifications` を新規モック追加。 | #321 仕様変更により、granted 状態のメインボタンはトグルではなく Popover を開く `通知設定` ボタンに変わったため。Push 購読の ON/OFF 操作は Popover 内のボタンに移動。 |

## 影響範囲

- Rail 下部の通知アイコン（`SidebarFooter`）の表示ラベル・クリック挙動が変わる。
- モバイル Sidebar ドロワー底部 (`variant='drawer'`) でも同様の変更。
- Push 通知の購読 API (`usePushNotifications`) 自体には変更なし。granted 状態の Popover から従来通り subscribe/unsubscribe される。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (`vitest run` 全 2382 件 PASS)
- [x] バックエンドユニットテストがすべてパスする (`jest` 全 1669 件 PASS)
- [x] ビルドが正常に完了すること (`npm run build` 成功)
- [ ] (手動確認) ブラウザで `Notification.permission` を `default` / `denied` / `granted` に切り替え、UI と Popover の挙動を確認

## 関連Issue
Fixes #321

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（今回は不要）
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)