### PR TITLE
feat: 検索結果ゼロ件時の「条件を広げる」サジェスチョン (#327)

### DIFF
--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -147,6 +147,9 @@ vi.mock('../components/Search/ChipFilterSection', () => ({
       </button>
     </div>
   ),
+  // Issue #327: SearchPage が SearchResultsWithSuggestions 内でラベル構築用に呼ぶ。
+  // テストでは即解決した空のマスタデータを返してチップラベルは ID 表記にフォールバックする。
+  getOrCreateMasterDataPromise: () => Promise.resolve({ users: [], channels: [], tags: [] }),
 }));
 
 // Step 7b: SavedViewsSection スタブ — Suspense + use(promise) を経由せずに

--- a/packages/client/src/__tests__/SearchResults.test.tsx
+++ b/packages/client/src/__tests__/SearchResults.test.tsx
@@ -150,6 +150,148 @@ describe('SearchResults', () => {
     });
   });
 
+  describe('検索結果ゼロ件時の「条件を広げる」セクション (#327)', () => {
+    const baseFilters = [{ type: 'keyword' as const, label: 'キーワード: hello' }];
+
+    it('結果 0 件かつ適用中フィルタが 1 つ以上あるとき「条件を広げる」セクションが表示される', () => {
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={baseFilters}
+          onRemoveFilter={vi.fn()}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('search-zero-suggestions')).toBeInTheDocument();
+      expect(screen.getByText('条件を広げる')).toBeInTheDocument();
+    });
+
+    it('結果 0 件でも適用中フィルタが 1 つも無いときはセクションを表示しない', () => {
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={[]}
+          onRemoveFilter={vi.fn()}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('search-zero-suggestions')).not.toBeInTheDocument();
+    });
+
+    it('適用中の各フィルタが解除チップとしてラベル付きで並ぶ（キーワード）', () => {
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={[{ type: 'keyword', label: 'キーワード: hello' }]}
+          onRemoveFilter={vi.fn()}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      const chip = screen.getByTestId('applied-filter-keyword');
+      expect(chip).toBeInTheDocument();
+      expect(chip).toHaveTextContent('キーワード: hello');
+    });
+
+    it('適用中の各フィルタが解除チップとして並ぶ（送信者・添付・日付・タグ・チャンネル）', () => {
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={[
+            { type: 'sender', label: '送信者: alice' },
+            { type: 'attachment', label: '添付ファイル: あり' },
+            { type: 'dateFrom', label: '開始日: 2024-01-01' },
+            { type: 'dateTo', label: '終了日: 2024-12-31' },
+            { type: 'tag', label: 'タグ: feature', value: 1 },
+            { type: 'channel', label: 'チャンネル: general' },
+          ]}
+          onRemoveFilter={vi.fn()}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId('applied-filter-sender')).toHaveTextContent('送信者: alice');
+      expect(screen.getByTestId('applied-filter-attachment')).toHaveTextContent(
+        '添付ファイル: あり',
+      );
+      expect(screen.getByTestId('applied-filter-dateFrom')).toHaveTextContent('開始日: 2024-01-01');
+      expect(screen.getByTestId('applied-filter-dateTo')).toHaveTextContent('終了日: 2024-12-31');
+      expect(screen.getByTestId('applied-filter-tag-1')).toHaveTextContent('タグ: feature');
+      expect(screen.getByTestId('applied-filter-channel')).toHaveTextContent('チャンネル: general');
+    });
+
+    it('チップの削除アイコン押下で onRemoveFilter が該当フィルタ種別を引数に呼ばれる', async () => {
+      const onRemoveFilter = vi.fn();
+      const tagFilter = { type: 'tag' as const, label: 'タグ: feature', value: 1 };
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={[tagFilter]}
+          onRemoveFilter={onRemoveFilter}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('remove-filter-tag-1'));
+
+      expect(onRemoveFilter).toHaveBeenCalledTimes(1);
+      expect(onRemoveFilter).toHaveBeenCalledWith(tagFilter);
+    });
+
+    it('「すべての条件をリセット」ボタンが表示される', () => {
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={baseFilters}
+          onRemoveFilter={vi.fn()}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: 'すべての条件をリセット' })).toBeInTheDocument();
+    });
+
+    it('「すべての条件をリセット」ボタン押下で onResetAll が呼ばれる', async () => {
+      const onResetAll = vi.fn();
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          appliedFilters={baseFilters}
+          onRemoveFilter={vi.fn()}
+          onResetAll={onResetAll}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'すべての条件をリセット' }));
+
+      expect(onResetAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('hasSearched=false のときは「条件を広げる」セクションも表示しない', () => {
+      render(
+        <SearchResults
+          results={[]}
+          onNavigate={vi.fn()}
+          hasSearched={false}
+          appliedFilters={baseFilters}
+          onRemoveFilter={vi.fn()}
+          onResetAll={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByTestId('search-zero-suggestions')).not.toBeInTheDocument();
+    });
+  });
+
   describe('スニペット + ハイライト (Step 7c-2)', () => {
     it('keyword props 指定時、マッチ部分が <mark> でハイライト表示される', () => {
       const result = makeResult({

--- a/packages/client/src/components/Chat/SearchResults.tsx
+++ b/packages/client/src/components/Chat/SearchResults.tsx
@@ -17,10 +17,32 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import CancelIcon from '@mui/icons-material/Cancel';
 import type { MessageSearchResult } from '@chat-app/shared';
 import TagChip from './TagChip';
 import { extractMessageText } from '../../utils/extractMessageText';
 import { buildSnippet } from '../../utils/buildSnippet';
+
+/**
+ * Issue #327: 検索結果ゼロ件時の「条件を広げる」サジェスチョン用フィルタ種別。
+ * tag のみ複数同時適用されうるため value (タグ ID) で個別識別する。
+ */
+export type AppliedFilterType =
+  | 'keyword'
+  | 'sender'
+  | 'attachment'
+  | 'dateFrom'
+  | 'dateTo'
+  | 'tag'
+  | 'channel';
+
+export interface AppliedFilter {
+  type: AppliedFilterType;
+  /** 解除チップ上に表示するラベル（例: "送信者: alice"） */
+  label: string;
+  /** 同一 type 内で複数同時に存在しうる場合の識別子（現状はタグ ID） */
+  value?: number | string;
+}
 
 type GroupBy = 'flat' | 'channel' | 'sender' | 'date';
 
@@ -56,6 +78,15 @@ interface Props {
    * Issue #249 対応で追加。後方互換のためデフォルトを `true` にして既存呼び出し側に影響しない。
    */
   hasSearched?: boolean;
+  /**
+   * Issue #327: 結果ゼロ件時に「条件を広げる」セクション内で個別解除できる現適用フィルタ一覧。
+   * 未指定 / 空配列のときはサジェスチョンセクションを描画しない。
+   */
+  appliedFilters?: AppliedFilter[];
+  /** チップの解除アイコン押下時に呼ばれる。`AppliedFilter` をそのまま渡す。 */
+  onRemoveFilter?: (filter: AppliedFilter) => void;
+  /** 「すべての条件をリセット」ボタン押下時に呼ばれる。 */
+  onResetAll?: () => void;
 }
 
 function formatDate(iso: string): string {
@@ -219,6 +250,9 @@ export default function SearchResults({
   onNavigate,
   keyword = '',
   hasSearched = true,
+  appliedFilters,
+  onRemoveFilter,
+  onResetAll,
 }: Props) {
   const [groupBy, setGroupBy] = useState<GroupBy>(() => readStoredGroupBy());
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -288,9 +322,60 @@ export default function SearchResults({
   }
 
   if (results.length === 0) {
+    const hasAppliedFilters = (appliedFilters?.length ?? 0) > 0;
     return (
       <Box sx={{ p: 4, textAlign: 'center' }}>
         <Typography color="text.secondary">見つかりませんでした</Typography>
+        {hasAppliedFilters && (
+          <Box
+            data-testid="search-zero-suggestions"
+            sx={{
+              mt: 3,
+              mx: 'auto',
+              maxWidth: 480,
+              textAlign: 'left',
+              p: 2,
+              borderRadius: 1,
+              bgcolor: 'action.hover',
+            }}
+          >
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: 600 }}>
+              条件を広げる
+            </Typography>
+            <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+              現在適用中のフィルタを個別に解除できます。
+            </Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5, mb: 1.5 }}>
+              {appliedFilters!.map((f) => {
+                const testId =
+                  f.value !== undefined
+                    ? `applied-filter-${f.type}-${f.value}`
+                    : `applied-filter-${f.type}`;
+                const removeTestId =
+                  f.value !== undefined
+                    ? `remove-filter-${f.type}-${f.value}`
+                    : `remove-filter-${f.type}`;
+                return (
+                  <Chip
+                    key={testId}
+                    data-testid={testId}
+                    label={f.label}
+                    size="small"
+                    onDelete={onRemoveFilter ? () => onRemoveFilter(f) : undefined}
+                    deleteIcon={
+                      <CancelIcon data-testid={removeTestId} aria-label={`${f.label} を解除`} />
+                    }
+                  />
+                );
+              })}
+            </Box>
+            {onResetAll && (
+              <Button size="small" variant="outlined" onClick={onResetAll}>
+                すべての条件をリセット
+              </Button>
+            )}
+          </Box>
+        )}
       </Box>
     );
   }

--- a/packages/client/src/components/Search/ChipFilterSection.tsx
+++ b/packages/client/src/components/Search/ChipFilterSection.tsx
@@ -32,7 +32,7 @@ interface MasterData {
  */
 let _masterDataPromise: Promise<MasterData> | null = null;
 
-function getOrCreateMasterDataPromise(): Promise<MasterData> {
+export function getOrCreateMasterDataPromise(): Promise<MasterData> {
   if (!_masterDataPromise) {
     _masterDataPromise = Promise.all([
       api.auth.users(),

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -1,17 +1,151 @@
-import { useState, useEffect, useCallback, useMemo, Suspense } from 'react';
+import { useState, useEffect, useCallback, useMemo, Suspense, use } from 'react';
 import { Box, Button, CircularProgress, Collapse, Stack, Typography } from '@mui/material';
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import { useNavigate } from 'react-router-dom';
 import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
 import SidebarDmList from '../components/Layout/SidebarDmList';
-import SearchResults from '../components/Chat/SearchResults';
+import SearchResults, { type AppliedFilter } from '../components/Chat/SearchResults';
 import SearchFilterPanel, { type SearchFilters } from '../components/Chat/SearchFilterPanel';
 import SavedViewsSection from '../components/Search/SavedViewsSection';
-import ChipFilterSection from '../components/Search/ChipFilterSection';
+import ChipFilterSection, {
+  getOrCreateMasterDataPromise,
+} from '../components/Search/ChipFilterSection';
 import { api } from '../api/client';
 import type { MessageSearchResult, SavedView } from '@chat-app/shared';
 import { useSnackbar } from '../contexts/SnackbarContext';
+
+function buildAppliedFilters(
+  searchQuery: string,
+  effective: SearchFilters,
+  lookup: {
+    users: { id: number; username: string }[];
+    channels: { id: number; name: string }[];
+    tags: { id: number; name: string }[];
+  },
+): AppliedFilter[] {
+  const filters: AppliedFilter[] = [];
+  const trimmed = searchQuery.trim();
+  if (trimmed) {
+    filters.push({ type: 'keyword', label: `キーワード: ${trimmed}` });
+  }
+  if (effective.dateFrom) {
+    filters.push({ type: 'dateFrom', label: `開始日: ${effective.dateFrom}` });
+  }
+  if (effective.dateTo) {
+    filters.push({ type: 'dateTo', label: `終了日: ${effective.dateTo}` });
+  }
+  if (effective.userId !== undefined) {
+    const u = lookup.users.find((x) => x.id === effective.userId);
+    filters.push({ type: 'sender', label: `送信者: ${u?.username ?? `#${effective.userId}`}` });
+  }
+  if (effective.hasAttachment !== undefined) {
+    filters.push({
+      type: 'attachment',
+      label: `添付ファイル: ${effective.hasAttachment ? 'あり' : 'なし'}`,
+    });
+  }
+  if (effective.channelId !== undefined) {
+    const c = lookup.channels.find((x) => x.id === effective.channelId);
+    filters.push({
+      type: 'channel',
+      label: `チャンネル: ${c?.name ?? `#${effective.channelId}`}`,
+    });
+  }
+  if (effective.tagIds && effective.tagIds.length > 0) {
+    for (const tagId of effective.tagIds) {
+      const t = lookup.tags.find((x) => x.id === tagId);
+      filters.push({ type: 'tag', label: `タグ: ${t?.name ?? `#${tagId}`}`, value: tagId });
+    }
+  }
+  return filters;
+}
+
+interface SearchResultsAreaProps {
+  results: MessageSearchResult[];
+  onNavigate: (channelId: number, messageId: number) => void;
+  keyword: string;
+  hasSearched: boolean;
+  searchQuery: string;
+  effectiveFilters: SearchFilters;
+  onRemoveFilter: (filter: AppliedFilter) => void;
+  onResetAll: () => void;
+}
+
+/**
+ * 結果が 0 件のときだけ master data を解決してチップラベルを構築する。
+ * 検索ヒット時は appliedFilters を計算しないため、無駄な suspend を発生させない。
+ */
+function SearchResultsArea({
+  results,
+  onNavigate,
+  keyword,
+  hasSearched,
+  searchQuery,
+  effectiveFilters,
+  onRemoveFilter,
+  onResetAll,
+}: SearchResultsAreaProps) {
+  const showSuggestions = hasSearched && results.length === 0;
+  return showSuggestions ? (
+    <Suspense
+      fallback={
+        <SearchResults
+          results={results}
+          onNavigate={onNavigate}
+          keyword={keyword}
+          hasSearched={hasSearched}
+        />
+      }
+    >
+      <SearchResultsWithSuggestions
+        results={results}
+        onNavigate={onNavigate}
+        keyword={keyword}
+        hasSearched={hasSearched}
+        searchQuery={searchQuery}
+        effectiveFilters={effectiveFilters}
+        onRemoveFilter={onRemoveFilter}
+        onResetAll={onResetAll}
+      />
+    </Suspense>
+  ) : (
+    <SearchResults
+      results={results}
+      onNavigate={onNavigate}
+      keyword={keyword}
+      hasSearched={hasSearched}
+    />
+  );
+}
+
+function SearchResultsWithSuggestions({
+  results,
+  onNavigate,
+  keyword,
+  hasSearched,
+  searchQuery,
+  effectiveFilters,
+  onRemoveFilter,
+  onResetAll,
+}: SearchResultsAreaProps) {
+  const master = use(getOrCreateMasterDataPromise());
+  const appliedFilters = useMemo(
+    () => buildAppliedFilters(searchQuery, effectiveFilters, master),
+    [searchQuery, effectiveFilters, master],
+  );
+  return (
+    <SearchResults
+      results={results}
+      onNavigate={onNavigate}
+      keyword={keyword}
+      hasSearched={hasSearched}
+      appliedFilters={appliedFilters}
+      onRemoveFilter={onRemoveFilter}
+      onResetAll={onResetAll}
+    />
+  );
+}
 
 /**
  * 検索ページ。クエリ入力 + チップ式フィルタ + 保存ビューを統合した独立ページ。
@@ -148,6 +282,61 @@ export default function SearchPage() {
     [showError],
   );
 
+  /**
+   * Issue #327: ゼロ件サジェスチョンからの個別解除。
+   * SearchFilterPanel 由来とチップ入力由来の両方を辿って該当フィルタを落とす。
+   * tag は配列の要素ごとに value で識別する。
+   */
+  const handleRemoveFilter = useCallback((filter: AppliedFilter) => {
+    switch (filter.type) {
+      case 'keyword':
+        setSearchQuery('');
+        setRawSearchText('');
+        break;
+      case 'dateFrom':
+        setSearchFilters((prev) => ({ ...prev, dateFrom: undefined }));
+        setChipFilters((prev) => ({ ...prev, dateFrom: undefined }));
+        break;
+      case 'dateTo':
+        setSearchFilters((prev) => ({ ...prev, dateTo: undefined }));
+        setChipFilters((prev) => ({ ...prev, dateTo: undefined }));
+        break;
+      case 'sender':
+        setSearchFilters((prev) => ({ ...prev, userId: undefined }));
+        setChipFilters((prev) => ({ ...prev, userId: undefined }));
+        break;
+      case 'attachment':
+        setSearchFilters((prev) => ({ ...prev, hasAttachment: undefined }));
+        setChipFilters((prev) => ({ ...prev, hasAttachment: undefined }));
+        break;
+      case 'channel':
+        setSearchFilters((prev) => ({ ...prev, channelId: undefined }));
+        setChipFilters((prev) => ({ ...prev, channelId: undefined }));
+        break;
+      case 'tag': {
+        const dropTagId = filter.value;
+        const without = (ids?: number[]) =>
+          ids && ids.length > 0 ? ids.filter((id) => id !== dropTagId) : undefined;
+        setSearchFilters((prev) => ({
+          ...prev,
+          tagIds: without(prev.tagIds)?.length ? without(prev.tagIds) : undefined,
+        }));
+        setChipFilters((prev) => ({
+          ...prev,
+          tagIds: without(prev.tagIds)?.length ? without(prev.tagIds) : undefined,
+        }));
+        break;
+      }
+    }
+  }, []);
+
+  const handleResetAll = useCallback(() => {
+    setSearchQuery('');
+    setRawSearchText('');
+    setSearchFilters({});
+    setChipFilters({});
+  }, []);
+
   return (
     <AppLayout
       defaultSidebarOpen={false}
@@ -276,11 +465,15 @@ export default function SearchPage() {
                 <CircularProgress size={24} />
               </Box>
             ) : (
-              <SearchResults
+              <SearchResultsArea
                 results={searchResults}
                 onNavigate={handleNavigate}
                 keyword={searchQuery}
                 hasSearched={hasSearched}
+                searchQuery={searchQuery}
+                effectiveFilters={effectiveFilters}
+                onRemoveFilter={handleRemoveFilter}
+                onResetAll={handleResetAll}
               />
             )}
           </Box>


### PR DESCRIPTION
## 概要
検索結果がゼロ件のときに「条件を広げる」セクションを表示し、現在適用中のフィルタを個別解除する解除チップと「すべての条件をリセット」ボタンを並べる。各操作は state を更新するだけで、既存の debounce useEffect が検索を自動再実行する。

## 変更内容
- `SearchResults`: `AppliedFilter` 型と `appliedFilters` / `onRemoveFilter` / `onResetAll` props を追加。結果 0 件かつ適用フィルタがあるときに `search-zero-suggestions` セクションを描画。
- `SearchPage`: 内部に `SearchResultsArea` を新設。結果 0 件時のみ `Suspense` 越しに master data (`users` / `channels` / `tags`) を解決し `appliedFilters` を構築する `SearchResultsWithSuggestions` を読み込む（結果ヒット時は不要な suspend を発生させない）。`handleRemoveFilter` / `handleResetAll` を実装。
- `ChipFilterSection`: 既存の `getOrCreateMasterDataPromise` を `export` してマスタデータ取得を再利用。
- `SearchPage.test.tsx`: `ChipFilterSection` mock に `getOrCreateMasterDataPromise` の空マスタデータ版を追加。
- `SearchResults.test.tsx`: #327 用に 8 件のテストを追加（セクション表示条件・チップ表示・解除コールバック・全リセット）。

## 影響範囲
- 検索ページ (`/search`) の結果ペイン。
- `SearchResults` を使う他箇所（影響を確認した限り SearchPage のみ）。新規 props はすべて optional のため後方互換。
- `ChipFilterSection` 内のキャッシュは export 化のみで挙動変更なし。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (`npm run test` で 142 ファイル 2418 件 PASS)
- [x] バックエンドユニットテストがすべてパスする (`npm run test` 配下で server 側 1669 件 PASS)
- [x] ビルドが正常に完了すること (`npm run build` 成功)
- [ ] (手動確認の場合) フィルタ適用 → ゼロ件 → チップで個別解除 → 即時再検索のフローを実機で確認

## 関連Issue
Fixes #327

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)