### PR TITLE
docs: Codex用ブラウザ確認スキルを追加

### DIFF
--- a/.codex/skills/codex-browser-dev/SKILL.md
+++ b/.codex/skills/codex-browser-dev/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: codex-browser-dev
+description: このプロジェクト（chat-app）で Codex の Playwright CLI Skill を使ってブラウザ上の画面操作、E2E 的な動作確認、実描画確認、コンソール・ネットワーク確認を行うための Codex 専用スキル。Claude Code の Playwright MCP ではなく Codex で画面操作が必要なときに使う。
+---
+
+# Codex Browser Dev
+
+このスキルは Codex 専用のブラウザ動作確認入口である。
+共通の確認観点、開発サーバー確認、React 19 Suspense のリクエスト数確認、一時ファイルの扱いは `doc/browser-e2e-guide.md` を正本として参照する。
+
+## 使うツール
+
+1. Codex の `playwright` skill を第一候補にする。
+   - `Playwright CLI Skill` の wrapper script で実ブラウザを起動し、`snapshot` の ref を使って操作する。
+   - `Browser` プラグインの `iab` は確認しない。Codex Browser が使えるかどうかに依存せず、Playwright CLI で進める。
+2. Playwright CLI が使えない場合だけ `Computer Use` にフォールバックする。
+   - `playwright` skill が未インストール、`npx` がない、CLI 起動に失敗するなど、CLI で進められない場合に限る。
+   - `computer-use:computer-use` skill の確認ポリシーに従う。
+3. どちらも使えない場合は、画面操作できない理由と、代替で実施した確認範囲をユーザーに報告する。
+
+## 開発サーバー
+
+まず既存サーバーの有無を確認する。
+
+```bash
+lsof -i :3001 -i :5173
+```
+
+- `node` が LISTEN していれば `http://localhost:5173` を開く。
+- 未起動の場合だけ `npm run dev` を起動する。
+- Codex sandbox では dev server の listen や PostgreSQL 接続が `EPERM` になることがある。その場合は同じ `npm run dev` を権限付きで再実行する。
+- 自分が起動したサーバーだけを終了する。ユーザーや別プロセスのサーバーは止めない。
+
+## Playwright CLI での確認手順
+
+先に `playwright` skill を読み、wrapper script を使う。
+
+```bash
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+export PWCLI="$CODEX_HOME/skills/playwright/scripts/playwright_cli.sh"
+```
+
+通常は作業ごとに session 名を付け、生成物を `output/playwright/<label>/` に閉じ込める。
+
+```bash
+mkdir -p output/playwright/<label>
+cd output/playwright/<label>
+"$PWCLI" --session <label> open http://localhost:5173 --headed
+"$PWCLI" --session <label> snapshot
+"$PWCLI" --session <label> fill e14 "example"
+"$PWCLI" --session <label> screenshot
+"$PWCLI" --session <label> console
+"$PWCLI" --session <label> close
+```
+
+確認の流れ:
+
+1. `open` で `http://localhost:5173` または対象 URL を開く。
+2. `snapshot` で操作対象の ref を確認する。
+3. `fill` / `click` / `press` などを ref 指定で実行する。
+4. 画面状態が変わったら `snapshot` を取り直す。
+5. UI 崩れ、重なり、スクロール、レスポンシブ表示を確認する場合は `screenshot` を使う。
+6. React 19 Suspense や API 連打が疑わしい場合は `console` / `requests` を確認する。
+7. 最後に `close` で Playwright session を閉じる。
+
+Codex sandbox では `npx --package @playwright/cli` の取得やブラウザ起動でネットワーク・プロセス権限が必要になる場合がある。その場合は、同じ `$PWCLI ...` コマンドを権限付きで再実行する。
+
+## 操作メモ
+
+- 接続先は通常 `http://localhost:5173`。
+- ログイン後にオンボーディングダイアログが出たら、検証対象でなければスキップする。
+- チャネル選択、モーダル開閉、リスト更新の直後は locator が古くなるため、操作直前に snapshot を取り直す。
+- Quill の入力欄は `.ql-editor` を使う。通常の textbox locator で拾えない場合は CSS locator でフォーカスする。
+- CSS 修正後に HMR 反映が怪しい場合は明示的に reload してから再確認する。
+- スクリーンショット、snapshot、console log などの一時ファイルは `output/playwright/` 配下に生成する。
+- 生成物は原則コミットしない。削除する場合は `doc/browser-e2e-guide.md` に従い、ユーザー確認を取る。ただしユーザーが明示的に削除を指示した場合は削除してよい。
+
+## Computer Use フォールバック
+
+Computer Use を使う場合は、ブラウザでの直接操作に限定し、次の手順で進める。
+
+1. ローカルアプリの URL を開く。
+2. スクリーンショット相当の画面理解で現在状態を確認する。
+3. クリック、入力、スクロールなどを一操作ずつ行う。
+4. 各操作後に画面を再確認してから次に進む。
+
+フォーム送信、アカウント作成、権限変更、外部サービスへの送信など副作用がある操作は、Computer Use の確認ポリシーに従って直前にユーザー確認を取る。

