### PR TITLE
feat: 検索構文の入力補完 (#326)

### DIFF
--- a/packages/client/src/__tests__/ChipFilterInput.test.tsx
+++ b/packages/client/src/__tests__/ChipFilterInput.test.tsx
@@ -11,9 +11,10 @@
  *   - 純粋コンポーネント: users / channels / tags 配列を props で直接渡す
  */
 
+import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { User, Channel, Tag } from '@chat-app/shared';
 import ChipFilterInput from '../components/Search/ChipFilterInput';
 
@@ -81,6 +82,32 @@ function renderInput(opts: RenderOpts = {}) {
     />,
   );
   return { ...utils, onTextChange, onResolved };
+}
+
+/**
+ * value を内部 state で保持して onTextChange で更新する controlled な wrapper。
+ * ユーザー操作（入力 / 候補選択）の結果を実際に value へ反映できるようにする。
+ */
+function renderControlled(opts: RenderOpts = {}) {
+  const externalOnTextChange = opts.onTextChange;
+  const onResolved = opts.onResolved ?? vi.fn();
+  const Wrapper = () => {
+    const [v, setV] = useState(opts.value ?? '');
+    return (
+      <ChipFilterInput
+        value={v}
+        onTextChange={(text) => {
+          setV(text);
+          externalOnTextChange?.(text);
+        }}
+        onResolved={onResolved}
+        users={opts.users ?? []}
+        channels={opts.channels ?? []}
+        tags={opts.tags ?? []}
+      />
+    );
+  };
+  return render(<Wrapper />);
 }
 
 describe('ChipFilterInput (Step 7c-1)', () => {
@@ -182,6 +209,276 @@ describe('ChipFilterInput (Step 7c-1)', () => {
       });
       const lastCall = onResolved.mock.calls[onResolved.mock.calls.length - 1][0];
       expect(lastCall.filters.tagIds).toEqual([7]);
+    });
+  });
+
+  describe('検索構文オートコンプリート (Issue #326)', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    describe('構文キーワード候補の表示', () => {
+      it('入力欄からフォーカスが外れているときは候補リストが表示されない', async () => {
+        renderInput();
+        const input = screen.getByLabelText('メッセージ検索');
+        // TextField が autoFocus 持ちなのでテスト側で明示的に blur する
+        input.blur();
+        await new Promise((r) => setTimeout(r, 0));
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+
+      it('入力欄にフォーカスが当たり、トークンに `:` が含まれない場合は from:/in:/has:/tag:/before:/after: の構文候補が表示される', async () => {
+        renderControlled();
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        expect(screen.getByRole('option', { name: 'from:' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'in:' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'has:' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'tag:' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'before:' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'after:' })).toBeInTheDocument();
+      });
+
+      it('"fr" のように前方一致する構文だけに候補が絞り込まれる', async () => {
+        renderControlled();
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'fr');
+        expect(screen.getByRole('option', { name: 'from:' })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'in:' })).not.toBeInTheDocument();
+      });
+
+      it('構文候補をクリックすると入力テキストにプレフィックス（例: "from:"）が補完される', async () => {
+        const onTextChange = vi.fn();
+        renderControlled({ onTextChange });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.click(screen.getByRole('option', { name: 'from:' }));
+        expect(onTextChange).toHaveBeenLastCalledWith('from:');
+      });
+    });
+
+    describe('値の候補表示', () => {
+      it('"from:" を入力した直後、users 配列のユーザー名候補が表示される', async () => {
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' }), makeUser({ id: 2, username: 'bob' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        expect(screen.getByRole('option', { name: 'alice' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'bob' })).toBeInTheDocument();
+      });
+
+      it('"in:" を入力した直後、channels 配列のチャンネル名候補が表示される', async () => {
+        renderControlled({
+          channels: [
+            makeChannel({ id: 1, name: 'general' }),
+            makeChannel({ id: 2, name: 'random' }),
+          ],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'in:');
+        expect(screen.getByRole('option', { name: 'general' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'random' })).toBeInTheDocument();
+      });
+
+      it('"tag:" を入力した直後、tags 配列のタグ名候補が表示される', async () => {
+        renderControlled({
+          tags: [makeTag({ id: 1, name: 'urgent' }), makeTag({ id: 2, name: 'bug' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'tag:');
+        expect(screen.getByRole('option', { name: 'urgent' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'bug' })).toBeInTheDocument();
+      });
+
+      it('"has:" を入力した直後、file と link の固定候補が表示される', async () => {
+        renderControlled();
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'has:');
+        expect(screen.getByRole('option', { name: 'file' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'link' })).toBeInTheDocument();
+      });
+
+      it('"from:al" のように値部分の前方一致で候補が絞り込まれる（大小文字無視）', async () => {
+        renderControlled({
+          users: [
+            makeUser({ id: 1, username: 'alice' }),
+            makeUser({ id: 2, username: 'Albert' }),
+            makeUser({ id: 3, username: 'bob' }),
+          ],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:al');
+        expect(screen.getByRole('option', { name: 'alice' })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: 'Albert' })).toBeInTheDocument();
+        expect(screen.queryByRole('option', { name: 'bob' })).not.toBeInTheDocument();
+      });
+
+      it('値の候補をクリックすると、対応するトークン（例: "from:alice"）が入力される', async () => {
+        const onTextChange = vi.fn();
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' })],
+          onTextChange,
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.click(screen.getByRole('option', { name: 'alice' }));
+        expect(onTextChange).toHaveBeenLastCalledWith('from:alice');
+      });
+    });
+
+    describe('キーボード操作', () => {
+      it('ArrowDown で候補のハイライトが次の項目へ移動する', async () => {
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' }), makeUser({ id: 2, username: 'bob' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        // 初期状態では最初の項目がハイライト
+        expect(screen.getByRole('option', { name: 'alice' })).toHaveAttribute(
+          'aria-selected',
+          'true',
+        );
+        await userEvent.keyboard('{ArrowDown}');
+        expect(screen.getByRole('option', { name: 'bob' })).toHaveAttribute(
+          'aria-selected',
+          'true',
+        );
+      });
+
+      it('ArrowUp で候補のハイライトが前の項目へ移動する', async () => {
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' }), makeUser({ id: 2, username: 'bob' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{ArrowUp}');
+        expect(screen.getByRole('option', { name: 'alice' })).toHaveAttribute(
+          'aria-selected',
+          'true',
+        );
+      });
+
+      it('ハイライト中に Enter を押すと候補が補完される', async () => {
+        const onTextChange = vi.fn();
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' })],
+          onTextChange,
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.keyboard('{Enter}');
+        expect(onTextChange).toHaveBeenLastCalledWith('from:alice');
+      });
+
+      it('ハイライト中に Tab を押すと候補が補完される', async () => {
+        const onTextChange = vi.fn();
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' })],
+          onTextChange,
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.keyboard('{Tab}');
+        expect(onTextChange).toHaveBeenLastCalledWith('from:alice');
+      });
+
+      it('Escape で候補リストが閉じる', async () => {
+        renderControlled();
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+        await userEvent.keyboard('{Escape}');
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      });
+
+      it('候補リスト表示中の Enter / Tab はフォーム送信やフォーカス移動を引き起こさない', async () => {
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.keyboard('{Enter}');
+        // Enter 後もフォーカスは入力欄に留まる
+        expect(document.activeElement).toBe(input);
+      });
+    });
+
+    describe('使用履歴', () => {
+      it('値の候補を選択すると、選択値が localStorage に保存される', async () => {
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.click(screen.getByRole('option', { name: 'alice' }));
+        const stored = localStorage.getItem('searchChipHistory.from');
+        expect(stored).not.toBeNull();
+        expect(JSON.parse(stored!)).toContain('alice');
+      });
+
+      it('履歴がある場合、その値が候補リストの先頭に優先表示される', async () => {
+        localStorage.setItem('searchChipHistory.from', JSON.stringify(['bob']));
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' }), makeUser({ id: 2, username: 'bob' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        const options = screen.getAllByRole('option');
+        // bob が先頭に表示
+        expect(options[0]).toHaveTextContent('bob');
+        expect(options[1]).toHaveTextContent('alice');
+      });
+
+      it('履歴の保存件数は最大10件で、古いものから捨てられる', async () => {
+        // 既に10件保存済（先頭が最新、末尾が最古）
+        const existing = Array.from({ length: 10 }, (_, i) => `user${i}`);
+        localStorage.setItem('searchChipHistory.from', JSON.stringify(existing));
+        renderControlled({
+          users: [makeUser({ id: 99, username: 'newbie' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.click(screen.getByRole('option', { name: 'newbie' }));
+        const stored = JSON.parse(localStorage.getItem('searchChipHistory.from')!) as string[];
+        expect(stored.length).toBe(10);
+        expect(stored[0]).toBe('newbie');
+        // 末尾の最古 user9 が捨てられる
+        expect(stored).not.toContain('user9');
+      });
+
+      it('from: / in: / tag: は別キーで履歴管理される', async () => {
+        renderControlled({
+          users: [makeUser({ id: 1, username: 'alice' })],
+          channels: [makeChannel({ id: 10, name: 'general' })],
+        });
+        const input = screen.getByLabelText('メッセージ検索');
+        await userEvent.click(input);
+        await userEvent.type(input, 'from:');
+        await userEvent.click(screen.getByRole('option', { name: 'alice' }));
+        await userEvent.clear(input);
+        await userEvent.click(input);
+        await userEvent.type(input, 'in:');
+        await userEvent.click(screen.getByRole('option', { name: 'general' }));
+        expect(JSON.parse(localStorage.getItem('searchChipHistory.from')!)).toContain('alice');
+        expect(JSON.parse(localStorage.getItem('searchChipHistory.in')!)).toContain('general');
+      });
     });
   });
 });

--- a/packages/client/src/components/Search/ChipFilterInput.tsx
+++ b/packages/client/src/components/Search/ChipFilterInput.tsx
@@ -1,5 +1,14 @@
-import { useEffect, useMemo } from 'react';
-import { Box, Chip, TextField, Typography } from '@mui/material';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Chip,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  TextField,
+  Typography,
+} from '@mui/material';
 import type { User, Channel, Tag } from '@chat-app/shared';
 import { parseSearchChips, type ParsedSearchChips } from '../../utils/parseSearchChips';
 import type { SearchFilters } from '../Chat/SearchFilterPanel';
@@ -17,6 +26,128 @@ interface Props {
   tags: Tag[];
 }
 
+const PREFIX_OPTIONS = ['from:', 'in:', 'has:', 'tag:', 'before:', 'after:'] as const;
+const HAS_VALUES = ['file', 'link'] as const;
+const HISTORY_NAMESPACE = 'searchChipHistory';
+const HISTORY_MAX = 10;
+type HistoryKey = 'from' | 'in' | 'tag';
+
+function loadHistory(key: HistoryKey): string[] {
+  try {
+    const raw = localStorage.getItem(`${HISTORY_NAMESPACE}.${key}`);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveHistory(key: HistoryKey, value: string): void {
+  try {
+    const current = loadHistory(key);
+    const next = [value, ...current.filter((v) => v !== value)].slice(0, HISTORY_MAX);
+    localStorage.setItem(`${HISTORY_NAMESPACE}.${key}`, JSON.stringify(next));
+  } catch {
+    // localStorage 不可の環境では履歴を諦める
+  }
+}
+
+/** カーソル位置を含むトークン（空白で区切られた現在編集中の単語）の範囲を返す */
+function getActiveToken(
+  value: string,
+  cursorPos: number,
+): { token: string; start: number; end: number } {
+  let start = cursorPos;
+  let end = cursorPos;
+  while (start > 0 && !/\s/.test(value[start - 1])) start--;
+  while (end < value.length && !/\s/.test(value[end])) end++;
+  return { token: value.slice(start, end), start, end };
+}
+
+interface SuggestionItem {
+  /** 候補リストに表示する文字列 (role=option の name) */
+  display: string;
+  /** 補完したときにトークンに置換される文字列 */
+  insert: string;
+  /** 履歴保存対象のときに記録するキー */
+  historyKey?: HistoryKey;
+}
+
+interface SuggestionState {
+  items: SuggestionItem[];
+  tokenStart: number;
+  tokenEnd: number;
+}
+
+/**
+ * カーソル位置のトークンから補完候補を組み立てる。
+ *
+ * - トークンに `:` が含まれない → 構文プレフィックス (from:/in:/has:/tag:/before:/after:) を前方一致で返す
+ * - `from:` / `in:` / `tag:` → マスタデータの名前を前方一致 (大小無視) で返す。履歴を先頭に並べ替える
+ * - `has:` → file / link の固定候補を返す
+ * - それ以外 (before: / after:) → 候補なし
+ */
+function buildSuggestions(
+  value: string,
+  cursorPos: number,
+  users: User[],
+  channels: Channel[],
+  tags: Tag[],
+): SuggestionState | null {
+  const { token, start, end } = getActiveToken(value, cursorPos);
+  const colonIdx = token.indexOf(':');
+
+  if (colonIdx < 0) {
+    const lower = token.toLowerCase();
+    const items = PREFIX_OPTIONS.filter((p) => p.toLowerCase().startsWith(lower)).map((p) => ({
+      display: p,
+      insert: p,
+    }));
+    if (items.length === 0) return null;
+    return { items, tokenStart: start, tokenEnd: end };
+  }
+
+  const prefix = token.slice(0, colonIdx);
+  const valuePart = token.slice(colonIdx + 1);
+  const lower = valuePart.toLowerCase();
+
+  let pool: string[];
+  let historyKey: HistoryKey | undefined;
+  if (prefix === 'from') {
+    pool = users.map((u) => u.username);
+    historyKey = 'from';
+  } else if (prefix === 'in') {
+    pool = channels.map((c) => c.name);
+    historyKey = 'in';
+  } else if (prefix === 'tag') {
+    pool = tags.map((t) => t.name);
+    historyKey = 'tag';
+  } else if (prefix === 'has') {
+    pool = [...HAS_VALUES];
+  } else {
+    return null;
+  }
+
+  const filtered = pool.filter((n) => n.toLowerCase().startsWith(lower));
+  if (filtered.length === 0) return null;
+
+  const history = historyKey ? loadHistory(historyKey) : [];
+  const historyHits = history.filter((h) => filtered.includes(h));
+  const remaining = filtered.filter((n) => !historyHits.includes(n));
+  const sorted = [...historyHits, ...remaining];
+
+  return {
+    items: sorted.map((name) => ({
+      display: name,
+      insert: `${prefix}:${name}`,
+      historyKey,
+    })),
+    tokenStart: start,
+    tokenEnd: end,
+  };
+}
+
 /**
  * 検索ページ上部のチップ式フィルタ入力欄 (純粋コンポーネント)。
  * マスタデータ (users / channels / tags) は親 (ChipFilterSection) が Suspense 経由で取得して渡す。
@@ -26,6 +157,8 @@ interface Props {
  *   2. fromUsername / inChannelName / tagName を ID に変換 (大文字小文字無視で照合)
  *   3. `{ keyword, filters }` を親に通知
  *   4. 解析結果のチップを TextField の下に表示 (読み取り専用)
+ *   5. カーソル位置のトークンから補完候補をリストボックスに表示し
+ *      ArrowUp/Down/Enter/Tab/Escape で操作可能 (Issue #326)
  *
  * `has:link` は未対応 (`hasFile` のみ対応)。
  */
@@ -39,7 +172,6 @@ export default function ChipFilterInput({
 }: Props) {
   const parsed: ParsedSearchChips = useMemo(() => parseSearchChips(value), [value]);
 
-  // マスタ照合 → SearchFilters への変換
   const resolved = useMemo(() => {
     const filters: Partial<SearchFilters> = {};
     if (parsed.fromUsername) {
@@ -64,10 +196,49 @@ export default function ChipFilterInput({
     return { keyword: parsed.keyword, filters };
   }, [parsed, users, channels, tags]);
 
-  // resolved が変わるたび親に通知
   useEffect(() => {
     onResolved(resolved);
   }, [resolved, onResolved]);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isFocused, setIsFocused] = useState(false);
+  const [escapeClosed, setEscapeClosed] = useState(false);
+  const [cursorPos, setCursorPos] = useState(0);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  const suggestions = useMemo(() => {
+    if (!isFocused || escapeClosed) return null;
+    return buildSuggestions(value, cursorPos, users, channels, tags);
+  }, [isFocused, escapeClosed, value, cursorPos, users, channels, tags]);
+
+  useEffect(() => {
+    setActiveIdx(0);
+  }, [suggestions]);
+
+  function applySuggestion(
+    item: SuggestionItem,
+    range: { tokenStart: number; tokenEnd: number },
+  ): void {
+    const newValue = value.slice(0, range.tokenStart) + item.insert + value.slice(range.tokenEnd);
+    onTextChange(newValue);
+    if (item.historyKey) saveHistory(item.historyKey, item.display);
+    // 補完直後はカーソルを補完後トークンの末尾に移動
+    const newCursor = range.tokenStart + item.insert.length;
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (el) {
+        el.focus();
+        el.setSelectionRange(newCursor, newCursor);
+      }
+    });
+    setCursorPos(newCursor);
+  }
+
+  function updateCursor(): void {
+    const el = inputRef.current;
+    if (!el) return;
+    setCursorPos(el.selectionStart ?? el.value.length);
+  }
 
   // 解析結果のチップをまとめる (表示用)
   const chips: Array<{ key: string; label: string; matched: boolean }> = [];
@@ -102,17 +273,106 @@ export default function ChipFilterInput({
     });
   }
 
+  const listboxId = 'chip-filter-suggestions';
+
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, position: 'relative' }}>
       <TextField
         fullWidth
         size="small"
         placeholder="例: from:alice has:file 議事録"
         value={value}
-        onChange={(e) => onTextChange(e.target.value)}
-        inputProps={{ 'aria-label': 'メッセージ検索' }}
+        onChange={(e) => {
+          onTextChange(e.target.value);
+          setEscapeClosed(false);
+          // onChange 後の selectionStart は最新位置
+          const target = e.target as HTMLInputElement;
+          setCursorPos(target.selectionStart ?? target.value.length);
+        }}
+        onFocus={() => {
+          setIsFocused(true);
+          setEscapeClosed(false);
+          updateCursor();
+        }}
+        onBlur={() => setIsFocused(false)}
+        onClick={updateCursor}
+        onKeyUp={(e) => {
+          // ArrowLeft / ArrowRight などのキャレット移動を反映
+          if (e.key.startsWith('Arrow') && e.key !== 'ArrowUp' && e.key !== 'ArrowDown') {
+            updateCursor();
+          }
+        }}
+        onKeyDown={(e) => {
+          if (!suggestions || suggestions.items.length === 0) return;
+          if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setActiveIdx((i) => (i + 1) % suggestions.items.length);
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setActiveIdx((i) => (i - 1 + suggestions.items.length) % suggestions.items.length);
+          } else if (e.key === 'Enter' || e.key === 'Tab') {
+            e.preventDefault();
+            const item = suggestions.items[activeIdx] ?? suggestions.items[0];
+            if (item) {
+              applySuggestion(item, {
+                tokenStart: suggestions.tokenStart,
+                tokenEnd: suggestions.tokenEnd,
+              });
+            }
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            setEscapeClosed(true);
+          }
+        }}
+        inputRef={inputRef}
+        inputProps={{
+          'aria-label': 'メッセージ検索',
+          'aria-autocomplete': 'list',
+          'aria-controls': listboxId,
+          'aria-expanded': !!suggestions,
+        }}
         autoFocus
       />
+      {suggestions && (
+        <Paper
+          elevation={3}
+          sx={{
+            position: 'absolute',
+            top: '100%',
+            left: 0,
+            right: 0,
+            zIndex: 10,
+            mt: 0.5,
+            maxHeight: 280,
+            overflowY: 'auto',
+          }}
+        >
+          <List id={listboxId} role="listbox" dense disablePadding>
+            {suggestions.items.map((item, idx) => {
+              const active = idx === activeIdx;
+              return (
+                <ListItemButton
+                  key={`${item.insert}:${idx}`}
+                  role="option"
+                  aria-label={item.display}
+                  aria-selected={active}
+                  selected={active}
+                  // mousedown が blur より先に発生するため、blur で suggestions が消えないように抑止
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() =>
+                    applySuggestion(item, {
+                      tokenStart: suggestions.tokenStart,
+                      tokenEnd: suggestions.tokenEnd,
+                    })
+                  }
+                >
+                  <ListItemText primary={item.display} primaryTypographyProps={{ fontSize: 14 }} />
+                </ListItemButton>
+              );
+            })}
+          </List>
+        </Paper>
+      )}
       {chips.length > 0 && (
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }} data-testid="chip-filter-chips">
           {chips.map((c) => (


### PR DESCRIPTION
## 概要
検索ページのチップ式フィルタ入力欄に、カーソル位置のトークンを解析するオートコンプリート機能を追加した。

## 変更内容
- `packages/client/src/components/Search/ChipFilterInput.tsx`
  - カーソル位置のトークンを抽出する `getActiveToken` を追加
  - 構文候補 / 値候補を組み立てる `buildSuggestions` を追加
  - `localStorage` を使った使用履歴の load/save ヘルパを追加
  - 入力欄に `aria-autocomplete=list` を付与し、その下に `role=listbox` の候補リストを表示
  - ArrowUp/Down/Enter/Tab/Escape のキーボードハンドリングを追加
- `packages/client/src/__tests__/ChipFilterInput.test.tsx`
  - 「検索構文オートコンプリート (Issue #326)」セクション (20 件) を追加

### 候補の仕様
- 入力中トークンに `:` が含まれない → `from:` `in:` `has:` `tag:` `before:` `after:` を前方一致で表示
- `from:` / `in:` / `tag:` → users / channels / tags の名前を前方一致（大小無視）で絞り込み
- `has:` → `file` / `link` の固定候補
- 値の選択時に `searchChipHistory.{from,in,tag}` キーで履歴を localStorage に保存（最大 10 件、最新が先頭）
- 履歴は次回入力時に候補リストの先頭に優先表示
- `before:` / `after:` は日付なので履歴対象外

### 操作
- ArrowDown / ArrowUp でハイライト移動（循環）
- Enter / Tab で選択（`preventDefault` でフォーム送信 / フォーカス移動を抑止）
- Escape で候補リストを閉じる（再度入力で再表示）
- 候補クリックの mousedown は `preventDefault` で blur 抑止

## 影響範囲
- 検索ページ (`/search`) のチップ式フィルタ入力欄
- 既存の `parseSearchChips` / マスタデータ照合ロジックは変更なし
- 既存テスト 12 件はそのまま通過

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (2438 件)
- [x] バックエンドユニットテストがすべてパスする (1669 件)
- [x] ビルドが正常に完了すること
- [x] `ChipFilterInput.test.tsx` 32 件すべてパス（既存 12 件 + Issue #326 で追加 20 件）

## 関連Issue
Fixes #326

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)