### PR TITLE
feat: タスクカードのドラッグハンドル分離 (#329)

### DIFF
--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -28,8 +28,10 @@ vi.mock('@dnd-kit/sortable', () => ({
   SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   verticalListSortingStrategy: vi.fn(),
   useSortable: () => ({
-    attributes: {},
-    listeners: {},
+    attributes: { 'data-dnd-attrs': 'true' },
+    // Issue #329: listeners がどの要素にスプレッドされたかをテストで判定できるよう
+    // data-* マーカーを混ぜる（本番では onPointerDown 等のハンドラが入る）
+    listeners: { 'data-dnd-listener': 'true' } as unknown as Record<string, () => void>,
     setNodeRef: vi.fn(),
     transform: null,
     transition: null,
@@ -720,6 +722,207 @@ describe('TaskBoardPage', () => {
       await screen.findByTestId('app-layout-sidebar');
       await userEvent.click(screen.getByText('select-channel-7'));
       expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7');
+    });
+  });
+
+  describe('タスクカードのドラッグハンドル分離 (Issue #329)', () => {
+    describe('ドラッグハンドル', () => {
+      it('カード左端に並べ替え用ドラッグハンドル（aria-label="ドラッグして並べ替え"）が表示される', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        const card = screen.getByTestId('task-card-1');
+        expect(
+          within(card).getByRole('button', { name: 'ドラッグして並べ替え' }),
+        ).toBeInTheDocument();
+      });
+
+      it('ドラッグハンドル要素は cursor: grab スタイルを持つ', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        const handle = within(screen.getByTestId('task-card-1')).getByRole('button', {
+          name: 'ドラッグして並べ替え',
+        });
+        expect(handle).toHaveStyle({ cursor: 'grab' });
+      });
+
+      it('Paper（カード）本体には dnd-kit の listeners が直接付与されない（カード全体ドラッグではない）', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        const card = screen.getByTestId('task-card-1');
+        // listeners は data-dnd-listener マーカー付きでモックしている。
+        // Paper にスプレッドされず、ハンドルにのみスプレッドされていることを検証。
+        expect(card).not.toHaveAttribute('data-dnd-listener');
+        const handle = within(card).getByRole('button', { name: 'ドラッグして並べ替え' });
+        expect(handle).toHaveAttribute('data-dnd-listener');
+      });
+    });
+
+    describe('カード本文クリックで詳細(編集)モーダルが開く', () => {
+      it('タスクのタイトル領域をクリックすると EditTaskDialog が開く', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByText('TODO タスク')).toBeInTheDocument();
+        });
+        await userEvent.click(screen.getByText('TODO タスク'));
+        expect(screen.getByTestId('edit-task-dialog')).toBeInTheDocument();
+      });
+
+      it('ドラッグハンドルをクリックしても EditTaskDialog は開かない', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        const handle = within(screen.getByTestId('task-card-1')).getByRole('button', {
+          name: 'ドラッグして並べ替え',
+        });
+        await userEvent.click(handle);
+        expect(screen.queryByTestId('edit-task-dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    describe('既存アイコンは引き続き動作する', () => {
+      it('編集アイコンクリックで EditTaskDialog が開く（カード本文クリックと同じだがイベントは伝播しない）', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        await userEvent.click(
+          screen.getByTestId('task-card-1').querySelector('[aria-label="タスクを編集"]')!,
+        );
+        expect(screen.getByTestId('edit-task-dialog')).toBeInTheDocument();
+      });
+
+      it('削除アイコンクリックで EditTaskDialog は開かず delete API が呼ばれる', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        await userEvent.click(
+          screen.getByTestId('task-card-1').querySelector('[aria-label="タスクを削除"]')!,
+        );
+        expect(screen.queryByTestId('edit-task-dialog')).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(mockTasksDelete).toHaveBeenCalledWith(1);
+        });
+      });
+
+      it('非表示アイコンクリックで EditTaskDialog は開かず update が呼ばれる', async () => {
+        mockTasksUpdate.mockResolvedValue({ task: { ...makeTasks()[0], isHidden: true } });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        await userEvent.click(
+          screen.getByTestId('task-card-1').querySelector('[aria-label="タスクを非表示"]')!,
+        );
+        expect(screen.queryByTestId('edit-task-dialog')).not.toBeInTheDocument();
+        await waitFor(() => {
+          expect(mockTasksUpdate).toHaveBeenCalledWith(1, { isHidden: true });
+        });
+      });
+
+      it('カレンダー表示アイコンクリックで EditTaskDialog は開かず navigate される', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          // dueAt がセットされているのは task id=3
+          expect(screen.getByTestId('task-card-3')).toBeInTheDocument();
+        });
+        await userEvent.click(
+          screen.getByTestId('task-card-3').querySelector('[aria-label="カレンダーで表示"]')!,
+        );
+        expect(screen.queryByTestId('edit-task-dialog')).not.toBeInTheDocument();
+        expect(mockNavigate).toHaveBeenCalledWith(expect.stringMatching(/^\/calendar\?date=/));
+      });
+    });
+
+    describe('キーボード操作', () => {
+      it('ドラッグハンドルが Tab でフォーカス可能（button 要素として実装される）', async () => {
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+        await waitFor(() => {
+          expect(screen.getByTestId('task-card-1')).toBeInTheDocument();
+        });
+        const handle = within(screen.getByTestId('task-card-1')).getByRole('button', {
+          name: 'ドラッグして並べ替え',
+        });
+        handle.focus();
+        expect(document.activeElement).toBe(handle);
+      });
     });
   });
 

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -24,6 +24,7 @@ import LinkIcon from '@mui/icons-material/Link';
 import EventIcon from '@mui/icons-material/Event';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import VisibilityIcon from '@mui/icons-material/Visibility';
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import {
   DndContext,
   closestCorners,
@@ -104,19 +105,42 @@ function SortableTaskCard({
     <Paper
       ref={setNodeRef}
       style={style}
-      {...attributes}
-      {...listeners}
       sx={{
         p: 1.5,
         mb: 1,
-        cursor: 'grab',
+        cursor: 'pointer',
         border: overdue ? '1px solid' : 'none',
         borderColor: overdue ? 'error.main' : undefined,
-        '&:active': { cursor: 'grabbing' },
       }}
       data-testid={`task-card-${task.id}`}
+      onClick={() => onEdit(task)}
     >
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        {/* Issue #329: ドラッグハンドルを左端に分離。dnd-kit の attributes/listeners をここに限定 */}
+        <Box
+          component="button"
+          type="button"
+          aria-label="ドラッグして並べ替え"
+          {...attributes}
+          {...listeners}
+          onClick={(e) => e.stopPropagation()}
+          style={{ cursor: 'grab' }}
+          sx={{
+            border: 'none',
+            bgcolor: 'transparent',
+            color: 'text.secondary',
+            display: 'flex',
+            alignItems: 'center',
+            p: 0.5,
+            mr: 0.5,
+            mt: -0.25,
+            touchAction: 'none',
+            '&:active': { cursor: 'grabbing' },
+            '&:focus-visible': { outline: 'auto' },
+          }}
+        >
+          <DragIndicatorIcon fontSize="small" />
+        </Box>
         <Typography variant="body2" fontWeight="medium" sx={{ flex: 1, mr: 1 }}>
           {task.title}
         </Typography>


### PR DESCRIPTION
## 概要
タスクカード全体がドラッグ対象になっていたため、本文クリックや既存アイコン操作とドラッグの意図が競合していた。左端に専用ドラッグハンドルを分離し、カード本文クリックで詳細(編集)モーダルが開く動線に変更した。

## 変更内容
- `packages/client/src/pages/TaskBoardPage.tsx`
  - `SortableTaskCard` の `Paper` から `{...attributes} {...listeners}` を外す
  - 左端に `<Box component="button">` の専用ハンドル（`DragIndicatorIcon`）を新設し、ここに `{...attributes} {...listeners}` を限定付与
  - `Paper` に `onClick={() => onEdit(task)}` を追加。カード本文クリックで `EditTaskDialog` を開く
  - `cursor: 'grab'` をカード全体からハンドルのみに移動。Paper は `cursor: 'pointer'`
  - ハンドル `onClick` は `e.stopPropagation()` でカード本文クリックを止める
- `packages/client/src/__tests__/TaskBoardPage.test.tsx`
  - 「タスクカードのドラッグハンドル分離 (Issue #329)」セクション 10 件を追加
  - `@dnd-kit/sortable` のモックの `listeners` に `data-dnd-listener` マーカーを追加し、ハンドルにのみスプレッドされていることを検証

## 設計メモ
- **詳細モーダル**: 事前合意により既存の `EditTaskDialog` を兼用（カード本文クリック ≡ 編集アイコンクリック）
- **キーボード操作**: ハンドルを native `<button>` 要素にすることで Tab フォーカスに対応。dnd-kit のキーボード操作（Tab+Space+矢印）はハンドル focus 経由で機能する
- **既存テストへの影響**: 既存テストはアイコンクリック / 表示確認のみで、本文 onClick 追加では壊れない

## 影響範囲
- タスクボードページ (`/tasks`) のカード操作のみ
- 既存テスト32件はそのまま通過、新規10件追加

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (2448 件、+10件)
- [x] バックエンドユニットテストがすべてパスする (1669 件)
- [x] ビルドが正常に完了すること
- [x] TaskBoardPage.test.tsx 42 件すべてパス

## 関連Issue
Fixes #329

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)