### PR TITLE
feat: タスクボードのカラム別 WIP／期限サマリーを追加 (#328)

### DIFF
--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -209,6 +209,36 @@ function makeTasks(): Task[] {
   ];
 }
 
+function makeTask(overrides: Partial<Task> & Pick<Task, 'id' | 'title' | 'status'>): Task {
+  return {
+    description: null,
+    assigneeId: null,
+    assigneeUsername: null,
+    dueAt: null,
+    sourceMessageId: null,
+    sourceChannelId: null,
+    createdBy: 1,
+    position: 0,
+    isHidden: false,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function todayAt(hour: number): string {
+  const d = new Date();
+  d.setHours(hour, 0, 0, 0);
+  return d.toISOString();
+}
+
+function daysFromNow(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  d.setHours(12, 0, 0, 0);
+  return d.toISOString();
+}
+
 // TaskBoardPage はモジュールレベルのキャッシュを持つため動的 import でリセット
 async function importTaskBoardPage() {
   vi.resetModules();
@@ -989,6 +1019,254 @@ describe('TaskBoardPage', () => {
       });
       const grid = screen.getByTestId('app-layout-grid');
       expect(grid).toHaveStyle({ gridTemplateColumns: '64px 240px 1fr' });
+    });
+  });
+
+  describe('Issue #328: カラム別 WIP／期限サマリー', () => {
+    describe('カラム見出しのサマリーバッジ', () => {
+      it('各カラム見出しに期限切れ・今日・担当自分の件数バッジが表示される', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({
+              id: 101,
+              title: '期限切れの未着手',
+              status: 'todo',
+              dueAt: daysFromNow(-1),
+            }),
+            makeTask({
+              id: 102,
+              title: '今日期限の未着手',
+              status: 'todo',
+              dueAt: todayAt(23),
+            }),
+            makeTask({
+              id: 103,
+              title: '自分担当の未着手',
+              status: 'todo',
+              assigneeId: 1,
+              assigneeUsername: 'alice',
+            }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        expect(within(todoColumn).getByTestId('summary-badge-todo-overdue')).toHaveTextContent(
+          '期限切れ 1',
+        );
+        expect(within(todoColumn).getByTestId('summary-badge-todo-today')).toHaveTextContent(
+          '今日 1',
+        );
+        expect(within(todoColumn).getByTestId('summary-badge-todo-mine')).toHaveTextContent(
+          '担当自分 1',
+        );
+      });
+
+      it('件数が 0 件のサマリーバッジは表示されない', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [makeTask({ id: 111, title: '通常の未着手', status: 'todo' })],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        expect(within(todoColumn).queryByTestId('summary-badge-todo-overdue')).toBeNull();
+        expect(within(todoColumn).queryByTestId('summary-badge-todo-today')).toBeNull();
+        expect(within(todoColumn).queryByTestId('summary-badge-todo-mine')).toBeNull();
+      });
+    });
+
+    describe('サマリーバッジによるカラム内絞り込み', () => {
+      it('期限切れバッジをクリックすると同じカラム内の期限切れタスクのみ表示される', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({
+              id: 121,
+              title: '期限切れの未着手',
+              status: 'todo',
+              dueAt: daysFromNow(-1),
+            }),
+            makeTask({ id: 122, title: '通常の未着手', status: 'todo' }),
+            makeTask({
+              id: 123,
+              title: '期限切れの進行中',
+              status: 'in_progress',
+              dueAt: daysFromNow(-1),
+            }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        await userEvent.click(within(todoColumn).getByTestId('summary-badge-todo-overdue'));
+        expect(within(todoColumn).getByText('期限切れの未着手')).toBeInTheDocument();
+        expect(within(todoColumn).queryByText('通常の未着手')).toBeNull();
+        expect(screen.getByText('期限切れの進行中')).toBeInTheDocument();
+      });
+
+      it('今日バッジをクリックすると同じカラム内の今日期限タスクのみ表示される', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({
+              id: 131,
+              title: '今日期限の未着手',
+              status: 'todo',
+              dueAt: todayAt(23),
+            }),
+            makeTask({
+              id: 132,
+              title: '明日期限の未着手',
+              status: 'todo',
+              dueAt: daysFromNow(1),
+            }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        await userEvent.click(within(todoColumn).getByTestId('summary-badge-todo-today'));
+        expect(within(todoColumn).getByText('今日期限の未着手')).toBeInTheDocument();
+        expect(within(todoColumn).queryByText('明日期限の未着手')).toBeNull();
+      });
+
+      it('担当自分バッジをクリックすると同じカラム内の自分担当タスクのみ表示される', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({
+              id: 141,
+              title: '自分担当の未着手',
+              status: 'todo',
+              assigneeId: 1,
+              assigneeUsername: 'alice',
+            }),
+            makeTask({
+              id: 142,
+              title: '他人担当の未着手',
+              status: 'todo',
+              assigneeId: 2,
+              assigneeUsername: 'bob',
+            }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        await userEvent.click(within(todoColumn).getByTestId('summary-badge-todo-mine'));
+        expect(within(todoColumn).getByText('自分担当の未着手')).toBeInTheDocument();
+        expect(within(todoColumn).queryByText('他人担当の未着手')).toBeNull();
+      });
+
+      it('選択中のサマリーバッジをもう一度クリックすると絞り込みが解除される', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({
+              id: 151,
+              title: '期限切れの未着手',
+              status: 'todo',
+              dueAt: daysFromNow(-1),
+            }),
+            makeTask({ id: 152, title: '通常の未着手', status: 'todo' }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        const overdueBadge = within(todoColumn).getByTestId('summary-badge-todo-overdue');
+        await userEvent.click(overdueBadge);
+        expect(within(todoColumn).queryByText('通常の未着手')).toBeNull();
+        await userEvent.click(overdueBadge);
+        expect(within(todoColumn).getByText('通常の未着手')).toBeInTheDocument();
+      });
+    });
+
+    describe('WIP リミット超過表示', () => {
+      it('WIP リミットを超過しているカラムは見出しの色が変わる', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({ id: 161, title: '未着手1', status: 'todo' }),
+            makeTask({ id: 162, title: '未着手2', status: 'todo' }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        await userEvent.type(within(todoColumn).getByLabelText('未着手の WIP リミット'), '1');
+        expect(within(todoColumn).getByTestId('task-column-heading-todo')).toHaveAttribute(
+          'data-wip-exceeded',
+          'true',
+        );
+      });
+
+      it('WIP リミットが未設定のカラムは件数に関わらず超過表示にならない', async () => {
+        mockTasksList.mockResolvedValue({
+          tasks: [
+            makeTask({ id: 171, title: '未着手1', status: 'todo' }),
+            makeTask({ id: 172, title: '未着手2', status: 'todo' }),
+          ],
+        });
+        const TaskBoardPage = await importTaskBoardPage();
+        await act(async () => {
+          render(
+            <MemoryRouter>
+              <TaskBoardPage />
+            </MemoryRouter>,
+          );
+        });
+
+        const todoColumn = await screen.findByTestId('column-todo');
+        expect(within(todoColumn).getByTestId('task-column-heading-todo')).toHaveAttribute(
+          'data-wip-exceeded',
+          'false',
+        );
+      });
     });
   });
 });

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -51,6 +51,7 @@ import AppLayout from '../components/Layout/AppLayout';
 import ChannelList from '../components/Channel/ChannelList';
 import SidebarDmList from '../components/Layout/SidebarDmList';
 import { useSnackbar } from '../contexts/SnackbarContext';