--- a/.codex/skills/codex-browser-dev/agents/openai.yaml
+++ b/.codex/skills/codex-browser-dev/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Codex Browser Dev"
+  short_description: "CodexでPlaywright CLI実ブラウザ確認"
+  default_prompt: "Use $codex-browser-dev to verify the local chat-app UI with Playwright CLI."
+
+policy:
+  allow_implicit_invocation: true

--- a/doc/agent-docs-guide.md
+++ b/doc/agent-docs-guide.md
@@ -10,6 +10,7 @@
 | `AGENTS.md` | Codex / Claude Code 共通の開発規約、TDD フロー、Git ワークフロー |
 | `CLAUDE.md` | Claude Code が最初に読む薄い入口。共通規約は `AGENTS.md` / `doc/` に委譲する |
 | `doc/*.md` | プロジェクト固有の仕様、設計ガイド、運用ガイド |
+| `.codex/**` | Codex 固有の skill / 設定。共通規約や技術仕様の本文は置かず、Codex 固有の発火条件・ツール名・実行手順だけを書く |
 | `.claude/**` | Claude Code 固有の skill / command / hook / permission 設定 |
 
 ## Codex で作業するとき
@@ -21,6 +22,7 @@
 5. 複数 Issue や worktree を扱う場合は `doc/parallel-dev-guide.md` を読む
 
 Codex 専用に同じ内容の文書を複製しない。Codex 固有の補足が必要な場合も、本文は正本へリンクし、差分だけを書く。
+Codex でブラウザ実機確認が必要な場合は `.codex/skills/codex-browser-dev/SKILL.md` を使う。
 
 ## Claude Code で作業するとき
 
@@ -31,7 +33,7 @@ Claude Code は `CLAUDE.md` と `.claude/skills` / `.claude/commands` を入口�
 
 - 開発規約を変える場合は `AGENTS.md` を更新する
 - 実装仕様や技術ガイドを追加する場合は `doc/` に置く
+- Codex の skill だけに有用な内容は `.codex/skills/` に置く
 - Claude Code の skill だけに有用な内容は `.claude/skills/` に置く
 - 同じ説明を複数ファイルへ貼り付けない
 - 参照先を変えた場合は `rg "古いファイル名|古い見出し"` で残存参照を確認する
-


### PR DESCRIPTION
## 概要
Codex でこのプロジェクトの画面操作・E2E 的な確認を行うための専用 skill を追加しました。Playwright CLI Skill を第一候補にし、Browser iab の事前確認には依存しない手順にしています。

## 変更内容
- `.codex/skills/codex-browser-dev/SKILL.md` を追加
- Playwright CLI Skill を第一候補にしたブラウザ確認手順を定義
- sandbox での `listen EPERM` や Playwright CLI 実行時の権限付き再実行方針を記載
- Playwright 生成物を `output/playwright/` 配下に閉じ込め、原則コミットしない方針を記載
- `.codex/skills/codex-browser-dev/agents/openai.yaml` を追加
- `doc/agent-docs-guide.md` に Codex 専用 skill の配置ルールを追記

## 影響範囲
- Codex 用の skill / ドキュメントのみ
- アプリケーションの実行コード、テストコード、ビルド成果物には影響なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする
- [x] バックエンドユニットテストがすべてパスする
- [x] ビルドが正常に完了すること
- [x] (手動確認の場合) 確認した手順やスクリーンショット

確認内容:
- `npm run build` 成功
- `npm run test` 成功（server 1669件、client 2382件）
- `rg -n "it\.todo|it\(['\"][^'\"]*['\"]\s*,\s*\)" packages .codex doc` で実テスト内に `it.todo` / 空ボディの `it` がないことを確認（docs 内の説明文のみ検出）
- `ruby -e 'require "yaml"; YAML.load_file(".codex/skills/codex-browser-dev/agents/openai.yaml"); puts "yaml ok"'` 成功
- Playwright 実証実験で発生した `output/playwright/` 配下の生成物は削除済み

## 関連Issue
なし

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）
