### PR TITLE
feat: 検索ページのヘッダーと保存ビュー領域を明示する (#325)

### DIFF
--- a/packages/client/src/__tests__/SavedViewPills.test.tsx
+++ b/packages/client/src/__tests__/SavedViewPills.test.tsx
@@ -69,4 +69,23 @@ describe('SavedViewPills (Step 7b)', () => {
     render(<SavedViewPills views={[view]} onSelect={vi.fn()} />);
     expect(screen.queryByTestId('CloseIcon')).toBeNull();
   });
+
+  // Issue #325: 横スクロール可能な行レイアウト
+  describe('Issue #325: 横スクロール可能な行レイアウト', () => {
+    it('ピル一覧コンテナは折り返さず横方向に並ぶ（flexWrap: nowrap）', () => {
+      const views = [makeView({ id: 1, name: 'view-1' }), makeView({ id: 2, name: 'view-2' })];
+      render(<SavedViewPills views={views} onSelect={vi.fn()} />);
+      const container = screen.getByTestId('saved-view-pills');
+      const style = window.getComputedStyle(container);
+      expect(style.flexWrap).toBe('nowrap');
+    });
+
+    it('ピル一覧コンテナははみ出し時に横スクロールできる（overflowX が auto または scroll）', () => {
+      const views = [makeView({ id: 1, name: 'view-1' })];
+      render(<SavedViewPills views={views} onSelect={vi.fn()} />);
+      const container = screen.getByTestId('saved-view-pills');
+      const style = window.getComputedStyle(container);
+      expect(['auto', 'scroll']).toContain(style.overflowX);
+    });
+  });
 });