+import { useAuth } from '../contexts/AuthContext';
 
 const STATUS_LABELS: Record<TaskStatus, string> = {
   todo: '未着手',
@@ -58,11 +59,23 @@ const STATUS_LABELS: Record<TaskStatus, string> = {
   done: '完了',
 };
 const STATUS_COLUMNS: TaskStatus[] = ['todo', 'in_progress', 'done'];
+type ColumnSummaryFilter = 'overdue' | 'today' | 'mine';
 
 // 期限切れ判定
 function isOverdue(dueAt: string | null): boolean {
   if (!dueAt) return false;
   return new Date(dueAt) < new Date();
+}
+
+function isDueToday(dueAt: string | null): boolean {
+  if (!dueAt) return false;
+  const due = new Date(dueAt);
+  const today = new Date();
+  return (
+    due.getFullYear() === today.getFullYear() &&
+    due.getMonth() === today.getMonth() &&
+    due.getDate() === today.getDate()
+  );
 }
 
 interface SortableTaskCardProps {
@@ -235,6 +248,7 @@ function SortableTaskCard({
 interface KanbanColumnProps {
   status: TaskStatus;
   tasks: Task[];
+  currentUserId: number | null;
   onDelete: (id: number) => void;
   onEdit: (task: Task) => void;
   onToggleHidden: (task: Task) => void;
@@ -245,6 +259,7 @@ interface KanbanColumnProps {
 function KanbanColumn({
   status,
   tasks,
+  currentUserId,
   onDelete,
   onEdit,
   onToggleHidden,
@@ -255,7 +270,34 @@ function KanbanColumn({
   const [inlineOpen, setInlineOpen] = useState(false);
   const [inlineTitle, setInlineTitle] = useState('');
   const [inlineSubmitting, setInlineSubmitting] = useState(false);
+  const [summaryFilter, setSummaryFilter] = useState<ColumnSummaryFilter | null>(null);
+  const [wipLimit, setWipLimit] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const wipLimitValue = wipLimit === '' ? null : Number(wipLimit);
+  const wipExceeded =
+    wipLimitValue !== null && Number.isFinite(wipLimitValue) && tasks.length > wipLimitValue;
+
+  const summaryCounts = useMemo(
+    () => ({
+      overdue: tasks.filter((task) => isOverdue(task.dueAt)).length,
+      today: tasks.filter((task) => isDueToday(task.dueAt)).length,
+      mine:
+        currentUserId == null ? 0 : tasks.filter((task) => task.assigneeId === currentUserId).length,
+    }),
+    [currentUserId, tasks],
+  );
+
+  const visibleTasks = useMemo(() => {
+    if (!summaryFilter) return tasks;
+    if (summaryFilter === 'overdue') return tasks.filter((task) => isOverdue(task.dueAt));
+    if (summaryFilter === 'today') return tasks.filter((task) => isDueToday(task.dueAt));
+    if (currentUserId == null) return [];
+    return tasks.filter((task) => task.assigneeId === currentUserId);
+  }, [currentUserId, summaryFilter, tasks]);
+
+  const toggleSummaryFilter = (filter: ColumnSummaryFilter) => {
+    setSummaryFilter((current) => (current === filter ? null : filter));
+  };
 
   // 入力フィールドを開いたときオートフォーカス
   useEffect(() => {
@@ -299,13 +341,72 @@ function KanbanColumn({
       }}
       data-testid={`column-${status}`}
     >
-      <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
-        {STATUS_LABELS[status]}
-        <Chip label={tasks.length} size="small" sx={{ ml: 1 }} />
-      </Typography>
+      <Box sx={{ mb: 1 }}>
+        <Box
+          sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 1 }}
+        >
+          <Typography
+            variant="subtitle1"
+            fontWeight="bold"
+            color={wipExceeded ? 'error.main' : 'text.primary'}
+            data-testid={`task-column-heading-${status}`}
+            data-wip-exceeded={wipExceeded ? 'true' : 'false'}
+          >
+            {STATUS_LABELS[status]}
+            <Chip
+              label={tasks.length}
+              size="small"
+              sx={{ ml: 1 }}
+              color={wipExceeded ? 'error' : 'default'}
+            />
+          </Typography>
+          <TextField
+            label={`${STATUS_LABELS[status]}の WIP リミット`}
+            value={wipLimit}
+            type="number"
+            size="small"
+            onChange={(e) => setWipLimit(e.target.value)}
+            inputProps={{ min: 0, 'aria-label': `${STATUS_LABELS[status]}の WIP リミット` }}
+            sx={{ width: 112 }}
+          />
+        </Box>
 
-      <SortableContext items={tasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-        {tasks.map((task) => (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', mt: 1 }}>
+          {summaryCounts.overdue > 0 && (
+            <Chip
+              label={`期限切れ ${summaryCounts.overdue}`}
+              size="small"
+              color={summaryFilter === 'overdue' ? 'error' : 'default'}
+              variant={summaryFilter === 'overdue' ? 'filled' : 'outlined'}
+              onClick={() => toggleSummaryFilter('overdue')}
+              data-testid={`summary-badge-${status}-overdue`}
+            />
+          )}
+          {summaryCounts.today > 0 && (
+            <Chip
+              label={`今日 ${summaryCounts.today}`}
+              size="small"
+              color={summaryFilter === 'today' ? 'primary' : 'default'}
+              variant={summaryFilter === 'today' ? 'filled' : 'outlined'}
+              onClick={() => toggleSummaryFilter('today')}
+              data-testid={`summary-badge-${status}-today`}
+            />
+          )}
+          {summaryCounts.mine > 0 && (
+            <Chip
+              label={`担当自分 ${summaryCounts.mine}`}
+              size="small"
+              color={summaryFilter === 'mine' ? 'success' : 'default'}
+              variant={summaryFilter === 'mine' ? 'filled' : 'outlined'}
+              onClick={() => toggleSummaryFilter('mine')}
+              data-testid={`summary-badge-${status}-mine`}
+            />
+          )}
+        </Box>
+      </Box>
+
+      <SortableContext items={visibleTasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+        {visibleTasks.map((task) => (
           <SortableTaskCard
             key={task.id}
             task={task}
@@ -317,7 +418,7 @@ function KanbanColumn({
         ))}
       </SortableContext>
 
-      {tasks.length === 0 && !inlineOpen && (
+      {visibleTasks.length === 0 && !inlineOpen && (
         <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center', mt: 2 }}>
           タスクなし
         </Typography>
@@ -394,6 +495,7 @@ function TaskBoardContent({
   const isMobile = useMediaQuery('(max-width: 767px)');
   const navigate = useNavigate();
   const { showError } = useSnackbar();
+  const { user } = useAuth();
 
   // Issue #267: タスクからカレンダーへジャンプ
   const handleJumpToCalendar = (task: Task) => {
@@ -636,6 +738,7 @@ function TaskBoardContent({
                 key={status}
                 status={status}
                 tasks={tasksByStatus[status]}
+                currentUserId={user?.id ?? null}
                 onDelete={(id) => void handleDelete(id)}
                 onEdit={(task) => setEditingTask(task)}
                 onToggleHidden={(task) => void handleToggleHidden(task)}


### PR DESCRIPTION
## 概要
タスクボードの各カラム見出しに「期限切れ」「今日期限」「担当自分」を示すバッジを追加し、要注意タスクを即視できるようにする。あわせて任意設定の WIP リミットを超過したカラムは見出しの色を変える。

## 変更内容
- `packages/client/src/pages/TaskBoardPage.tsx`
  - `KanbanColumn` にサマリーバッジ（期限切れ／今日／担当自分）を追加。件数 0 件は非表示。
  - バッジクリックでカラム内タスクを該当条件に絞り込み、再度クリックで解除。
  - カラムごとに WIP リミットの入力欄を追加。タスク数が上限を超えると見出し・件数 Chip がエラー色に変化。
  - 担当自分の判定用に `useAuth().user.id` を `currentUserId` として `KanbanColumn` へ渡す。
- `packages/client/src/__tests__/TaskBoardPage.test.tsx`
  - Issue #328 用 describe を追加。バッジ表示／0件非表示／フィルタ動作／WIP 超過時の見た目をカバー。

## 影響範囲
- タスクボード（`/tasks`）のカラム見出し UI のみ。タスクの並び順・ステータス更新・チャンネル絞り込み等の既存ロジックには手を加えていない。

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（`npm run test --workspace=packages/client` → 2476 件 pass）
- [x] バックエンドユニットテストがすべてパスする（`npm run test --workspace=packages/server` → 1669 件 pass）
- [x] ビルドが正常に完了すること（`npm run build`）
- [ ] (手動確認の場合) 確認した手順やスクリーンショット

## 関連Issue
Fixes #328

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）