### PR TITLE
feat: カレンダー月表示のイベント密度改善 (#330)

### DIFF
--- a/packages/client/src/__tests__/MonthView.test.tsx
+++ b/packages/client/src/__tests__/MonthView.test.tsx
@@ -12,7 +12,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { MonthView } from '../components/Calendar/MonthView';
-import type { CalendarEvent } from '@chat-app/shared';
+import type { CalendarEvent, Channel, Task } from '@chat-app/shared';
 
 const TODAY = new Date(2026, 4, 15); // 2026-05-15 (金)
 const CURSOR = new Date(2026, 4, 15);
@@ -21,6 +21,44 @@ const channelColors = new Map<number, string>([
   [10, '#1976d2'],
   [11, '#d81b60'],
 ]);
+
+function makeChannel(id: number, name: string): Channel {
+  return {
+    id,
+    name,
+    description: null,
+    topic: null,
+    createdBy: 1,
+    createdAt: '2026-04-30T00:00:00Z',
+    isPrivate: false,
+    postingPermission: 'everyone',
+    unreadCount: 0,
+  };
+}
+
+function makeTask(
+  id: number,
+  dueAt: string | null,
+  title = `T${id}`,
+  status: Task['status'] = 'todo',
+): Task {
+  return {
+    id,
+    title,
+    description: null,
+    status,
+    assigneeId: null,
+    assigneeUsername: null,
+    dueAt,
+    sourceMessageId: null,
+    sourceChannelId: null,
+    createdBy: 1,
+    position: 0,
+    isHidden: false,
+    createdAt: '2026-04-30T00:00:00Z',
+    updatedAt: '2026-04-30T00:00:00Z',
+  };
+}
 
 function makeEvent(
   id: number,
@@ -271,6 +309,212 @@ describe('MonthView', () => {
       await userEvent.click(block);
       expect(onEventClick).toHaveBeenCalledTimes(1);
       expect(onDayClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('イベント密度改善 (Issue #330)', () => {
+    describe('種別アイコン', () => {
+      it('チャンネルイベントのバーには種別=channel のアイコンが表示される', () => {
+        const ev = makeEvent(1, 10, '2026-05-10T10:00:00Z');
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        const icon = within(block).getByTestId('event-type-icon');
+        expect(icon).toHaveAttribute('data-event-kind', 'channel');
+      });
+
+      it('個人予定 (channelId=null) のバーには種別=personal のアイコンが表示される', () => {
+        const ev = makeEvent(1, null, '2026-05-10T10:00:00Z');
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        const icon = within(block).getByTestId('event-type-icon');
+        expect(icon).toHaveAttribute('data-event-kind', 'personal');
+      });
+
+      it('タスクバーには種別=task のアイコンが表示される', () => {
+        const task = makeTask(1, new Date(2026, 4, 10, 10).toISOString());
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('task-block-1');
+        const icon = within(block).getByTestId('event-type-icon');
+        expect(icon).toHaveAttribute('data-event-kind', 'task');
+      });
+    });
+
+    describe('チャンネル略称', () => {
+      it('ASCII チャンネル名「general」はイベントバー末尾に略称「gen」(3字)が表示される', () => {
+        const ev = makeEvent(1, 10, '2026-05-10T10:00:00Z');
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channels={[makeChannel(10, 'general')]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        const abbr = within(block).getByTestId('event-channel-abbr');
+        expect(abbr).toHaveTextContent('gen');
+      });
+
+      it('日本語チャンネル名「技術部」はイベントバー末尾に略称「技術」(2字)が表示される', () => {
+        const ev = makeEvent(1, 10, '2026-05-10T10:00:00Z');
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channels={[makeChannel(10, '技術部')]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        const abbr = within(block).getByTestId('event-channel-abbr');
+        expect(abbr).toHaveTextContent('技術');
+      });
+
+      it('channelId が null のイベントには略称が表示されない', () => {
+        const ev = makeEvent(1, null, '2026-05-10T10:00:00Z');
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channels={[makeChannel(10, 'general')]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        expect(within(block).queryByTestId('event-channel-abbr')).toBeNull();
+      });
+
+      it('channels props が未指定のときは略称が表示されない（後方互換）', () => {
+        const ev = makeEvent(1, 10, '2026-05-10T10:00:00Z');
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        expect(within(block).queryByTestId('event-channel-abbr')).toBeNull();
+      });
+    });
+
+    describe('今日のバーハイライト', () => {
+      it('今日のセル内のイベントバーには data-today-bar="true" が付与される', () => {
+        // ローカルタイムで TODAY と同日のイベント
+        const ev = makeEvent(1, 10, new Date(2026, 4, 15, 10).toISOString());
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        expect(block).toHaveAttribute('data-today-bar', 'true');
+      });
+
+      it('今日以外のセル内のイベントバーには data-today-bar="true" が付与されない', () => {
+        const ev = makeEvent(1, 10, new Date(2026, 4, 10, 10).toISOString());
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[ev]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('event-block-1');
+        expect(block).not.toHaveAttribute('data-today-bar', 'true');
+      });
+
+      it('今日のセル内のタスクバーにも data-today-bar="true" が付与される', () => {
+        const task = makeTask(1, new Date(2026, 4, 15, 10).toISOString());
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={[]}
+            tasks={[task]}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const block = screen.getByTestId('task-block-1');
+        expect(block).toHaveAttribute('data-today-bar', 'true');
+      });
+    });
+
+    describe('「+N 件」集約は維持される', () => {
+      it('1日に 4 件以上のイベントがある場合も「+N 件」が表示される（既存挙動の維持）', () => {
+        const day = '2026-05-10';
+        const evs = [
+          makeEvent(1, 10, `${day}T09:00:00Z`),
+          makeEvent(2, 10, `${day}T10:00:00Z`),
+          makeEvent(3, 10, `${day}T11:00:00Z`),
+          makeEvent(4, 10, `${day}T12:00:00Z`),
+        ];
+        render(
+          <MonthView
+            cursor={CURSOR}
+            today={TODAY}
+            events={evs}
+            channelColors={channelColors}
+            onEventClick={onEventClick}
+            onDayClick={onDayClick}
+          />,
+        );
+        const start = new Date(`${day}T09:00:00Z`);
+        const cell = screen.getByTestId(
+          `day-cell-${start.getFullYear()}-${start.getMonth()}-${start.getDate()}`,
+        );
+        expect(within(cell).getByText('+1 件')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/client/src/components/Calendar/MonthView.tsx
+++ b/packages/client/src/components/Calendar/MonthView.tsx
@@ -1,13 +1,17 @@
 // Issue #152 — カレンダー月表示（7×6 グリッド）
 // Issue #267 — 期限付きタスクの表示と DnD による期限変更
+// Issue #330 — イベント種別アイコン・チャンネル略称・今日のバーハイライト
 
 import { useMemo } from 'react';
 import { Box, Typography } from '@mui/material';
 import RepeatIcon from '@mui/icons-material/Repeat';
+import TagIcon from '@mui/icons-material/Tag';
+import PersonIcon from '@mui/icons-material/Person';
+import AssignmentIcon from '@mui/icons-material/Assignment';
 import { useDroppable, useDraggable } from '@dnd-kit/core';
 
 import { WEEKDAYS_JA, fmtTime, sameDay, startOfMonthGrid } from '../../utils/calendar';
-import type { CalendarEvent, Task } from '@chat-app/shared';
+import type { CalendarEvent, Channel, Task } from '@chat-app/shared';
 
 interface Props {
   cursor: Date;
@@ -15,6 +19,8 @@ interface Props {
   events: CalendarEvent[];
   tasks?: Task[];
   channelColors: Map<number, string>;
+  /** チャンネル略称表示用。未指定なら略称を出さない（後方互換） */
+  channels?: Channel[];
   onEventClick: (event: CalendarEvent) => void;
   onDayClick: (date: Date) => void;
   onTaskClick?: (task: Task) => void;
@@ -38,6 +44,19 @@ function dayKey(d: Date): string {
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
 }
 
+/**
+ * Issue #330: チャンネル名の先頭を 2〜3 字で略称化する。
+ * ASCII 文字列なら 3 字、それ以外（日本語等）なら 2 字。
+ */
+function channelAbbr(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return '';
+  const isAscii = /^[\x20-\x7E]+$/.test(trimmed);
+  return Array.from(trimmed)
+    .slice(0, isAscii ? 3 : 2)
+    .join('');
+}
+
 interface DayCellProps {
   date: Date;
   inMonth: boolean;
@@ -50,6 +69,7 @@ interface DayCellProps {
   dayEvents: CalendarEvent[];
   dayTasks: Task[];
   channelColors: Map<number, string>;
+  channelsById: Map<number, Channel>;
   onEventClick: (event: CalendarEvent) => void;
   onDayClick: (date: Date) => void;
   onTaskClick?: (task: Task) => void;
@@ -67,6 +87,7 @@ function DayCell({
   dayEvents,
   dayTasks,
   channelColors,
+  channelsById,
   onEventClick,
   onDayClick,
   onTaskClick,
@@ -139,10 +160,15 @@ function DayCell({
           const color =
             ev.channelId !== null ? (channelColors.get(ev.channelId) ?? '#1976d2') : '#1976d2';
           const startDate = new Date(ev.startsAt);
+          const kind: 'channel' | 'personal' = ev.channelId !== null ? 'channel' : 'personal';
+          const channel = ev.channelId !== null ? channelsById.get(ev.channelId) : undefined;
+          const abbr = channel ? channelAbbr(channel.name) : '';
           return (
             <Box
               key={ev.id}
               data-testid={`event-block-${ev.id}`}
+              data-event-kind={kind}
+              {...(isToday ? { 'data-today-bar': 'true' } : {})}
               onClick={(e) => {
                 e.stopPropagation();
                 onEventClick(ev);
@@ -154,30 +180,65 @@ function DayCell({
                 py: 0.25,
                 borderRadius: 0.5,
                 fontSize: 11,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.25,
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',
-                textOverflow: 'ellipsis',
                 cursor: 'pointer',
+                outline: isToday ? '2px solid' : 'none',
+                outlineColor: isToday ? 'primary.dark' : 'transparent',
                 '&:hover': { opacity: 0.85 },
               }}
               title={`${fmtTime(startDate)} ${ev.title}`}
             >
-              <Box component="span" sx={{ opacity: 0.85, fontWeight: 500, mr: 0.5 }}>
+              <Box
+                component="span"
+                data-testid="event-type-icon"
+                data-event-kind={kind}
+                sx={{ display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}
+              >
+                {kind === 'channel' ? (
+                  <TagIcon sx={{ fontSize: 12 }} />
+                ) : (
+                  <PersonIcon sx={{ fontSize: 12 }} />
+                )}
+              </Box>
+              <Box component="span" sx={{ opacity: 0.85, fontWeight: 500, flexShrink: 0 }}>
                 {fmtTime(startDate)}
               </Box>
               {(ev.recurrenceRule !== null || ev.recurrenceMasterId !== null) && (
                 <RepeatIcon
                   data-testid={`event-recurrence-icon-${ev.id}`}
-                  sx={{ fontSize: 11, mr: 0.25, verticalAlign: 'text-bottom' }}
+                  sx={{ fontSize: 11, flexShrink: 0 }}
                 />
               )}
-              {ev.title}
+              <Box
+                component="span"
+                sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}
+              >
+                {ev.title}
+              </Box>
+              {abbr && (
+                <Box
+                  component="span"
+                  data-testid="event-channel-abbr"
+                  sx={{ opacity: 0.85, fontSize: 10, ml: 0.25, flexShrink: 0 }}
+                >
+                  {abbr}
+                </Box>
+              )}
             </Box>
           );
         })}
 
         {tasksToShow.map((task) => (
-          <DraggableTaskBlock key={task.id} task={task} onTaskClick={onTaskClick} />
+          <DraggableTaskBlock
+            key={task.id}
+            task={task}
+            isToday={isToday}
+            onTaskClick={onTaskClick}
+          />
         ))}
 
         {overflow > 0 && (
@@ -192,10 +253,11 @@ function DayCell({
 
 interface DraggableTaskBlockProps {
   task: Task;
+  isToday: boolean;
   onTaskClick?: (task: Task) => void;
 }
 
-function DraggableTaskBlock({ task, onTaskClick }: DraggableTaskBlockProps) {
+function DraggableTaskBlock({ task, isToday, onTaskClick }: DraggableTaskBlockProps) {
   const { setNodeRef, attributes, listeners, isDragging } = useDraggable({ id: `task-${task.id}` });
   const due = task.dueAt ? new Date(task.dueAt) : null;
   const dueText = due ? `${due.getFullYear()}/${due.getMonth() + 1}/${due.getDate()}` : '';
@@ -209,6 +271,8 @@ function DraggableTaskBlock({ task, onTaskClick }: DraggableTaskBlockProps) {
       {...listeners}
       data-testid={`task-block-${task.id}`}
       data-task-status={task.status}
+      data-event-kind="task"
+      {...(isToday ? { 'data-today-bar': 'true' } : {})}
       onClick={(e) => {
         e.stopPropagation();
         onTaskClick?.(task);
@@ -221,19 +285,33 @@ function DraggableTaskBlock({ task, onTaskClick }: DraggableTaskBlockProps) {
         py: 0.25,
         borderRadius: 0.5,
         fontSize: 11,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 0.25,
         whiteSpace: 'nowrap',
         overflow: 'hidden',
-        textOverflow: 'ellipsis',
         cursor: 'grab',
         opacity: isDragging ? 0.5 : 1,
         textDecoration: task.status === 'done' ? 'line-through' : 'none',
+        outline: isToday ? '2px solid' : 'none',
+        outlineColor: isToday ? 'primary.dark' : 'transparent',
         '&:hover': { opacity: 0.85 },
       }}
     >
-      <Box component="span" sx={{ opacity: 0.85, fontWeight: 500, mr: 0.5 }}>
-        [タスク]
+      <Box
+        component="span"
+        data-testid="event-type-icon"
+        data-event-kind="task"
+        sx={{ display: 'inline-flex', alignItems: 'center', flexShrink: 0 }}
+      >
+        <AssignmentIcon sx={{ fontSize: 12 }} />
       </Box>
-      {task.title}
+      <Box
+        component="span"
+        sx={{ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis' }}
+      >
+        {task.title}
+      </Box>
     </Box>
   );
 }
@@ -244,6 +322,7 @@ export function MonthView({
   events,
   tasks = [],
   channelColors,
+  channels,
   onEventClick,
   onDayClick,
   onTaskClick,
@@ -259,6 +338,14 @@ export function MonthView({
     }
     return out;
   }, [gridStart]);
+
+  const channelsById = useMemo(() => {
+    const m = new Map<number, Channel>();
+    if (channels) {
+      for (const c of channels) m.set(c.id, c);
+    }
+    return m;
+  }, [channels]);
 
   const eventsByDay = useMemo(() => {
     const map = new Map<string, CalendarEvent[]>();
@@ -363,6 +450,7 @@ export function MonthView({
               dayEvents={dayEvents}
               dayTasks={dayTasks}
               channelColors={channelColors}
+              channelsById={channelsById}
               onEventClick={onEventClick}
               onDayClick={onDayClick}
               onTaskClick={onTaskClick}

--- a/packages/client/src/pages/CalendarPage.tsx
+++ b/packages/client/src/pages/CalendarPage.tsx
@@ -321,6 +321,7 @@ function CalendarContent({
                 today={today}
                 events={filteredEvents}
                 tasks={filteredTasks}
+                channels={channels}
                 channelColors={channelColors}
                 onEventClick={handleEventClick}
                 onDayClick={handleDayClick}


### PR DESCRIPTION
## 概要
カレンダー月表示のイベント/タスクバーは色のみで種別を区別しており、チャンネル由来/タスク由来/個人予定の識別が困難だった。種別アイコン・チャンネル略称・今日のバーハイライトを追加して識別性を向上させた。

## 変更内容
- `packages/client/src/components/Calendar/MonthView.tsx`
  - イベントバー左端に種別アイコンを追加
    - チャンネルイベント: `TagIcon` (`data-event-kind="channel"`)
    - 個人予定 (`channelId=null`): `PersonIcon` (`data-event-kind="personal"`)
  - タスクバーに `AssignmentIcon` を表示 (`data-event-kind="task"`)。既存「\\[タスク]」テキストはアイコンで置換
  - イベントバー末尾に `data-testid="event-channel-abbr"` のチャンネル略称を表示
    - ASCII 名 → 先頭 3 字 (`general` → `gen`)
    - 日本語名 → 先頭 2 字 (`技術部` → `技術`)
    - `channels` props 未指定 / `channelId=null` のときは非表示（後方互換）
  - 今日のセル内のイベント/タスクバーに `data-today-bar="true"` と `outline` を付与
  - 既存の「+N 件」集約挙動は維持
- `packages/client/src/pages/CalendarPage.tsx`
  - `MonthView` 呼び出しに `channels={channels}` を追加
- `packages/client/src/__tests__/MonthView.test.tsx`
  - 「イベント密度改善 (Issue #330)」セクションを追加（11 件）

## 設計メモ
- **props の追加**: `MonthView` に `channels?: Channel[]` を任意指定で追加。未渡しなら略称が表示されないため既存テスト（10件）を破壊しない
- **略称ロジック**: ASCII (`/^[\\x20-\\x7E]+$/`) なら 3 字、それ以外は 2 字。`Array.from()` でサロゲートペア対応
- **今日ハイライト**: 視覚 (`outline: 2px solid primary.dark`) と DOM 属性 (`data-today-bar="true"`) の両方で表現。テストは属性で検証

## 影響範囲
- カレンダーページ (`/calendar`) の月表示のみ
- WeekView / AgendaView は変更なし
- 既存テスト10件はそのまま通過、新規11件追加

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする (2459 件、+21件)
- [x] バックエンドユニットテストがすべてパスする (1669 件)
- [x] ビルドが正常に完了すること
- [x] MonthView.test.tsx 21 件すべてパス（既存10件 + 新規11件）

## 関連Issue
Fixes #330

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（不要）
- [x] \`it.todo\` / 空ボディの \`it\` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)