--- a/packages/client/src/__tests__/SavedViewsSection.test.tsx
+++ b/packages/client/src/__tests__/SavedViewsSection.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * components/Search/SavedViewsSection.tsx のユニットテスト
+ *
+ * テスト対象:
+ *   - 親 (SearchPage) から受け取った Promise を use() で解決し、
+ *     保存ビュー有り → SavedViewPills、保存ビュー無し → プレースホルダ
+ *     の出し分けを行うこと (Issue #325)
+ *
+ * 戦略:
+ *   - Promise を直接生成して渡し、<Suspense> で包んで描画する
+ *   - 初期レンダリング時に use() がサスペンドするため act(async) で render を包む
+ *     （react19-suspense-guide.md「Vitest パターン」に従う）
+ */
+
+import { Suspense } from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import type { SavedView } from '@chat-app/shared';
+import SavedViewsSection from '../components/Search/SavedViewsSection';
+
+function makeView(overrides: Partial<SavedView> = {}): SavedView {
+  return {
+    id: 1,
+    userId: 1,
+    name: 'view1',
+    query: { keyword: 'hello' },
+    position: 0,
+    createdAt: '2026-05-01T00:00:00Z',
+    updatedAt: '2026-05-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('SavedViewsSection (Issue #325)', () => {
+  describe('保存ビュー未作成時のプレースホルダ', () => {
+    it('保存ビューが 0 件のとき、追加方法の案内テキストが表示される', async () => {
+      const promise = Promise.resolve({ savedViews: [] });
+      await act(async () => {
+        render(
+          <Suspense fallback={<div data-testid="suspense-fallback">loading</div>}>
+            <SavedViewsSection promise={promise} onSelect={vi.fn()} onDelete={vi.fn()} />
+          </Suspense>,
+        );
+      });
+      const placeholder = screen.getByTestId('saved-views-empty-placeholder');
+      expect(placeholder).toBeInTheDocument();
+      // 案内文として「保存」「ビュー」が含まれる
+      expect(placeholder.textContent).toMatch(/保存/);
+      expect(placeholder.textContent).toMatch(/ビュー/);
+    });
+
+    it('保存ビューが 1 件以上あるとき、プレースホルダは表示されず、SavedViewPills が描画される', async () => {
+      const promise = Promise.resolve({
+        savedViews: [makeView({ id: 1, name: '営業チーム' })],
+      });
+      await act(async () => {
+        render(
+          <Suspense fallback={<div data-testid="suspense-fallback">loading</div>}>
+            <SavedViewsSection promise={promise} onSelect={vi.fn()} onDelete={vi.fn()} />
+          </Suspense>,
+        );
+      });
+      expect(screen.getByTestId('saved-view-pills')).toBeInTheDocument();
+      expect(screen.queryByTestId('saved-views-empty-placeholder')).not.toBeInTheDocument();
+      expect(screen.getByText('営業チーム')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -594,4 +594,90 @@ describe('SearchPage', () => {
       expect(localStorage.getItem('sidebar.open')).toBe('true');
     });
   });
+
+  // Issue #325: ヘッダーと保存ビュー領域の情報階層
+  describe('Issue #325: ヘッダーと保存ビュー領域の情報階層', () => {
+    describe('ページタイトル', () => {
+      it('上部にページタイトル「検索」が見出し（heading role）として表示される', () => {
+        renderSearch();
+        const heading = screen.getByRole('heading', { name: '検索', level: 1 });
+        expect(heading).toBeInTheDocument();
+      });
+    });
+
+    describe('レイアウト順序', () => {
+      it('DOM 上で「ページタイトル → 検索入力 → 保存ビュー行 → 検索構文ヘルプ」の順で並ぶ', () => {
+        renderSearch();
+        const main = screen.getByTestId('app-layout-main');
+        const heading = screen.getByRole('heading', { name: '検索', level: 1 });
+        const chipSection = screen.getByTestId('mock-chip-filter-section');
+        const savedViewsSection = screen.getByTestId('mock-saved-views-section');
+        const helpTrigger = screen.getByRole('button', { name: /検索構文ヘルプ/ });
+
+        // 全要素が main 配下にある
+        expect(main).toContainElement(heading);
+        expect(main).toContainElement(chipSection);
+        expect(main).toContainElement(savedViewsSection);
+        expect(main).toContainElement(helpTrigger);
+
+        // DOM 順序を compareDocumentPosition で検証 (FOLLOWING=4)
+        const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+        expect(heading.compareDocumentPosition(chipSection) & FOLLOWING).toBeTruthy();
+        expect(chipSection.compareDocumentPosition(savedViewsSection) & FOLLOWING).toBeTruthy();
+        expect(savedViewsSection.compareDocumentPosition(helpTrigger) & FOLLOWING).toBeTruthy();
+      });
+
+      it('保存ビュー行は検索入力の直下に配置される（チップ入力と保存ビューが同一ヘッダー領域に隣接する）', () => {
+        renderSearch();
+        const chipSection = screen.getByTestId('mock-chip-filter-section');
+        const savedViewsSection = screen.getByTestId('mock-saved-views-section');
+        // 同じ親要素 (ヘッダー領域) を共有していること
+        expect(chipSection.parentElement).toBe(savedViewsSection.parentElement);
+        // 親要素内で chipSection の直後の要素ノードが savedViewsSection
+        expect(chipSection.nextElementSibling).toBe(savedViewsSection);
+      });
+    });
+
+    describe('検索構文ヘルプ', () => {
+      it('検索構文ヘルプを開くトリガー（ボタン）が表示される', () => {
+        renderSearch();
+        const trigger = screen.getByRole('button', { name: /検索構文ヘルプ/ });
+        expect(trigger).toBeInTheDocument();
+      });
+
+      it('初期状態ではヘルプ内容は閉じている', () => {
+        renderSearch();
+        const trigger = screen.getByRole('button', { name: /検索構文ヘルプ/ });
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByTestId('search-syntax-help-panel')).not.toBeInTheDocument();
+      });
+
+      it('ヘルプトリガーをクリックするとヘルプ内容が展開され、検索構文の説明が表示される', async () => {
+        renderSearch();
+        const trigger = screen.getByRole('button', { name: /検索構文ヘルプ/ });
+        await userEvent.click(trigger);
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        const panel = await screen.findByTestId('search-syntax-help-panel');
+        expect(panel).toBeInTheDocument();
+        // 検索構文の代表例 (`from:` / `in:` / `has:`) が説明文として含まれる
+        expect(panel.textContent).toMatch(/from:/);
+        expect(panel.textContent).toMatch(/in:/);
+        expect(panel.textContent).toMatch(/has:/);
+      });
+
+      it('展開済みのヘルプトリガーを再度クリックすると閉じる', async () => {
+        renderSearch();
+        const trigger = screen.getByRole('button', { name: /検索構文ヘルプ/ });
+        // 開く
+        await userEvent.click(trigger);
+        expect(await screen.findByTestId('search-syntax-help-panel')).toBeInTheDocument();
+        // 再度クリックで閉じる
+        await userEvent.click(trigger);
+        expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        await waitFor(() => {
+          expect(screen.queryByTestId('search-syntax-help-panel')).not.toBeInTheDocument();
+        });
+      });
+    });
+  });
 });

--- a/packages/client/src/components/Search/SavedViewPills.tsx
+++ b/packages/client/src/components/Search/SavedViewPills.tsx
@@ -19,7 +19,17 @@ export default function SavedViewPills({ views, onSelect, onDelete }: Props) {
   if (views.length === 0) return null;
   return (
     <Box
-      sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}
+      sx={{
+        display: 'flex',
+        flexWrap: 'nowrap',
+        gap: 1,
+        overflowX: 'auto',
+        // 横スクロール時に縦方向のはみ出しを許容しない
+        overflowY: 'hidden',
+        // スクロールバーを薄く見せる
+        scrollbarWidth: 'thin',
+        py: 0.5,
+      }}
       data-testid="saved-view-pills"
       role="list"
     >

--- a/packages/client/src/components/Search/SavedViewsSection.tsx
+++ b/packages/client/src/components/Search/SavedViewsSection.tsx
@@ -1,4 +1,5 @@
 import { use } from 'react';
+import { Box, Typography } from '@mui/material';
 import type { SavedView } from '@chat-app/shared';
 import SavedViewPills from './SavedViewPills';
 
@@ -16,8 +17,26 @@ interface Props {
  * このラッパーを別ファイルに切り出すことで、SearchPage のテスト時に
  * `vi.mock('../components/Search/SavedViewsSection')` で丸ごとスタブ化でき、
  * jsdom + vitest 環境で Suspense 解決を経由せずにテストできる。
+ *
+ * Issue #325: 保存ビューが 0 件のときは追加方法の案内 (プレースホルダ) を表示する。
  */
 export default function SavedViewsSection({ promise, onSelect, onDelete }: Props) {
   const { savedViews } = use(promise);
+  if (savedViews.length === 0) {
+    return (
+      <Box
+        data-testid="saved-views-empty-placeholder"
+        sx={{
+          px: 1,
+          py: 0.5,
+          color: 'text.secondary',
+        }}
+      >
+        <Typography variant="caption">
+          保存ビューはまだありません。フィルタを設定して「保存」ボタンからビューを追加できます。
+        </Typography>
+      </Box>
+    );
+  }
   return <SavedViewPills views={savedViews} onSelect={onSelect} onDelete={onDelete} />;
 }

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Box, Button, CircularProgress, Collapse, Stack, Typography } from '@mui/material';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { useNavigate } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
@@ -33,6 +34,8 @@ export default function SearchPage() {
   const [rawSearchText, setRawSearchText] = useState('');
   const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
   const [searching, setSearching] = useState(false);
+  // Issue #325: 検索構文ヘルプパネルの開閉状態
+  const [helpOpen, setHelpOpen] = useState(false);
 
   // 保存ビュー一覧 promise。削除/作成後に savedViewsKey をインクリメントして再フェッチする
   const [savedViewsKey, setSavedViewsKey] = useState(0);
@@ -163,7 +166,20 @@ export default function SearchPage() {
       <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
         <Box
           sx={{
-            p: 2,
+            px: 2,
+            pt: 2,
+            pb: 0.5,
+            flexShrink: 0,
+          }}
+        >
+          <Typography variant="h5" component="h1" sx={{ fontWeight: 600 }}>
+            検索
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            px: 2,
+            pb: 2,
             borderBottom: 1,
             borderColor: 'divider',
             flexShrink: 0,
@@ -186,6 +202,53 @@ export default function SearchPage() {
               onDelete={handleDeleteSavedView}
             />
           </Suspense>
+          <Box>
+            <Button
+              size="small"
+              variant="text"
+              startIcon={<HelpOutlineIcon fontSize="small" />}
+              aria-expanded={helpOpen}
+              aria-controls="search-syntax-help-panel"
+              onClick={() => setHelpOpen((v) => !v)}
+              sx={{ textTransform: 'none', color: 'text.secondary' }}
+            >
+              検索構文ヘルプ
+            </Button>
+            <Collapse in={helpOpen} unmountOnExit>
+              <Box
+                id="search-syntax-help-panel"
+                data-testid="search-syntax-help-panel"
+                sx={{
+                  mt: 1,
+                  p: 1.5,
+                  borderRadius: 1,
+                  bgcolor: 'action.hover',
+                  fontSize: 13,
+                }}
+              >
+                <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+                  使用できる検索構文
+                </Typography>
+                <Stack spacing={0.5} component="ul" sx={{ pl: 2, m: 0 }}>
+                  <li>
+                    <code>from:ユーザー名</code> — 投稿者で絞り込み
+                  </li>
+                  <li>
+                    <code>in:チャンネル名</code> — チャンネルで絞り込み
+                  </li>
+                  <li>
+                    <code>has:link</code> / <code>has:file</code> — 添付の有無で絞り込み
+                  </li>
+                  <li>
+                    <code>before:YYYY-MM-DD</code> / <code>after:YYYY-MM-DD</code> — 日付で絞り込み
+                  </li>
+                  <li>
+                    <code>tag:タグ名</code> — タグで絞り込み
+                  </li>
+                </Stack>
+              </Box>
+            </Collapse>
+          </Box>
         </Box>
         <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
           <Box


### PR DESCRIPTION
## 概要
Issue #325 の受け入れ条件を満たすため、検索ページに「検索」見出し・保存ビュー行・検索構文ヘルプを配置し、情報階層を整理した。

## 変更内容
- **ページタイトル**: `SearchPage` 上部に h1 として「検索」見出しを追加
- **保存ビュー行の再配置**: 検索入力（ChipFilterSection）の直下に保存ビュー（SavedViewsSection）を配置
- **横スクロール対応**: `SavedViewPills` を `flexWrap: nowrap` + `overflowX: auto` に変更し、はみ出し時は横スクロールで閲覧できるように変更（旧: 折り返し）
- **検索構文ヘルプ**: `HelpOutline` アイコン付きの開閉式パネルを追加。`from:` / `in:` / `has:` / `before:` / `after:` / `tag:` の使い方を一覧表示。`aria-expanded` / `aria-controls` でアクセシビリティに配慮
- **保存ビュー未作成時のプレースホルダ**: `SavedViewsSection` に「保存ビューはまだありません。フィルタを設定して『保存』ボタンからビューを追加できます。」の案内を追加（`SavedViewPills` は純粋コンポーネントのまま据え置き）

## 影響範囲
- `packages/client/src/pages/SearchPage.tsx`
- `packages/client/src/components/Search/SavedViewsSection.tsx`
- `packages/client/src/components/Search/SavedViewPills.tsx`
- 上記コンポーネントのテストファイル（`SavedViewsSection.test.tsx` は新規）

検索ページ以外への影響なし。`SavedViewPills` の見た目（折り返し→横スクロール）は SearchPage 内でのみ使われている。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（2404 件）
- [x] バックエンドユニットテストがすべてパスする（1669 件）
- [x] ビルドが正常に完了すること（`npm run build` 成功）
- [x] 追加した検索ページ関連テスト: 全 39 件 pass（SearchPage 28 / SavedViewPills 7 / SavedViewsSection 2 ※新規 11 件含む）

## 関連Issue
Fixes #325

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)