### PR TITLE
feat: ナレッジベース / Wiki 機能を追加 (#355)

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -2609,5 +2609,128 @@ table "thread_reads" {
   }
 }
 
+# Wiki ページ（#355）
+table "wiki_pages" {
+  schema  = schema.public
+  comment = "Wikiページ本体（チャンネル所属型 / #355）"
+  column "id" {
+    null    = false
+    type    = serial
+    comment = "WikiページID"
+  }
+  column "channel_id" {
+    null    = false
+    type    = integer
+    comment = "所属チャンネルID"
+  }
+  column "title" {
+    null    = false
+    type    = text
+    comment = "タイトル"
+  }
+  column "content" {
+    null    = false
+    type    = text
+    default = ""
+    comment = "本文（Markdown）"
+  }
+  column "created_by" {
+    null    = true
+    type    = integer
+    comment = "作成者ユーザーID（ユーザー削除時に NULL）"
+  }
+  column "updated_by" {
+    null    = true
+    type    = integer
+    comment = "最終更新者ユーザーID（ユーザー削除時に NULL）"
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "作成日時"
+  }
+  column "updated_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "更新日時（楽観ロック用）"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_wiki_pages_channel" {
+    columns     = [column.channel_id]
+    ref_columns = [table.channels.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_wiki_pages_created_by" {
+    columns     = [column.created_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  foreign_key "fk_wiki_pages_updated_by" {
+    columns     = [column.updated_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  index "idx_wiki_pages_channel" {
+    columns = [column.channel_id]
+  }
+  index "idx_wiki_pages_updated_at" {
+    columns = [column.updated_at]
+  }
+}
+
+table "wiki_page_tags" {
+  schema  = schema.public
+  comment = "Wikiページとタグの紐付け（#355）"
+  column "wiki_page_id" {
+    null    = false
+    type    = integer
+    comment = "WikiページID"
+  }
+  column "tag_id" {
+    null    = false
+    type    = integer
+    comment = "タグID"
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "付与日時"
+  }
+  column "created_by" {
+    null    = true
+    type    = integer
+    comment = "付与者ユーザーID"
+  }
+  primary_key {
+    columns = [column.wiki_page_id, column.tag_id]
+  }
+  foreign_key "fk_wpt_page" {
+    columns     = [column.wiki_page_id]
+    ref_columns = [table.wiki_pages.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_wpt_tag" {
+    columns     = [column.tag_id]
+    ref_columns = [table.tags.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  foreign_key "fk_wpt_user" {
+    columns     = [column.created_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+}
+
 schema "public" {
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3154,6 +3154,15 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -3165,8 +3174,16 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "4.17.25",
@@ -3200,6 +3217,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/http-errors": {
@@ -3263,6 +3289,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/methods": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
@@ -3280,7 +3315,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/multer": {
@@ -3448,6 +3482,12 @@
         "@types/express": "*",
         "@types/serve-static": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3775,6 +3815,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -4440,6 +4486,16 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4756,6 +4812,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -4804,6 +4870,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -4927,6 +5033,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -5408,6 +5524,19 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -5522,6 +5651,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dezalgo": {
@@ -6349,6 +6491,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -6502,6 +6654,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -7098,6 +7256,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -7158,6 +7356,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/http_ece": {
       "version": "1.2.0",
@@ -7310,6 +7518,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -7341,6 +7555,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -7496,6 +7734,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7575,6 +7823,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -7626,6 +7884,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -8923,6 +9193,16 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8993,6 +9273,16 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9000,6 +9290,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdn-data": {
@@ -9042,6 +9614,569 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9607,6 +10742,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -10095,6 +11255,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10235,6 +11405,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-quill-new": {
       "version": "3.8.3",
@@ -10481,6 +11678,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -11091,6 +12354,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/spawn-command": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
@@ -11317,6 +12590,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -11374,6 +12661,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylis": {
@@ -11725,6 +13030,26 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -12147,6 +13472,93 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12266,6 +13678,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -12979,6 +14419,16 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "packages/client": {
       "name": "@chat-app/client",
       "version": "1.0.0",
@@ -12993,9 +14443,11 @@
         "highlight.js": "^11.10.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
         "react-quill-new": "^3.3.3",
         "react-router-dom": "^6.22.3",
         "recharts": "^3.8.1",
+        "remark-gfm": "^4.0.1",
         "socket.io-client": "^4.7.4"
       },
       "devDependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -21,9 +21,11 @@
     "highlight.js": "^11.10.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
     "react-quill-new": "^3.3.3",
     "react-router-dom": "^6.22.3",
     "recharts": "^3.8.1",
+    "remark-gfm": "^4.0.1",
     "socket.io-client": "^4.7.4"
   },
   "devDependencies": {

--- a/packages/client/src/__tests__/ChannelWikiTab.test.tsx
+++ b/packages/client/src/__tests__/ChannelWikiTab.test.tsx
@@ -1,0 +1,549 @@
+/**
+ * テスト対象: components/Channel/ChannelWikiTab.tsx（チャンネル内Wikiタブ / #355）
+ * 戦略:
+ *   - api/client をモックして Wiki ページの取得・作成・更新・削除を差し替える
+ *   - 2ペイン UI（左:一覧+検索+新規ボタン / 右:詳細・編集・新規フォーム）の
+ *     状態遷移とユーザー操作を検証する
+ *   - Markdown プレビュー切替・削除確認ダイアログ・楽観ロック競合時のエラー表示も対象
+ *   - URLクエリ（wikiPage / newWiki / fromMessage）によるディープリンクも検証
+ */
+
+import { render, screen, waitFor, act, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import type { WikiPage, WikiPageSummary } from '@chat-app/shared';
+
+vi.mock('../api/client', () => ({
+  api: {
+    wikiPages: {
+      list: vi.fn(),
+      get: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+    tags: {
+      list: vi.fn().mockResolvedValue({ tags: [] }),
+    },
+  },
+}));
+
+import { api } from '../api/client';
+import ChannelWikiTab, { resetWikiPagesCache } from '../components/Channel/ChannelWikiTab';
+
+const mockApi = api as unknown as {
+  wikiPages: {
+    list: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+  tags: { list: ReturnType<typeof vi.fn> };
+};
+
+const makeSummary = (overrides: Partial<WikiPageSummary> = {}): WikiPageSummary => ({
+  id: 1,
+  channelId: 100,
+  title: 'タイトル',
+  createdBy: 1,
+  createdByUsername: 'alice',
+  updatedBy: 1,
+  updatedByUsername: 'alice',
+  createdAt: '2026-05-01T00:00:00Z',
+  updatedAt: '2026-05-01T00:00:00Z',
+  tags: [],
+  ...overrides,
+});
+
+const makePage = (overrides: Partial<WikiPage> = {}): WikiPage => ({
+  id: 1,
+  channelId: 100,
+  title: 'タイトル',
+  content: '# 見出し\n本文',
+  createdBy: 1,
+  createdByUsername: 'alice',
+  updatedBy: 1,
+  updatedByUsername: 'alice',
+  createdAt: '2026-05-01T00:00:00Z',
+  updatedAt: '2026-05-01T00:00:00Z',
+  tags: [],
+  ...overrides,
+});
+
+function renderTab(props: {
+  channelId?: number;
+  currentUserId?: number;
+  currentUserRole?: 'user' | 'admin';
+  channelCreatedBy?: number;
+  initialEntries?: string[];
+}) {
+  const {
+    channelId = 100,
+    currentUserId = 1,
+    currentUserRole = 'user',
+    channelCreatedBy = 1,
+    initialEntries = ['/?channel=100'],
+  } = props;
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <ChannelWikiTab
+        channelId={channelId}
+        currentUserId={currentUserId}
+        currentUserRole={currentUserRole}
+        channelCreatedBy={channelCreatedBy}
+      />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetWikiPagesCache();
+  mockApi.wikiPages.list.mockResolvedValue({ pages: [] });
+  mockApi.wikiPages.get.mockResolvedValue({ page: makePage() });
+  mockApi.wikiPages.create.mockResolvedValue({ page: makePage() });
+  mockApi.wikiPages.update.mockResolvedValue({ page: makePage() });
+  mockApi.wikiPages.delete.mockResolvedValue(undefined);
+});
+
+describe('ChannelWikiTab（一覧表示）', () => {
+  it('マウント時にAPIからチャンネルのWikiページ一覧を取得して表示する', async () => {
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1, title: 'はじめに' })],
+    });
+    renderTab({});
+    await waitFor(() => {
+      expect(screen.getByText('はじめに')).toBeInTheDocument();
+    });
+    expect(mockApi.wikiPages.list).toHaveBeenCalledWith(100, undefined);
+  });
+
+  it('ページが0件のときは空状態メッセージを表示する', async () => {
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [] });
+    renderTab({});
+    await waitFor(() => {
+      expect(screen.getByText(/まだ.*Wiki.*ありません|ページがありません/)).toBeInTheDocument();
+    });
+  });
+
+  it('一覧の各項目にタイトルと更新日時が表示される', async () => {
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1, title: 'A', updatedAt: '2026-05-10T00:00:00Z' })],
+    });
+    renderTab({});
+    await waitFor(() => {
+      expect(screen.getByText('A')).toBeInTheDocument();
+    });
+    // 更新日（年月日のいずれかが表示されている想定）
+    expect(screen.getAllByText(/2026/).length).toBeGreaterThan(0);
+  });
+
+  it('一覧項目をクリックすると右ペインに詳細が表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 7, title: 'クリック対象' })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({ id: 7, title: 'クリック対象', content: '詳細本文' }),
+    });
+    renderTab({});
+    await waitFor(() => screen.getByText('クリック対象'));
+    await user.click(screen.getByText('クリック対象'));
+    await waitFor(() => {
+      expect(screen.getByText(/詳細本文/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ChannelWikiTab（検索）', () => {
+  it('検索ボックスに文字を入力するとAPIへ q クエリ付きで再取得が走る', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    mockApi.wikiPages.list.mockClear();
+    mockApi.wikiPages.list.mockResolvedValue({ pages: [] });
+    await user.type(screen.getByPlaceholderText(/検索/), 'foo');
+    await waitFor(() => {
+      expect(mockApi.wikiPages.list).toHaveBeenCalledWith(100, 'foo');
+    });
+  });
+
+  it('検索クエリをクリアすると全件取得に戻る', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    const input = screen.getByPlaceholderText(/検索/) as HTMLInputElement;
+    await user.type(input, 'foo');
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalledWith(100, 'foo'));
+    mockApi.wikiPages.list.mockClear();
+    await user.clear(input);
+    await waitFor(() => {
+      expect(mockApi.wikiPages.list).toHaveBeenCalledWith(100, undefined);
+    });
+  });
+});
+
+describe('ChannelWikiTab（詳細表示）', () => {
+  it('選択ページのタイトル・本文（Markdownレンダリング後）が表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1, title: 'タイトル' })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({ id: 1, title: 'タイトル', content: '# 見出しA' }),
+    });
+    renderTab({});
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await waitFor(() => {
+      // h1 がMarkdownから生成される
+      expect(screen.getByRole('heading', { level: 1, name: '見出しA' })).toBeInTheDocument();
+    });
+  });
+
+  it('作成者・更新者・更新日時が表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1 })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({ createdByUsername: 'alice', updatedByUsername: 'bob' }),
+    });
+    renderTab({});
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await waitFor(() => {
+      expect(screen.getByText(/alice/)).toBeInTheDocument();
+      expect(screen.getByText(/bob/)).toBeInTheDocument();
+    });
+  });
+
+  it('紐付くタグがチップとして表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1 })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({
+        tags: [{ id: 11, name: 'faq', useCount: 0, createdAt: '' }],
+      }),
+    });
+    renderTab({});
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await waitFor(() => {
+      expect(screen.getByText('faq')).toBeInTheDocument();
+    });
+  });
+
+  it('編集権限がある場合は編集ボタンが表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1, createdBy: 1 })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ createdBy: 1 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /編集/ })).toBeInTheDocument();
+    });
+  });
+
+  it('編集権限がない場合は編集ボタンが非表示', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1, createdBy: 99 })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ createdBy: 99 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 999 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await waitFor(() => screen.getByText(/詳細|本文|#/));
+    expect(screen.queryByRole('button', { name: /編集/ })).not.toBeInTheDocument();
+  });
+
+  it('削除権限がある場合は削除ボタンが表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1 })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage() });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /削除/ })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ChannelWikiTab（新規作成）', () => {
+  it('「新規作成」ボタンを押すと右ペインに新規作成フォームが表示される', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
+  });
+
+  it('フォームにタイトル・本文・タグ入力欄がある', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/本文/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/タグ/)).toBeInTheDocument();
+  });
+
+  it('本文はテキストエリアとプレビューをタブ切替できる', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    expect(screen.getByRole('tab', { name: /編集|テキスト/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /プレビュー/ })).toBeInTheDocument();
+  });
+
+  it('プレビュータブを開くとMarkdownがレンダリング表示される', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    await user.type(screen.getByLabelText(/本文/), '# Hello');
+    await user.click(screen.getByRole('tab', { name: /プレビュー/ }));
+    expect(screen.getByRole('heading', { level: 1, name: 'Hello' })).toBeInTheDocument();
+  });
+
+  it('保存ボタンを押すとAPIに作成リクエストが送られる', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.create.mockResolvedValueOnce({
+      page: makePage({ id: 42, title: '新ページ' }),
+    });
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    await user.type(screen.getByLabelText(/タイトル/), '新ページ');
+    await user.click(screen.getByRole('button', { name: /^保存$/ }));
+    await waitFor(() => {
+      expect(mockApi.wikiPages.create).toHaveBeenCalledWith(
+        100,
+        expect.objectContaining({ title: '新ページ' }),
+      );
+    });
+  });
+
+  it('保存成功すると一覧が更新され作成したページが選択状態になる', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.create.mockResolvedValueOnce({
+      page: makePage({ id: 42, title: '新ページ', content: 'created' }),
+    });
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    await user.type(screen.getByLabelText(/タイトル/), '新ページ');
+    await user.click(screen.getByRole('button', { name: /^保存$/ }));
+    await waitFor(() => {
+      expect(screen.getByText('created')).toBeInTheDocument();
+    });
+  });
+
+  it('タイトル未入力のまま保存しようとするとバリデーションエラーが表示される', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    await user.click(screen.getByRole('button', { name: /^保存$/ }));
+    expect(screen.getByText(/タイトルを入力|タイトルは必須/)).toBeInTheDocument();
+    expect(mockApi.wikiPages.create).not.toHaveBeenCalled();
+  });
+
+  it('キャンセルボタンで新規作成フォームを閉じられる', async () => {
+    const user = userEvent.setup();
+    renderTab({});
+    await waitFor(() => expect(mockApi.wikiPages.list).toHaveBeenCalled());
+    await user.click(screen.getByRole('button', { name: /新規作成|新規Wiki/ }));
+    await user.click(screen.getByRole('button', { name: /キャンセル/ }));
+    expect(screen.queryByLabelText(/タイトル/)).not.toBeInTheDocument();
+  });
+});
+
+describe('ChannelWikiTab（編集）', () => {
+  it('編集ボタンを押すと現在のタイトル・本文・タグでフォームに入る', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 1, title: '元タイトル' })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({ id: 1, title: '元タイトル', content: '元本文' }),
+    });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('元タイトル'));
+    await user.click(screen.getByText('元タイトル'));
+    await user.click(await screen.findByRole('button', { name: /編集/ }));
+    expect((screen.getByLabelText(/タイトル/) as HTMLInputElement).value).toBe('元タイトル');
+  });
+
+  it('保存ボタンを押すとPATCHリクエストが送られる', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1, title: 'old' }) });
+    mockApi.wikiPages.update.mockResolvedValueOnce({ page: makePage({ id: 1, title: 'new' }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /編集/ }));
+    const titleInput = screen.getByLabelText(/タイトル/) as HTMLInputElement;
+    await user.clear(titleInput);
+    await user.type(titleInput, 'new');
+    await user.click(screen.getByRole('button', { name: /^保存$/ }));
+    await waitFor(() => expect(mockApi.wikiPages.update).toHaveBeenCalled());
+  });
+
+  it('保存時にexpectedUpdatedAtを含めて送信する（楽観ロック）', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({ id: 1, updatedAt: '2026-05-10T00:00:00.000Z' }),
+    });
+    mockApi.wikiPages.update.mockResolvedValueOnce({ page: makePage({ id: 1 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /編集/ }));
+    await user.click(screen.getByRole('button', { name: /^保存$/ }));
+    await waitFor(() => {
+      expect(mockApi.wikiPages.update).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ expectedUpdatedAt: '2026-05-10T00:00:00.000Z' }),
+      );
+    });
+  });
+
+  it('409レスポンスを受け取ったときに競合メッセージが表示される', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1 }) });
+    const err = Object.assign(new Error('conflict'), { statusCode: 409 });
+    mockApi.wikiPages.update.mockRejectedValueOnce(err);
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /編集/ }));
+    await user.click(screen.getByRole('button', { name: /^保存$/ }));
+    await waitFor(() => {
+      expect(screen.getByText(/競合|他の.*更新/)).toBeInTheDocument();
+    });
+  });
+
+  it('キャンセルボタンで詳細表示に戻る', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /編集/ }));
+    await user.click(screen.getByRole('button', { name: /キャンセル/ }));
+    // 詳細ビュー（編集ボタンが再表示される）
+    expect(await screen.findByRole('button', { name: /編集/ })).toBeInTheDocument();
+  });
+});
+
+describe('ChannelWikiTab（削除）', () => {
+  it('削除ボタンを押すと確認ダイアログが開く', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /削除/ }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('確認ダイアログでキャンセルすると削除されない', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /削除/ }));
+    const dialog = screen.getByRole('dialog');
+    await act(async () => {
+      await userEvent.click(within(dialog).getByRole('button', { name: /キャンセル/ }));
+    });
+    expect(mockApi.wikiPages.delete).not.toHaveBeenCalled();
+  });
+
+  it('確認ダイアログで削除確定するとDELETEリクエストが送られる', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list.mockResolvedValueOnce({ pages: [makeSummary({ id: 1 })] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1 }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('タイトル'));
+    await user.click(screen.getByText('タイトル'));
+    await user.click(await screen.findByRole('button', { name: /削除/ }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /削除する|削除$/ }));
+    await waitFor(() => {
+      expect(mockApi.wikiPages.delete).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it('削除成功すると一覧から該当ページが消え右ペインが空状態に戻る', async () => {
+    const user = userEvent.setup();
+    mockApi.wikiPages.list
+      .mockResolvedValueOnce({ pages: [makeSummary({ id: 1, title: 'X' })] })
+      .mockResolvedValue({ pages: [] });
+    mockApi.wikiPages.get.mockResolvedValueOnce({ page: makePage({ id: 1, title: 'X' }) });
+    renderTab({ currentUserId: 1, channelCreatedBy: 1 });
+    await waitFor(() => screen.getByText('X'));
+    await user.click(screen.getByText('X'));
+    await user.click(await screen.findByRole('button', { name: /削除/ }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /削除する|削除$/ }));
+    await waitFor(() => {
+      expect(screen.queryByText('X')).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('ChannelWikiTab（URLクエリでの動線）', () => {
+  it('?wikiPage=:id 付きで開くと該当ページの詳細が初期表示される', async () => {
+    mockApi.wikiPages.list.mockResolvedValueOnce({
+      pages: [makeSummary({ id: 5, title: 'preselected' })],
+    });
+    mockApi.wikiPages.get.mockResolvedValueOnce({
+      page: makePage({ id: 5, title: 'preselected', content: 'deep linked' }),
+    });
+    renderTab({ initialEntries: ['/?channel=100&wikiPage=5'] });
+    await waitFor(() => {
+      expect(screen.getByText('deep linked')).toBeInTheDocument();
+    });
+  });
+
+  it('?newWiki=1 付きで開くと新規作成フォームが初期表示される', async () => {
+    renderTab({ initialEntries: ['/?channel=100&newWiki=1'] });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/タイトル/)).toBeInTheDocument();
+    });
+  });
+
+  it('?newWiki=1&fromMessage=:id 付きで開くと本文に引用形式でメッセージがプリフィルされる', async () => {
+    sessionStorage.setItem(
+      'wiki.fromMessage.123',
+      JSON.stringify({ content: 'メッセージ本文', url: 'http://example/m/123' }),
+    );
+    renderTab({ initialEntries: ['/?channel=100&newWiki=1&fromMessage=123'] });
+    await waitFor(() => {
+      const body = screen.getByLabelText(/本文/) as HTMLTextAreaElement;
+      expect(body.value).toContain('メッセージ本文');
+    });
+    sessionStorage.removeItem('wiki.fromMessage.123');
+  });
+});

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -113,6 +113,10 @@ vi.mock('../components/Chat/ScheduledMessagesDialog', () => ({
 vi.mock('../pages/FilesPage', () => ({
   ChannelFilesTab: () => <div data-testid="channel-files-tab" />,
 }));
+// ChannelWikiTab: data-testid で表示確認可能にする（#355）
+vi.mock('../components/Channel/ChannelWikiTab', () => ({
+  default: () => <div data-testid="channel-wiki-tab" />,
+}));
 
 // Snackbar の呼び出しをテストから検証可能にする
 const mockSnackbar = vi.hoisted(() => ({
@@ -423,6 +427,43 @@ describe('ChatPage', () => {
           'data-active',
           'true',
         );
+      });
+    });
+
+    // Wikiタブ切替（#355）
+    describe('Wiki切替アイコンの動作', () => {
+      it('Wiki切替アイコンをクリックするとWikiタブが表示される', async () => {
+        const user = userEvent.setup();
+        renderChatPage();
+        await selectChannel();
+        await user.click(screen.getByRole('button', { name: /Wiki/ }));
+        expect(screen.getByTestId('channel-wiki-tab')).toBeInTheDocument();
+      });
+
+      it('Wiki表示中に再度アイコンをクリックするとメッセージ一覧に戻る', async () => {
+        const user = userEvent.setup();
+        renderChatPage();
+        await selectChannel();
+        await user.click(screen.getByRole('button', { name: /Wiki/ }));
+        expect(screen.getByTestId('channel-wiki-tab')).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /Wiki/ }));
+        expect(screen.queryByTestId('channel-wiki-tab')).not.toBeInTheDocument();
+      });
+
+      it('Wiki表示中はアイコンが選択状態のスタイル（data-active=true）', async () => {
+        const user = userEvent.setup();
+        renderChatPage();
+        await selectChannel();
+        await user.click(screen.getByRole('button', { name: /Wiki/ }));
+        expect(screen.getByRole('button', { name: /Wiki/ })).toHaveAttribute('data-active', 'true');
+      });
+
+      it('?wikiPage=:id 付きURLで開くと自動的にWikiタブが選択される', async () => {
+        renderChatPage('/chat?channel=1&wikiPage=5');
+        await selectChannel();
+        await waitFor(() => {
+          expect(screen.getByTestId('channel-wiki-tab')).toBeInTheDocument();
+        });
       });
     });
 

--- a/packages/client/src/__tests__/MarkdownRenderer.test.tsx
+++ b/packages/client/src/__tests__/MarkdownRenderer.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * テスト対象: components/Wiki/MarkdownRenderer.tsx（#355）
+ * 戦略:
+ *   - react-markdown + remark-gfm を用いた Markdown レンダリングコンポーネントを検証
+ *   - XSS 対策（生HTML/scriptタグの無害化）を含む
+ *   - 基本的なMarkdown要素（見出し・リスト・コード・リンク）の出力を検証する
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import MarkdownRenderer from '../components/Wiki/MarkdownRenderer';
+
+describe('MarkdownRenderer', () => {
+  it('見出し（# 〜 ######）が h1〜h6 にレンダリングされる', () => {
+    render(<MarkdownRenderer source={'# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6'} />);
+    expect(screen.getByRole('heading', { level: 1, name: 'H1' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'H2' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 6, name: 'H6' })).toBeInTheDocument();
+  });
+
+  it('箇条書きリストが ul/li にレンダリングされる', () => {
+    const { container } = render(<MarkdownRenderer source={'- a\n- b\n- c'} />);
+    expect(container.querySelectorAll('ul li').length).toBe(3);
+  });
+
+  it('番号付きリストが ol/li にレンダリングされる', () => {
+    const { container } = render(<MarkdownRenderer source={'1. a\n2. b'} />);
+    expect(container.querySelectorAll('ol li').length).toBe(2);
+  });
+
+  it('コードブロック（```）が pre/code にレンダリングされる', () => {
+    const { container } = render(<MarkdownRenderer source={'```\nhello\n```'} />);
+    expect(container.querySelector('pre code')).toBeInTheDocument();
+  });
+
+  it('インラインコード（`code`）が code にレンダリングされる', () => {
+    const { container } = render(<MarkdownRenderer source={'use `code` here'} />);
+    const codes = Array.from(container.querySelectorAll('code')).filter((el) => !el.closest('pre'));
+    expect(codes.length).toBeGreaterThan(0);
+    expect(codes[0].textContent).toBe('code');
+  });
+
+  it('リンク（[text](url)）が a タグにレンダリングされる', () => {
+    render(<MarkdownRenderer source={'[click](https://example.com)'} />);
+    const link = screen.getByRole('link', { name: 'click' }) as HTMLAnchorElement;
+    expect(link.href).toBe('https://example.com/');
+  });
+
+  it('GFM の表組みがテーブルとしてレンダリングされる', () => {
+    const md = '| a | b |\n|---|---|\n| 1 | 2 |';
+    const { container } = render(<MarkdownRenderer source={md} />);
+    expect(container.querySelector('table')).toBeInTheDocument();
+  });
+
+  it('GFM のチェックボックスがチェックボックスとしてレンダリングされる', () => {
+    const md = '- [x] done\n- [ ] todo';
+    const { container } = render(<MarkdownRenderer source={md} />);
+    expect(container.querySelectorAll('input[type="checkbox"]').length).toBe(2);
+  });
+
+  it('生の <script> タグは出力されない（XSS対策）', () => {
+    const { container } = render(
+      <MarkdownRenderer source={'<script>alert(1)</script>\n通常のテキスト'} />,
+    );
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  it('javascript: スキームのリンクは無害化される', () => {
+    const { container } = render(<MarkdownRenderer source={'[bad](javascript:alert(1))'} />);
+    const a = container.querySelector('a');
+    // href が javascript: で始まらない（react-markdown 標準でブロック）
+    expect(a?.getAttribute('href') ?? '').not.toMatch(/^javascript:/);
+  });
+});

--- a/packages/client/src/__tests__/MessageActions.test.tsx
+++ b/packages/client/src/__tests__/MessageActions.test.tsx
@@ -15,6 +15,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import MessageActions from '../components/Chat/MessageActions';
 import { makeMessage } from './__fixtures__/messages';
 
+// react-router-dom の useNavigate をモック（#355 Wikiページ化の遷移検証用）
+const mockNavigate = vi.hoisted(() => vi.fn());
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 // Socket モック
 const mockSocket = { emit: vi.fn(), on: vi.fn(), off: vi.fn() };
 vi.mock('../contexts/SocketContext', () => ({
@@ -605,11 +612,12 @@ describe('MessageActions', () => {
       render(<MessageActions message={message} isOwn={false} />);
       await openMenu();
       await userEvent.click(screen.getByRole('menuitem', { name: /Wikiページ化/ }));
-      // sessionStorage にプリフィル情報が入る + URL が wiki タブに切り替わる
+      // sessionStorage にプリフィル情報が入る
       const stored = sessionStorage.getItem('wiki.fromMessage.42');
       expect(stored).not.toBeNull();
-      expect(window.location.search).toContain('newWiki=1');
-      expect(window.location.search).toContain('fromMessage=42');
+      expect(JSON.parse(stored as string).content).toBe('メッセージ本文');
+      // React Router の navigate で wiki タブに遷移する
+      expect(mockNavigate).toHaveBeenCalledWith('/chat?channel=7&newWiki=1&fromMessage=42');
       sessionStorage.removeItem('wiki.fromMessage.42');
     });
 

--- a/packages/client/src/__tests__/MessageActions.test.tsx
+++ b/packages/client/src/__tests__/MessageActions.test.tsx
@@ -591,4 +591,35 @@ describe('MessageActions', () => {
       });
     });
   });
+
+  // Wikiページ化（3点メニュー）#355
+  describe('Wikiページ化（メニュー経由）', () => {
+    it('3点メニューに「Wikiページ化」メニュー項目が表示される', async () => {
+      render(<MessageActions message={makeMessage()} isOwn={false} />);
+      await openMenu();
+      expect(screen.getByRole('menuitem', { name: /Wikiページ化/ })).toBeInTheDocument();
+    });
+
+    it('「Wikiページ化」をクリックするとWikiタブ（newWiki=1）かつfromMessage付きURLに遷移する', async () => {
+      const message = makeMessage({ id: 42, channelId: 7, content: 'メッセージ本文' });
+      render(<MessageActions message={message} isOwn={false} />);
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: /Wikiページ化/ }));
+      // sessionStorage にプリフィル情報が入る + URL が wiki タブに切り替わる
+      const stored = sessionStorage.getItem('wiki.fromMessage.42');
+      expect(stored).not.toBeNull();
+      expect(window.location.search).toContain('newWiki=1');
+      expect(window.location.search).toContain('fromMessage=42');
+      sessionStorage.removeItem('wiki.fromMessage.42');
+    });
+
+    it('「Wikiページ化」クリック後にメニューが閉じる', async () => {
+      render(<MessageActions message={makeMessage()} isOwn={false} />);
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: /Wikiページ化/ }));
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -66,6 +66,10 @@ import type {
   CreateCalendarPollInput,
   CastCalendarVoteInput,
   ThreadSummary,
+  WikiPage,
+  WikiPageSummary,
+  CreateWikiPageInput,
+  UpdateWikiPageInput,
 } from '@chat-app/shared';
 import type {
   AdminUser,
@@ -803,5 +807,24 @@ export const api = {
   },
   threads: {
     listSubscribed: () => request<{ threads: ThreadSummary[] }>('/threads/subscribed'),
+  },
+  // #355 Wiki ページ
+  wikiPages: {
+    list: (channelId: number, q?: string) => {
+      const qs = q ? `?q=${encodeURIComponent(q)}` : '';
+      return request<{ pages: WikiPageSummary[] }>(`/channels/${channelId}/wiki-pages${qs}`);
+    },
+    get: (id: number) => request<{ page: WikiPage }>(`/wiki-pages/${id}`),
+    create: (channelId: number, input: CreateWikiPageInput) =>
+      request<{ page: WikiPage }>(`/channels/${channelId}/wiki-pages`, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    update: (id: number, input: UpdateWikiPageInput) =>
+      request<{ page: WikiPage }>(`/wiki-pages/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(input),
+      }),
+    delete: (id: number) => request<void>(`/wiki-pages/${id}`, { method: 'DELETE' }),
   },
 };

--- a/packages/client/src/components/Channel/ChannelWikiTab.tsx
+++ b/packages/client/src/components/Channel/ChannelWikiTab.tsx
@@ -1,0 +1,452 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  Box,
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  List,
+  ListItemButton,
+  ListItemText,
+  Stack,
+  Tab,
+  Tabs,
+  TextField,
+  Typography,
+  Alert,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import type { WikiPage, WikiPageSummary } from '@chat-app/shared';
+import { api } from '../../api/client';
+import MarkdownRenderer from '../Wiki/MarkdownRenderer';
+
+interface Props {
+  channelId: number;
+  currentUserId: number;
+  currentUserRole: 'user' | 'admin';
+  channelCreatedBy: number;
+}
+
+// 一覧キャッシュ（チャンネル×クエリ単位）。テスト時は resetWikiPagesCache() でクリア
+const listCache = new Map<string, WikiPageSummary[]>();
+export function resetWikiPagesCache(): void {
+  listCache.clear();
+}
+
+type RightPaneMode =
+  | { kind: 'empty' }
+  | { kind: 'detail'; pageId: number }
+  | { kind: 'new' }
+  | { kind: 'edit'; pageId: number };
+
+export default function ChannelWikiTab({
+  channelId,
+  currentUserId,
+  currentUserRole,
+  channelCreatedBy,
+}: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [pages, setPages] = useState<WikiPageSummary[]>([]);
+  const [searchInput, setSearchInput] = useState('');
+  const [activeQuery, setActiveQuery] = useState<string | undefined>(undefined);
+  const [right, setRight] = useState<RightPaneMode>({ kind: 'empty' });
+  const [currentPage, setCurrentPage] = useState<WikiPage | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refreshList = useCallback(
+    async (q?: string) => {
+      const key = `${channelId}|${q ?? ''}`;
+      const res = await api.wikiPages.list(channelId, q);
+      listCache.set(key, res.pages);
+      setPages(res.pages);
+    },
+    [channelId],
+  );
+
+  // 初期ロード
+  useEffect(() => {
+    void refreshList(activeQuery);
+  }, [activeQuery, refreshList]);
+
+  // 検索入力をデバウンスで activeQuery に反映
+  useEffect(() => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      const trimmed = searchInput.trim();
+      setActiveQuery(trimmed.length > 0 ? trimmed : undefined);
+    }, 150);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [searchInput]);
+
+  // URLクエリでの動線
+  const wikiPageParam = searchParams.get('wikiPage');
+  const newWikiParam = searchParams.get('newWiki');
+  const fromMessageParam = searchParams.get('fromMessage');
+
+  useEffect(() => {
+    if (wikiPageParam) {
+      const id = parseInt(wikiPageParam, 10);
+      if (!isNaN(id)) {
+        setRight({ kind: 'detail', pageId: id });
+      }
+    } else if (newWikiParam) {
+      setRight({ kind: 'new' });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 詳細ページの読み込み（既に同じIDの page が currentPage にあれば再フェッチしない）
+  useEffect(() => {
+    if (right.kind === 'detail') {
+      if (currentPage && currentPage.id === right.pageId) return;
+      let alive = true;
+      void api.wikiPages.get(right.pageId).then((res) => {
+        if (alive) setCurrentPage(res.page);
+      });
+      return () => {
+        alive = false;
+      };
+    }
+    if (right.kind !== 'edit') {
+      setCurrentPage(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [right]);
+
+  const handleSelect = useCallback(
+    (pageId: number) => {
+      setRight({ kind: 'detail', pageId });
+      const next = new URLSearchParams(searchParams);
+      next.set('wikiPage', String(pageId));
+      next.delete('newWiki');
+      next.delete('fromMessage');
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const handleNew = useCallback(() => {
+    setRight({ kind: 'new' });
+    const next = new URLSearchParams(searchParams);
+    next.delete('wikiPage');
+    next.set('newWiki', '1');
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  const canEditPage = useMemo(() => {
+    if (!currentPage) return false;
+    if (currentUserRole === 'admin') return true;
+    if (currentPage.createdBy === currentUserId) return true;
+    if (channelCreatedBy === currentUserId) return true;
+    return false;
+  }, [currentPage, currentUserId, currentUserRole, channelCreatedBy]);
+
+  const canDeletePage = useMemo(() => {
+    if (!currentPage) return false;
+    if (currentUserRole === 'admin') return true;
+    if (channelCreatedBy === currentUserId) return true;
+    return false;
+  }, [currentPage, currentUserId, currentUserRole, channelCreatedBy]);
+
+  return (
+    <Box sx={{ display: 'flex', flexGrow: 1, overflow: 'hidden' }}>
+      {/* 左ペイン: 一覧 */}
+      <Box
+        sx={{
+          width: 320,
+          borderRight: 1,
+          borderColor: 'divider',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <Box sx={{ p: 1 }}>
+          <TextField
+            placeholder="検索"
+            size="small"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            fullWidth
+          />
+        </Box>
+        <Button
+          onClick={handleNew}
+          startIcon={<AddIcon />}
+          sx={{ mx: 1, mb: 1 }}
+          variant="outlined"
+          size="small"
+        >
+          新規作成
+        </Button>
+        <Divider />
+        <Box sx={{ flexGrow: 1, overflowY: 'auto' }}>
+          {pages.length === 0 ? (
+            <Typography sx={{ p: 2, color: 'text.secondary' }}>
+              まだWikiページがありません
+            </Typography>
+          ) : (
+            <List dense disablePadding>
+              {pages.map((p) => (
+                <ListItemButton
+                  key={p.id}
+                  selected={right.kind === 'detail' && right.pageId === p.id}
+                  onClick={() => handleSelect(p.id)}
+                >
+                  <ListItemText
+                    primary={p.title}
+                    secondary={new Date(p.updatedAt).toLocaleString('ja-JP')}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
+          )}
+        </Box>
+      </Box>
+
+      {/* 右ペイン */}
+      <Box sx={{ flexGrow: 1, overflowY: 'auto', p: 2 }}>
+        {right.kind === 'empty' && (
+          <Typography color="text.secondary">左の一覧からWikiページを選択してください</Typography>
+        )}
+
+        {right.kind === 'detail' && currentPage && (
+          <WikiPageDetail
+            page={currentPage}
+            canEdit={canEditPage}
+            canDelete={canDeletePage}
+            onEdit={() => setRight({ kind: 'edit', pageId: currentPage.id })}
+            onDeleted={async () => {
+              setRight({ kind: 'empty' });
+              setCurrentPage(null);
+              await refreshList(activeQuery);
+            }}
+          />
+        )}
+
+        {right.kind === 'new' && (
+          <WikiPageForm
+            mode="new"
+            initial={{
+              title: '',
+              content: buildInitialContent(fromMessageParam),
+            }}
+            onSubmit={async ({ title, content }) => {
+              const res = await api.wikiPages.create(channelId, { title, content });
+              await refreshList(activeQuery);
+              setRight({ kind: 'detail', pageId: res.page.id });
+              setCurrentPage(res.page);
+              if (fromMessageParam) {
+                sessionStorage.removeItem(`wiki.fromMessage.${fromMessageParam}`);
+              }
+            }}
+            onCancel={() => setRight({ kind: 'empty' })}
+          />
+        )}
+
+        {right.kind === 'edit' && currentPage && (
+          <WikiPageForm
+            mode="edit"
+            initial={{ title: currentPage.title, content: currentPage.content }}
+            onSubmit={async ({ title, content }) => {
+              const res = await api.wikiPages.update(currentPage.id, {
+                title,
+                content,
+                expectedUpdatedAt: currentPage.updatedAt,
+              });
+              await refreshList(activeQuery);
+              setCurrentPage(res.page);
+              setRight({ kind: 'detail', pageId: res.page.id });
+            }}
+            onCancel={() => setRight({ kind: 'detail', pageId: currentPage.id })}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+function buildInitialContent(fromMessageParam: string | null): string {
+  if (!fromMessageParam) return '';
+  try {
+    const raw = sessionStorage.getItem(`wiki.fromMessage.${fromMessageParam}`);
+    if (!raw) return '';
+    const obj = JSON.parse(raw) as { content?: string; url?: string };
+    const quoted = (obj.content ?? '')
+      .split('\n')
+      .map((line) => `> ${line}`)
+      .join('\n');
+    return `${quoted}\n\n${obj.url ?? ''}\n`;
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 詳細ペイン
+// ---------------------------------------------------------------------------
+
+interface DetailProps {
+  page: WikiPage;
+  canEdit: boolean;
+  canDelete: boolean;
+  onEdit: () => void;
+  onDeleted: () => Promise<void>;
+}
+
+function WikiPageDetail({ page, canEdit, canDelete, onEdit, onDeleted }: DetailProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const handleConfirmDelete = async () => {
+    await api.wikiPages.delete(page.id);
+    setConfirmOpen(false);
+    await onDeleted();
+  };
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Typography variant="h5">{page.title}</Typography>
+        <Stack direction="row" spacing={1}>
+          {canEdit && (
+            <Button onClick={onEdit} variant="outlined" size="small">
+              編集
+            </Button>
+          )}
+          {canDelete && (
+            <Button
+              onClick={() => setConfirmOpen(true)}
+              color="error"
+              variant="outlined"
+              size="small"
+            >
+              削除
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+      <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        作成: {page.createdByUsername ?? '不明'} / 更新: {page.updatedByUsername ?? '不明'} (
+        {new Date(page.updatedAt).toLocaleString('ja-JP')})
+      </Typography>
+      {page.tags.length > 0 && (
+        <Stack direction="row" spacing={1} sx={{ mb: 2 }} flexWrap="wrap">
+          {page.tags.map((t) => (
+            <Chip key={t.id} label={t.name} size="small" />
+          ))}
+        </Stack>
+      )}
+      <Divider sx={{ mb: 2 }} />
+      <MarkdownRenderer source={page.content} />
+
+      <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+        <DialogTitle>Wikiページを削除しますか？</DialogTitle>
+        <DialogContent>
+          <Typography>「{page.title}」を削除します。この操作は取り消せません。</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setConfirmOpen(false)}>キャンセル</Button>
+          <Button onClick={handleConfirmDelete} color="error" variant="contained">
+            削除する
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// フォーム（新規 / 編集）
+// ---------------------------------------------------------------------------
+
+interface FormProps {
+  mode: 'new' | 'edit';
+  initial: { title: string; content: string };
+  onSubmit: (data: { title: string; content: string }) => Promise<void>;
+  onCancel: () => void;
+}
+
+function WikiPageForm({ mode, initial, onSubmit, onCancel }: FormProps) {
+  const [title, setTitle] = useState(initial.title);
+  const [content, setContent] = useState(initial.content);
+  const [tab, setTab] = useState<'edit' | 'preview'>('edit');
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    if (title.trim().length === 0) {
+      setTitleError('タイトルは必須です');
+      return;
+    }
+    setTitleError(null);
+    setServerError(null);
+    try {
+      await onSubmit({ title: title.trim(), content });
+    } catch (err: unknown) {
+      const statusCode = (err as { statusCode?: number }).statusCode;
+      if (statusCode === 409) {
+        setServerError('他のユーザーによる更新と競合しました。最新の状態を確認してください。');
+      } else {
+        setServerError((err as Error).message || '保存に失敗しました');
+      }
+    }
+  };
+
+  return (
+    <Box>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        {mode === 'new' ? 'Wikiページを新規作成' : 'Wikiページを編集'}
+      </Typography>
+      {serverError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {serverError}
+        </Alert>
+      )}
+      <TextField
+        label="タイトル"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        fullWidth
+        error={!!titleError}
+        helperText={titleError ?? undefined}
+        sx={{ mb: 2 }}
+      />
+      <TextField
+        label="タグ（カンマ区切り）"
+        placeholder="まだ未対応 — タグはサーバ実装済み（UIは将来対応）"
+        fullWidth
+        sx={{ mb: 2 }}
+        disabled
+      />
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 1 }}>
+        <Tab value="edit" label="編集" />
+        <Tab value="preview" label="プレビュー" />
+      </Tabs>
+      {tab === 'edit' ? (
+        <TextField
+          label="本文"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          multiline
+          minRows={10}
+          fullWidth
+        />
+      ) : (
+        <Box sx={{ minHeight: 200, p: 1, border: 1, borderColor: 'divider' }}>
+          <MarkdownRenderer source={content} />
+        </Box>
+      )}
+      <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+        <Button onClick={handleSave} variant="contained">
+          保存
+        </Button>
+        <Button onClick={onCancel}>キャンセル</Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/packages/client/src/components/Chat/MessageActions.tsx
+++ b/packages/client/src/components/Chat/MessageActions.tsx
@@ -23,6 +23,7 @@ import AlarmIcon from '@mui/icons-material/Alarm';
 import ForwardIcon from '@mui/icons-material/Forward';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AssignmentIcon from '@mui/icons-material/Assignment';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 import type { Message } from '@chat-app/shared';
 import EmojiPicker from './EmojiPicker';
 import ReminderDialog from '../Reminder/ReminderDialog';
@@ -275,6 +276,29 @@ export default function MessageActions({
             <AssignmentIcon fontSize="small" />
           </ListItemIcon>
           <ListItemText>タスク化</ListItemText>
+        </MenuItem>
+
+        {/* Wikiページ化 (#355) */}
+        <MenuItem
+          onClick={() => {
+            const url = `${window.location.origin}/?channel=${message.channelId}&message=${message.id}`;
+            sessionStorage.setItem(
+              `wiki.fromMessage.${message.id}`,
+              JSON.stringify({ content: message.content, url }),
+            );
+            const params = new URLSearchParams(window.location.search);
+            params.set('channel', String(message.channelId));
+            params.set('newWiki', '1');
+            params.set('fromMessage', String(message.id));
+            const newSearch = `?${params.toString()}`;
+            window.history.pushState({}, '', `${window.location.pathname}${newSearch}`);
+            closeMenu();
+          }}
+        >
+          <ListItemIcon>
+            <MenuBookIcon fontSize="small" />
+          </ListItemIcon>
+          <ListItemText>Wikiページ化</ListItemText>
         </MenuItem>
 
         {/* 通報（自分のメッセージ以外） */}

--- a/packages/client/src/components/Chat/MessageActions.tsx
+++ b/packages/client/src/components/Chat/MessageActions.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Box,
   IconButton,
@@ -33,6 +34,7 @@ import CreateTaskDialog from '../Task/CreateTaskDialog';
 import { api } from '../../api/client';
 import { useSocket } from '../../contexts/SocketContext';
 import { useSnackbar } from '../../contexts/SnackbarContext';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 interface Props {
   message: Message;
@@ -68,9 +70,21 @@ export default function MessageActions({
   const [createTaskDialogOpen, setCreateTaskDialogOpen] = useState(false);
   const socket = useSocket();
   const { showSuccess, showError } = useSnackbar();
+  const navigate = useNavigate();
 
   const handleDelete = () => {
     socket?.emit('delete_message', message.id);
+  };
+
+  // メッセージを Wiki ページ化する（#355）
+  // 本文と元メッセージURLを sessionStorage に保存し、Wikiタブの新規作成フォームへ遷移する
+  const handleWikify = () => {
+    const url = `${window.location.origin}/?channel=${message.channelId}&message=${message.id}`;
+    sessionStorage.setItem(
+      `wiki.fromMessage.${message.id}`,
+      JSON.stringify({ content: extractMessageText(message.content), url }),
+    );
+    navigate(`/chat?channel=${message.channelId}&newWiki=1&fromMessage=${message.id}`);
   };
 
   const handleCopyLink = () => {
@@ -281,17 +295,7 @@ export default function MessageActions({
         {/* Wikiページ化 (#355) */}
         <MenuItem
           onClick={() => {
-            const url = `${window.location.origin}/?channel=${message.channelId}&message=${message.id}`;
-            sessionStorage.setItem(
-              `wiki.fromMessage.${message.id}`,
-              JSON.stringify({ content: message.content, url }),
-            );
-            const params = new URLSearchParams(window.location.search);
-            params.set('channel', String(message.channelId));
-            params.set('newWiki', '1');
-            params.set('fromMessage', String(message.id));
-            const newSearch = `?${params.toString()}`;
-            window.history.pushState({}, '', `${window.location.pathname}${newSearch}`);
+            handleWikify();
             closeMenu();
           }}
         >

--- a/packages/client/src/components/Wiki/MarkdownRenderer.tsx
+++ b/packages/client/src/components/Wiki/MarkdownRenderer.tsx
@@ -1,0 +1,18 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { Box } from '@mui/material';
+
+interface Props {
+  source: string;
+}
+
+export default function MarkdownRenderer({ source }: Props) {
+  return (
+    <Box
+      className="markdown-body"
+      sx={{ '& pre': { p: 1, bgcolor: 'action.hover', overflowX: 'auto' } }}
+    >
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{source}</ReactMarkdown>
+    </Box>
+  );
+}

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -14,11 +14,13 @@ import {
 } from '@mui/material';
 import ScheduleSendIcon from '@mui/icons-material/ScheduleSend';
 import AttachFileIcon from '@mui/icons-material/AttachFile';
+import MenuBookIcon from '@mui/icons-material/MenuBook';
 import ViewSidebarIcon from '@mui/icons-material/ViewSidebar';
 import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import AddIcon from '@mui/icons-material/Add';
 import AppLayout from '../components/Layout/AppLayout';
 import { ChannelFilesTab } from './FilesPage';
+import ChannelWikiTab from '../components/Channel/ChannelWikiTab';
 import ChannelList from '../components/Channel/ChannelList';
 import CreateChannelDialog from '../components/Channel/CreateChannelDialog';
 import SidebarDmList from '../components/Layout/SidebarDmList';
@@ -53,7 +55,7 @@ export default function ChatPage({ users }: Props) {
   const activeChannelName = activeChannel?.name ?? '';
   // #247 #248 URL 直リンク時に activeChannel を埋めるための全チャンネルリスト
   const [allChannels, setAllChannels] = useState<Channel[] | null>(null);
-  const [activeTab, setActiveTab] = useState<'messages' | 'files'>('messages');
+  const [activeTab, setActiveTab] = useState<'messages' | 'files' | 'wiki'>('messages');
   // #148 下書きマップ: channelId → 下書きコンテンツ
   const [draftMap, setDraftMap] = useState<Map<number, string>>(new Map());
   const draftMapRef = useRef(draftMap);
@@ -122,6 +124,13 @@ export default function ChatPage({ users }: Props) {
   //   → SPA 内遷移にも対応（searchParams が変わるたびに再実行される）
   // useEffect B (deps=[highlightMessageId, messages]): messages が届いたら対象要素へスクロール → 5秒後に解除
   const [highlightMessageId, setHighlightMessageId] = useState<number | null>(null);
+
+  // ?wikiPage / ?newWiki 付き URL で開いたとき自動的に Wiki タブを選択する（#355）
+  useEffect(() => {
+    if (searchParams.get('wikiPage') || searchParams.get('newWiki')) {
+      setActiveTab('wiki');
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     const messageParam = searchParams.get('message');
@@ -398,13 +407,24 @@ export default function ChatPage({ users }: Props) {
               onSelect={(id, _name, channel) => {
                 // activeChannelName は activeChannel?.name から派生するため name 引数は使わない (#247 #248)
                 setActiveChannel(channel ?? null);
-                setActiveTab('messages');
+                // Wikiディープリンク (#355) を保持しているときは Wiki タブを維持
+                const keepWiki =
+                  searchParams.get('wikiPage') !== null || searchParams.get('newWiki') !== null;
+                if (!keepWiki) {
+                  setActiveTab('messages');
+                }
                 // #317 最近開いたチャンネル履歴に追加
                 if (channel) {
                   addRecentChannel({ id: channel.id, name: channel.name });
                 }
                 // URL を push 更新すると useEffect で activeChannelId が同期される
-                setSearchParams({ channel: String(id) });
+                if (keepWiki) {
+                  const next = new URLSearchParams(searchParams);
+                  next.set('channel', String(id));
+                  setSearchParams(next);
+                } else {
+                  setSearchParams({ channel: String(id) });
+                }
               }}
               draftMap={draftMap}
             />
@@ -470,6 +490,20 @@ export default function ChatPage({ users }: Props) {
                   <AttachFileIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
+              <Tooltip title="Wiki">
+                <IconButton
+                  size="small"
+                  aria-label="Wiki"
+                  onClick={() => setActiveTab((t) => (t === 'wiki' ? 'messages' : 'wiki'))}
+                  data-active={activeTab === 'wiki' ? 'true' : undefined}
+                  sx={{
+                    bgcolor: activeTab === 'wiki' ? 'action.selected' : undefined,
+                    flexShrink: 0,
+                  }}
+                >
+                  <MenuBookIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
               <Tooltip title="予約送信一覧">
                 <IconButton
                   size="small"
@@ -515,6 +549,16 @@ export default function ChatPage({ users }: Props) {
             >
               <ChannelFilesTab channelId={activeChannelId} />
             </Suspense>
+          )}
+
+          {/* Wikiタブ (#355) */}
+          {activeTab === 'wiki' && activeChannelId && activeChannel && user && (
+            <ChannelWikiTab
+              channelId={activeChannelId}
+              currentUserId={user.id}
+              currentUserRole={user.role}
+              channelCreatedBy={activeChannel.createdBy ?? 0}
+            />
           )}
 
           {/* チャット未選択時の案内文 + CTA (#317) */}

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -479,6 +479,25 @@ export function createTestDatabase() {
       last_read_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       PRIMARY KEY (user_id, root_message_id)
     );
+
+    CREATE TABLE IF NOT EXISTS wiki_pages (
+      id SERIAL PRIMARY KEY,
+      channel_id INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+      title TEXT NOT NULL,
+      content TEXT NOT NULL DEFAULT '',
+      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      updated_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+
+    CREATE TABLE IF NOT EXISTS wiki_page_tags (
+      wiki_page_id INTEGER NOT NULL REFERENCES wiki_pages(id) ON DELETE CASCADE,
+      tag_id INTEGER NOT NULL REFERENCES tags(id) ON DELETE CASCADE,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      created_by INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      PRIMARY KEY (wiki_page_id, tag_id)
+    );
   `);
 
   // pg-mem で作った Pool アダプタ
@@ -554,6 +573,8 @@ export function getSharedTestDatabase(): TestDatabase {
  */
 export async function resetTestData(db: TestDatabase): Promise<void> {
   // 外部キー参照の末端から順に削除する
+  await db.execute('DELETE FROM wiki_page_tags', []);
+  await db.execute('DELETE FROM wiki_pages', []);
   await db.execute('DELETE FROM thread_reads', []);
   await db.execute('DELETE FROM tasks', []);
   await db.execute('DELETE FROM saved_views', []);

--- a/packages/server/src/__tests__/integration/wikiPageController.test.ts
+++ b/packages/server/src/__tests__/integration/wikiPageController.test.ts
@@ -1,0 +1,457 @@
+/**
+ * wikiPageController のHTTPレベルテスト（#355）
+ *
+ * テスト対象: packages/server/src/routes/wikiPages.ts
+ * 戦略:
+ *   - supertest でHTTPリクエストを発行し、レスポンスのステータスコードと
+ *     レスポンスボディを検証する
+ *   - DB は pg-mem のインメモリ PostgreSQL 互換 DB を使用
+ *   - 認証・認可・楽観ロックの 401/403/409 を中心に検証する
+ */
+
+import { createTestDatabase } from '../__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+
+jest.mock('../../db/database', () => testDb);
+
+import request from 'supertest';
+import { createApp } from '../../app';
+import { registerUser, createChannelReq } from '../__fixtures__/testHelpers';
+
+const app = createApp();
+
+async function makeChannelMember(channelId: number, userId: number): Promise<void> {
+  await testDb.execute(
+    `INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+    [channelId, userId],
+  );
+}
+
+describe('POST /api/channels/:channelId/wiki-pages', () => {
+  it('正常: タイトルと本文を指定するとページが作成され201と作成されたページが返る', async () => {
+    const { token } = await registerUser(app, 'wp_post1', 'wp_post1@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-post1');
+
+    const res = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'タイトル', content: '本文' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.page.title).toBe('タイトル');
+    expect(res.body.page.content).toBe('本文');
+  });
+
+  it('正常: tagIdsを指定するとタグが紐付いた状態で返る', async () => {
+    const { token } = await registerUser(app, 'wp_post2', 'wp_post2@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-post2');
+    const tag = await testDb.queryOne<{ id: number }>(
+      `INSERT INTO tags (name) VALUES ('wp-tag1') RETURNING id`,
+      [],
+    );
+
+    const res = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 't', tagIds: [tag!.id] });
+
+    expect(res.status).toBe(201);
+    expect(res.body.page.tags.length).toBe(1);
+    expect(res.body.page.tags[0].id).toBe(tag!.id);
+  });
+
+  it('異常: トークンなしで401が返る', async () => {
+    const res = await request(app).post(`/api/channels/1/wiki-pages`).send({ title: 't' });
+    expect(res.status).toBe(401);
+  });
+
+  it('異常: チャンネル非メンバーは403が返る', async () => {
+    const { token: t1 } = await registerUser(app, 'wp_post3a', 'wp_post3a@test.com');
+    const { token: t2 } = await registerUser(app, 'wp_post3b', 'wp_post3b@test.com');
+    const channelId = await createChannelReq(app, t1, 'wp-ch-post3');
+
+    const res = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${t2}`)
+      .send({ title: 't' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('異常: タイトルが空文字列だと400が返る', async () => {
+    const { token } = await registerUser(app, 'wp_post4', 'wp_post4@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-post4');
+
+    const res = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: '   ' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('異常: 存在しないchannelIdだと404が返る', async () => {
+    const { token } = await registerUser(app, 'wp_post5', 'wp_post5@test.com');
+    const res = await request(app)
+      .post(`/api/channels/99999/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 't' });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/channels/:channelId/wiki-pages', () => {
+  it('正常: そのチャンネルのページ一覧が返る', async () => {
+    const { token } = await registerUser(app, 'wp_list1', 'wp_list1@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-list1');
+
+    await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'p1' });
+    await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'p2' });
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pages.length).toBe(2);
+  });
+
+  it('正常: クエリパラメータq でタイトル/本文の部分一致検索ができる', async () => {
+    const { token } = await registerUser(app, 'wp_list2', 'wp_list2@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-list2');
+
+    await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'apple' });
+    await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'banana' });
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/wiki-pages?q=apple`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pages.length).toBe(1);
+    expect(res.body.pages[0].title).toBe('apple');
+  });
+
+  it('正常: 該当ページが0件のときは空配列が返る', async () => {
+    const { token } = await registerUser(app, 'wp_list3', 'wp_list3@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-list3');
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.pages).toEqual([]);
+  });
+
+  it('異常: トークンなしで401が返る', async () => {
+    const res = await request(app).get(`/api/channels/1/wiki-pages`);
+    expect(res.status).toBe(401);
+  });
+
+  it('異常: チャンネル非メンバーは403が返る', async () => {
+    const { token: t1 } = await registerUser(app, 'wp_list4a', 'wp_list4a@test.com');
+    const { token: t2 } = await registerUser(app, 'wp_list4b', 'wp_list4b@test.com');
+    const channelId = await createChannelReq(app, t1, 'wp-ch-list4');
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${t2}`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/wiki-pages/:id', () => {
+  it('正常: 指定IDのページ詳細（タグ含む）が返る', async () => {
+    const { token } = await registerUser(app, 'wp_get1', 'wp_get1@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-get1');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'g' });
+    const pageId = create.body.page.id;
+
+    const res = await request(app).get(`/api/wiki-pages/${pageId}`).set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.page.id).toBe(pageId);
+    expect(Array.isArray(res.body.page.tags)).toBe(true);
+  });
+
+  it('異常: 存在しないIDで404が返る', async () => {
+    const { token } = await registerUser(app, 'wp_get2', 'wp_get2@test.com');
+    const res = await request(app).get(`/api/wiki-pages/99999`).set('Cookie', `token=${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('異常: チャンネル非メンバーは403が返る', async () => {
+    const { token: t1 } = await registerUser(app, 'wp_get3a', 'wp_get3a@test.com');
+    const { token: t2 } = await registerUser(app, 'wp_get3b', 'wp_get3b@test.com');
+    const channelId = await createChannelReq(app, t1, 'wp-ch-get3');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${t1}`)
+      .send({ title: 'g' });
+
+    const res = await request(app)
+      .get(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${t2}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('異常: トークンなしで401が返る', async () => {
+    const res = await request(app).get(`/api/wiki-pages/1`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PATCH /api/wiki-pages/:id', () => {
+  it('正常: 作成者が編集すると200と更新後ページが返る', async () => {
+    const { token } = await registerUser(app, 'wp_patch1', 'wp_patch1@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-patch1');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'orig' });
+
+    const res = await request(app)
+      .patch(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'updated', expectedUpdatedAt: create.body.page.updatedAt });
+
+    expect(res.status).toBe(200);
+    expect(res.body.page.title).toBe('updated');
+  });
+
+  it('正常: チャンネル作成者は他人作成のページも編集できる', async () => {
+    const { token: ownerToken, userId: ownerId } = await registerUser(
+      app,
+      'wp_patch2_owner',
+      'wp_patch2_owner@test.com',
+    );
+    const { token: memberToken, userId: memberId } = await registerUser(
+      app,
+      'wp_patch2_member',
+      'wp_patch2_member@test.com',
+    );
+    const channelId = await createChannelReq(app, ownerToken, 'wp-ch-patch2');
+    await makeChannelMember(channelId, memberId);
+
+    // member がページを作成
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${memberToken}`)
+      .send({ title: 'orig' });
+
+    // owner（チャンネル作成者）が編集
+    const res = await request(app)
+      .patch(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${ownerToken}`)
+      .send({ title: 'by-owner', expectedUpdatedAt: create.body.page.updatedAt });
+
+    expect(res.status).toBe(200);
+    expect(res.body.page.title).toBe('by-owner');
+    // 未使用警告抑止
+    void ownerId;
+  });
+
+  it('正常: 管理者は編集できる', async () => {
+    const { token: t1 } = await registerUser(app, 'wp_patch3_user', 'wp_patch3_user@test.com');
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'wp_patch3_admin',
+      'wp_patch3_admin@test.com',
+    );
+    await testDb.execute(`UPDATE users SET role = 'admin' WHERE id = $1`, [adminId]);
+
+    const channelId = await createChannelReq(app, t1, 'wp-ch-patch3');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${t1}`)
+      .send({ title: 'o' });
+
+    const res = await request(app)
+      .patch(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${adminToken}`)
+      .send({ title: 'admin', expectedUpdatedAt: create.body.page.updatedAt });
+    expect(res.status).toBe(200);
+  });
+
+  it('正常: tagIdsを更新すると紐付けが置換される', async () => {
+    const { token } = await registerUser(app, 'wp_patch4', 'wp_patch4@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-patch4');
+    const t1 = await testDb.queryOne<{ id: number }>(
+      `INSERT INTO tags (name) VALUES ('p4t1') RETURNING id`,
+      [],
+    );
+    const t2 = await testDb.queryOne<{ id: number }>(
+      `INSERT INTO tags (name) VALUES ('p4t2') RETURNING id`,
+      [],
+    );
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 't', tagIds: [t1!.id] });
+
+    const res = await request(app)
+      .patch(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${token}`)
+      .send({ tagIds: [t2!.id], expectedUpdatedAt: create.body.page.updatedAt });
+    expect(res.status).toBe(200);
+    expect(res.body.page.tags.map((x: { id: number }) => x.id)).toEqual([t2!.id]);
+  });
+
+  it('異常: 編集権限のない一般メンバーは403が返る', async () => {
+    const { token: owner } = await registerUser(app, 'wp_patch5_owner', 'wp_patch5o@test.com');
+    const { token: m, userId: mId } = await registerUser(app, 'wp_patch5_m', 'wp_patch5m@test.com');
+    const { token: other, userId: otherId } = await registerUser(
+      app,
+      'wp_patch5_other',
+      'wp_patch5x@test.com',
+    );
+    const channelId = await createChannelReq(app, owner, 'wp-ch-patch5');
+    await makeChannelMember(channelId, mId);
+    await makeChannelMember(channelId, otherId);
+
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${m}`)
+      .send({ title: 'o' });
+
+    const res = await request(app)
+      .patch(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${other}`)
+      .send({ title: 'x', expectedUpdatedAt: create.body.page.updatedAt });
+    expect(res.status).toBe(403);
+  });
+
+  it('異常: expectedUpdatedAtが現状と不一致なら409が返る（楽観ロック）', async () => {
+    const { token } = await registerUser(app, 'wp_patch6', 'wp_patch6@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-patch6');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'o' });
+
+    const res = await request(app)
+      .patch(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'x', expectedUpdatedAt: '2000-01-01T00:00:00.000Z' });
+    expect(res.status).toBe(409);
+  });
+
+  it('異常: 存在しないIDで404が返る', async () => {
+    const { token } = await registerUser(app, 'wp_patch7', 'wp_patch7@test.com');
+    const res = await request(app)
+      .patch(`/api/wiki-pages/99999`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'x', expectedUpdatedAt: '2020-01-01T00:00:00.000Z' });
+    expect(res.status).toBe(404);
+  });
+
+  it('異常: トークンなしで401が返る', async () => {
+    const res = await request(app)
+      .patch(`/api/wiki-pages/1`)
+      .send({ title: 'x', expectedUpdatedAt: '2020-01-01T00:00:00.000Z' });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('DELETE /api/wiki-pages/:id', () => {
+  it('正常: チャンネル作成者は削除できる（204）', async () => {
+    const { token } = await registerUser(app, 'wp_del1', 'wp_del1@test.com');
+    const channelId = await createChannelReq(app, token, 'wp-ch-del1');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${token}`)
+      .send({ title: 'd' });
+
+    const res = await request(app)
+      .delete(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${token}`);
+    expect(res.status).toBe(204);
+  });
+
+  it('正常: 管理者は削除できる', async () => {
+    const { token: t1 } = await registerUser(app, 'wp_del2_user', 'wp_del2_user@test.com');
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'wp_del2_admin',
+      'wp_del2_admin@test.com',
+    );
+    await testDb.execute(`UPDATE users SET role = 'admin' WHERE id = $1`, [adminId]);
+
+    const channelId = await createChannelReq(app, t1, 'wp-ch-del2');
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${t1}`)
+      .send({ title: 'd' });
+
+    const res = await request(app)
+      .delete(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${adminToken}`);
+    expect(res.status).toBe(204);
+  });
+
+  it('異常: ページ作成者であってもチャンネル作成者でなければ403', async () => {
+    const { token: owner } = await registerUser(app, 'wp_del3_owner', 'wp_del3_owner@test.com');
+    const { token: m, userId: mId } = await registerUser(app, 'wp_del3_m', 'wp_del3_m@test.com');
+    const channelId = await createChannelReq(app, owner, 'wp-ch-del3');
+    await makeChannelMember(channelId, mId);
+
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${m}`)
+      .send({ title: 'd' });
+
+    const res = await request(app)
+      .delete(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${m}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('異常: 一般メンバーは403が返る', async () => {
+    const { token: owner } = await registerUser(app, 'wp_del4_owner', 'wp_del4_owner@test.com');
+    const { token: other, userId: otherId } = await registerUser(
+      app,
+      'wp_del4_other',
+      'wp_del4_other@test.com',
+    );
+    const channelId = await createChannelReq(app, owner, 'wp-ch-del4');
+    await makeChannelMember(channelId, otherId);
+    const create = await request(app)
+      .post(`/api/channels/${channelId}/wiki-pages`)
+      .set('Cookie', `token=${owner}`)
+      .send({ title: 'd' });
+
+    const res = await request(app)
+      .delete(`/api/wiki-pages/${create.body.page.id}`)
+      .set('Cookie', `token=${other}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('異常: 存在しないIDで404が返る', async () => {
+    const { token } = await registerUser(app, 'wp_del5', 'wp_del5@test.com');
+    const res = await request(app).delete(`/api/wiki-pages/99999`).set('Cookie', `token=${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('異常: トークンなしで401が返る', async () => {
+    const res = await request(app).delete(`/api/wiki-pages/1`);
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/server/src/__tests__/wikiPage.test.ts
+++ b/packages/server/src/__tests__/wikiPage.test.ts
@@ -1,0 +1,404 @@
+/**
+ * テスト対象: wikiPageService の Wiki ページ管理機能（#355）
+ * 戦略:
+ *   - pg-mem のインメモリ PostgreSQL 互換 DB を使いサービス層を直接テストする
+ *   - 外部キー制約を満たすため beforeAll でユーザー・チャンネルを挿入する
+ *   - 作成・更新・削除・一覧+検索・タグ付与・楽観ロック・権限チェックの
+ *     ビジネスロジックを網羅する
+ */
+
+import { createTestDatabase } from './__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+
+jest.mock('../db/database', () => testDb);
+
+import * as wikiPageService from '../services/wikiPageService';
+
+let userId1: number;
+let userId2: number;
+let userIdAdmin: number;
+let channelId1: number;
+let channelId2: number;
+let tagId1: number;
+let tagId2: number;
+
+beforeAll(async () => {
+  const u1 = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO users (username, email, password_hash) VALUES ('w_user1', 'w1@test.com', 'h') RETURNING id`,
+    [],
+  );
+  const u2 = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO users (username, email, password_hash) VALUES ('w_user2', 'w2@test.com', 'h') RETURNING id`,
+    [],
+  );
+  const ua = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO users (username, email, password_hash, role) VALUES ('w_admin', 'wa@test.com', 'h', 'admin') RETURNING id`,
+    [],
+  );
+  userId1 = u1!.id;
+  userId2 = u2!.id;
+  userIdAdmin = ua!.id;
+
+  const c1 = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO channels (name, created_by) VALUES ('w_ch1', $1) RETURNING id`,
+    [userId1],
+  );
+  const c2 = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO channels (name, created_by) VALUES ('w_ch2', $1) RETURNING id`,
+    [userId2],
+  );
+  channelId1 = c1!.id;
+  channelId2 = c2!.id;
+
+  const t1 = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO tags (name) VALUES ('faq') RETURNING id`,
+    [],
+  );
+  const t2 = await testDb.queryOne<{ id: number }>(
+    `INSERT INTO tags (name) VALUES ('runbook') RETURNING id`,
+    [],
+  );
+  tagId1 = t1!.id;
+  tagId2 = t2!.id;
+});
+
+beforeEach(async () => {
+  await testDb.execute('DELETE FROM wiki_page_tags', []);
+  await testDb.execute('DELETE FROM wiki_pages', []);
+});
+
+describe('Wikiページ管理機能（wikiPageService）', () => {
+  describe('ページ作成', () => {
+    it('タイトル・本文・チャンネルIDを指定してWikiページを作成できる', async () => {
+      const page = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 'テストページ',
+        content: '本文',
+      });
+      expect(page.id).toBeDefined();
+      expect(page.title).toBe('テストページ');
+      expect(page.content).toBe('本文');
+      expect(page.channelId).toBe(channelId1);
+    });
+
+    it('作成時にcreated_byとupdated_byが同じユーザーIDで設定される', async () => {
+      const page = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      expect(page.createdBy).toBe(userId1);
+      expect(page.updatedBy).toBe(userId1);
+    });
+
+    it('作成時のcreated_atとupdated_atがほぼ同時刻に設定される', async () => {
+      const page = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const c = new Date(page.createdAt).getTime();
+      const u = new Date(page.updatedAt).getTime();
+      expect(Math.abs(u - c)).toBeLessThan(2000);
+    });
+
+    it('タイトルが空文字列の場合はエラーになる', async () => {
+      await expect(
+        wikiPageService.createWikiPage(channelId1, userId1, { title: '   ' }),
+      ).rejects.toThrow();
+    });
+
+    it('本文が空文字列でも作成できる（空のWikiページは許容）', async () => {
+      const page = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 't',
+        content: '',
+      });
+      expect(page.content).toBe('');
+    });
+
+    it('存在しないチャンネルIDを指定するとエラーになる', async () => {
+      await expect(
+        wikiPageService.createWikiPage(99999, userId1, { title: 't' }),
+      ).rejects.toThrow();
+    });
+
+    it('同一チャンネル内でタイトル重複を許容する', async () => {
+      const a = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'dup' });
+      const b = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'dup' });
+      expect(a.id).not.toBe(b.id);
+    });
+
+    it('タグIDリストを指定するとwiki_page_tagsに紐付けが作成される', async () => {
+      const page = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 't',
+        tagIds: [tagId1, tagId2],
+      });
+      expect(page.tags.map((t) => t.id).sort()).toEqual([tagId1, tagId2].sort());
+    });
+
+    it('存在しないタグIDを含めるとエラーになる', async () => {
+      await expect(
+        wikiPageService.createWikiPage(channelId1, userId1, {
+          title: 't',
+          tagIds: [99999],
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('ページ取得', () => {
+    it('IDを指定して単一ページを取得できる', async () => {
+      const created = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'g' });
+      const got = await wikiPageService.getWikiPage(created.id);
+      expect(got?.id).toBe(created.id);
+    });
+
+    it('取得結果にタイトル・本文・作成者・更新者・作成日時・更新日時が含まれる', async () => {
+      const created = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 'g2',
+        content: 'c',
+      });
+      const got = await wikiPageService.getWikiPage(created.id);
+      expect(got).toMatchObject({
+        title: 'g2',
+        content: 'c',
+        createdBy: userId1,
+        updatedBy: userId1,
+      });
+      expect(got?.createdAt).toBeDefined();
+      expect(got?.updatedAt).toBeDefined();
+    });
+
+    it('取得結果に紐づくタグ一覧が含まれる', async () => {
+      const created = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 'g3',
+        tagIds: [tagId1],
+      });
+      const got = await wikiPageService.getWikiPage(created.id);
+      expect(got?.tags.length).toBe(1);
+      expect(got?.tags[0].id).toBe(tagId1);
+    });
+
+    it('存在しないIDを指定するとnullを返す', async () => {
+      const got = await wikiPageService.getWikiPage(99999);
+      expect(got).toBeNull();
+    });
+  });
+
+  describe('ページ一覧（チャンネル単位）', () => {
+    it('チャンネルIDを指定してそのチャンネルのページのみ返す', async () => {
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      await wikiPageService.createWikiPage(channelId2, userId2, { title: 'b' });
+      const list = await wikiPageService.listWikiPages(channelId1);
+      expect(list.length).toBe(1);
+      expect(list[0].title).toBe('a');
+    });
+
+    it('他のチャンネルのページは含まれない', async () => {
+      await wikiPageService.createWikiPage(channelId2, userId2, { title: 'b' });
+      const list = await wikiPageService.listWikiPages(channelId1);
+      expect(list.length).toBe(0);
+    });
+
+    it('更新日時の降順で返す', async () => {
+      const p1 = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'old' });
+      await testDb.execute(
+        `UPDATE wiki_pages SET updated_at = NOW() - INTERVAL '1 hour' WHERE id = $1`,
+        [p1.id],
+      );
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'new' });
+      const list = await wikiPageService.listWikiPages(channelId1);
+      expect(list[0].title).toBe('new');
+      expect(list[1].title).toBe('old');
+    });
+
+    it('検索クエリqを指定するとタイトル部分一致でフィルタされる', async () => {
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'apple pie' });
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'banana' });
+      const list = await wikiPageService.listWikiPages(channelId1, 'apple');
+      expect(list.length).toBe(1);
+      expect(list[0].title).toBe('apple pie');
+    });
+
+    it('検索クエリqを指定すると本文部分一致でもフィルタされる', async () => {
+      await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 'x',
+        content: 'apple in body',
+      });
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'y', content: 'other' });
+      const list = await wikiPageService.listWikiPages(channelId1, 'apple');
+      expect(list.length).toBe(1);
+      expect(list[0].title).toBe('x');
+    });
+
+    it('検索クエリqは大文字小文字を区別しない（ILIKE）', async () => {
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'Apple' });
+      const list = await wikiPageService.listWikiPages(channelId1, 'apple');
+      expect(list.length).toBe(1);
+    });
+
+    it('検索クエリが空文字列のときは全件返す', async () => {
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      await wikiPageService.createWikiPage(channelId1, userId1, { title: 'b' });
+      const list = await wikiPageService.listWikiPages(channelId1, '');
+      expect(list.length).toBe(2);
+    });
+  });
+
+  describe('ページ更新', () => {
+    it('タイトル・本文を更新できる', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'old' });
+      const updated = await wikiPageService.updateWikiPage(p.id, userId1, {
+        title: 'new',
+        content: 'body',
+        expectedUpdatedAt: p.updatedAt,
+      });
+      expect(updated.title).toBe('new');
+      expect(updated.content).toBe('body');
+    });
+
+    it('更新するとupdated_atが新しい時刻になる', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      await new Promise((r) => setTimeout(r, 10));
+      const updated = await wikiPageService.updateWikiPage(p.id, userId1, {
+        title: 'b',
+        expectedUpdatedAt: p.updatedAt,
+      });
+      expect(new Date(updated.updatedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(p.updatedAt).getTime(),
+      );
+    });
+
+    it('更新するとupdated_byが更新者のIDになる', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const updated = await wikiPageService.updateWikiPage(p.id, userId2, {
+        title: 'b',
+        expectedUpdatedAt: p.updatedAt,
+      });
+      expect(updated.updatedBy).toBe(userId2);
+    });
+
+    it('expectedUpdatedAtが現在のupdated_atと一致しないと409相当のエラーになる（楽観ロック）', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const stale = '2000-01-01T00:00:00.000Z';
+      await expect(
+        wikiPageService.updateWikiPage(p.id, userId1, {
+          title: 'b',
+          expectedUpdatedAt: stale,
+        }),
+      ).rejects.toMatchObject({ statusCode: 409 });
+    });
+
+    it('expectedUpdatedAtが一致すれば正常に更新される', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const updated = await wikiPageService.updateWikiPage(p.id, userId1, {
+        title: 'b',
+        expectedUpdatedAt: p.updatedAt,
+      });
+      expect(updated.title).toBe('b');
+    });
+
+    it('タグIDリストを更新すると既存の紐付けが置換される', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 'a',
+        tagIds: [tagId1],
+      });
+      const updated = await wikiPageService.updateWikiPage(p.id, userId1, {
+        tagIds: [tagId2],
+        expectedUpdatedAt: p.updatedAt,
+      });
+      expect(updated.tags.map((t) => t.id)).toEqual([tagId2]);
+    });
+
+    it('存在しないページIDを更新しようとするとエラーになる', async () => {
+      await expect(
+        wikiPageService.updateWikiPage(99999, userId1, {
+          title: 'a',
+          expectedUpdatedAt: '2020-01-01T00:00:00.000Z',
+        }),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+
+  describe('ページ削除', () => {
+    it('IDを指定してページを削除できる（ハードデリート）', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      await wikiPageService.deleteWikiPage(p.id);
+      const got = await wikiPageService.getWikiPage(p.id);
+      expect(got).toBeNull();
+    });
+
+    it('削除するとwiki_page_tagsの紐付けもCASCADEで削除される', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, {
+        title: 'a',
+        tagIds: [tagId1],
+      });
+      await wikiPageService.deleteWikiPage(p.id);
+      const rows = await testDb.query(`SELECT * FROM wiki_page_tags WHERE wiki_page_id = $1`, [
+        p.id,
+      ]);
+      expect(rows.length).toBe(0);
+    });
+
+    it('存在しないIDを削除しようとするとエラーになる', async () => {
+      await expect(wikiPageService.deleteWikiPage(99999)).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe('権限チェック（canEdit）', () => {
+    it('ページ作成者本人は編集可能', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const info = await wikiPageService.loadPageAuthInfo(p.id);
+      expect(wikiPageService.canEdit(info!, { userId: userId1, userRole: 'user' })).toBe(true);
+    });
+
+    it('チャンネル作成者（channels.created_by）は編集可能', async () => {
+      // channelId1 の作成者は userId1。userId2 作成のページを直接 INSERT し、
+      // userId1（チャンネル作成者）が編集可能であることを確認する。
+      const inserted = await testDb.queryOne<{ id: number }>(
+        `INSERT INTO wiki_pages (channel_id, title, created_by, updated_by) VALUES ($1, 'x', $2, $2) RETURNING id`,
+        [channelId1, userId2],
+      );
+      const info = await wikiPageService.loadPageAuthInfo(inserted!.id);
+      expect(wikiPageService.canEdit(info!, { userId: userId1, userRole: 'user' })).toBe(true);
+    });
+
+    it('管理者（users.role=admin）は編集可能', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const info = await wikiPageService.loadPageAuthInfo(p.id);
+      expect(wikiPageService.canEdit(info!, { userId: userIdAdmin, userRole: 'admin' })).toBe(true);
+    });
+
+    it('上記いずれにも該当しない一般メンバーは編集不可（403相当）', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const info = await wikiPageService.loadPageAuthInfo(p.id);
+      expect(wikiPageService.canEdit(info!, { userId: userId2, userRole: 'user' })).toBe(false);
+    });
+  });
+
+  describe('権限チェック（canDelete）', () => {
+    it('チャンネル作成者は削除可能', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const info = await wikiPageService.loadPageAuthInfo(p.id);
+      expect(wikiPageService.canDelete(info!, { userId: userId1, userRole: 'user' })).toBe(true);
+    });
+
+    it('管理者は削除可能', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const info = await wikiPageService.loadPageAuthInfo(p.id);
+      expect(wikiPageService.canDelete(info!, { userId: userIdAdmin, userRole: 'admin' })).toBe(
+        true,
+      );
+    });
+
+    it('ページ作成者であってもチャンネル作成者でなければ削除不可', async () => {
+      // channelId1 の作成者は userId1。userId2 がページを作成したと仮定して直接 INSERT する。
+      const inserted = await testDb.queryOne<{ id: number }>(
+        `INSERT INTO wiki_pages (channel_id, title, created_by, updated_by) VALUES ($1, 'x', $2, $2) RETURNING id`,
+        [channelId1, userId2],
+      );
+      const info = await wikiPageService.loadPageAuthInfo(inserted!.id);
+      expect(wikiPageService.canDelete(info!, { userId: userId2, userRole: 'user' })).toBe(false);
+    });
+
+    it('一般メンバーは削除不可', async () => {
+      const p = await wikiPageService.createWikiPage(channelId1, userId1, { title: 'a' });
+      const info = await wikiPageService.loadPageAuthInfo(p.id);
+      expect(wikiPageService.canDelete(info!, { userId: userId2, userRole: 'user' })).toBe(false);
+    });
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -25,6 +25,7 @@ import savedViewRoutes from './routes/savedViews';
 import guestLinksRouter, { channelGuestLinksRouter } from './routes/guestLinks';
 import calendarRoutes from './routes/calendar';
 import threadRoutes from './routes/threads';
+import wikiPageRoutes, { channelWikiRouter } from './routes/wikiPages';
 import { errorHandler } from './middleware/errorHandler';
 import { setupSwagger } from './swagger/setup';
 
@@ -70,6 +71,8 @@ export function createApp() {
   app.use('/api/guest-links', guestLinksRouter);
   app.use('/api/calendar', calendarRoutes);
   app.use('/api/threads', threadRoutes);
+  app.use('/api/channels/:channelId/wiki-pages', channelWikiRouter);
+  app.use('/api/wiki-pages', wikiPageRoutes);
 
   app.use(errorHandler);
 

--- a/packages/server/src/routes/wikiPages.ts
+++ b/packages/server/src/routes/wikiPages.ts
@@ -1,0 +1,160 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
+import { queryOne } from '../db/database';
+import { createError } from '../middleware/errorHandler';
+import * as wikiPageService from '../services/wikiPageService';
+
+const router = Router();
+
+async function loadAuthCtx(userId: number): Promise<{ userId: number; userRole: string }> {
+  const row = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [userId]);
+  return { userId, userRole: row?.role ?? 'user' };
+}
+
+async function assertChannelAccess(channelId: number, userId: number): Promise<void> {
+  const channel = await queryOne<{ id: number }>('SELECT id FROM channels WHERE id = $1', [
+    channelId,
+  ]);
+  if (!channel) {
+    throw createError('チャンネルが見つかりません', 404);
+  }
+  const auth = await loadAuthCtx(userId);
+  if (auth.userRole === 'admin') return;
+  const member = await wikiPageService.isChannelMember(channelId, userId);
+  if (!member) {
+    throw createError('チャンネルメンバーではありません', 403);
+  }
+}
+
+// チャンネル所属 Wiki 一覧 / 作成
+export const channelWikiRouter = Router({ mergeParams: true });
+
+channelWikiRouter.get(
+  '/',
+  authenticateToken,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId;
+      const channelId = parseInt(String(req.params.channelId), 10);
+      if (isNaN(channelId)) {
+        throw createError('Invalid channel ID', 400);
+      }
+      await assertChannelAccess(channelId, userId);
+      const q = typeof req.query.q === 'string' ? req.query.q : undefined;
+      const pages = await wikiPageService.listWikiPages(channelId, q);
+      res.json({ pages });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+channelWikiRouter.post(
+  '/',
+  authenticateToken,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId;
+      const channelId = parseInt(String(req.params.channelId), 10);
+      if (isNaN(channelId)) {
+        throw createError('Invalid channel ID', 400);
+      }
+      await assertChannelAccess(channelId, userId);
+      const { title, content, tagIds } = req.body as {
+        title?: string;
+        content?: string;
+        tagIds?: number[];
+      };
+      const page = await wikiPageService.createWikiPage(channelId, userId, {
+        title: title ?? '',
+        content,
+        tagIds,
+      });
+      res.status(201).json({ page });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// 単一 Wiki ページ操作（GET / PATCH / DELETE）
+router.get('/:id', authenticateToken, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = (req as AuthenticatedRequest).userId;
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) throw createError('Invalid wiki page ID', 400);
+
+    const info = await wikiPageService.loadPageAuthInfo(id);
+    if (!info) throw createError('Wikiページが見つかりません', 404);
+
+    await assertChannelAccess(info.channelId, userId);
+
+    const page = await wikiPageService.getWikiPage(id);
+    if (!page) throw createError('Wikiページが見つかりません', 404);
+    res.json({ page });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.patch('/:id', authenticateToken, async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = (req as AuthenticatedRequest).userId;
+    const id = parseInt(req.params.id, 10);
+    if (isNaN(id)) throw createError('Invalid wiki page ID', 400);
+
+    const info = await wikiPageService.loadPageAuthInfo(id);
+    if (!info) throw createError('Wikiページが見つかりません', 404);
+
+    const auth = await loadAuthCtx(userId);
+    if (!wikiPageService.canEdit(info, auth)) {
+      throw createError('編集権限がありません', 403);
+    }
+
+    const { title, content, tagIds, expectedUpdatedAt } = req.body as {
+      title?: string;
+      content?: string;
+      tagIds?: number[];
+      expectedUpdatedAt?: string;
+    };
+    if (!expectedUpdatedAt) {
+      throw createError('expectedUpdatedAt が必要です', 400);
+    }
+    const page = await wikiPageService.updateWikiPage(id, userId, {
+      title,
+      content,
+      tagIds,
+      expectedUpdatedAt,
+    });
+    res.json({ page });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.delete(
+  '/:id',
+  authenticateToken,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = (req as AuthenticatedRequest).userId;
+      const id = parseInt(req.params.id, 10);
+      if (isNaN(id)) throw createError('Invalid wiki page ID', 400);
+
+      const info = await wikiPageService.loadPageAuthInfo(id);
+      if (!info) throw createError('Wikiページが見つかりません', 404);
+
+      const auth = await loadAuthCtx(userId);
+      if (!wikiPageService.canDelete(info, auth)) {
+        throw createError('削除権限がありません', 403);
+      }
+
+      await wikiPageService.deleteWikiPage(id);
+      res.status(204).send();
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/packages/server/src/services/wikiPageService.ts
+++ b/packages/server/src/services/wikiPageService.ts
@@ -1,0 +1,303 @@
+import { query, queryOne, execute } from '../db/database';
+import { createError } from '../middleware/errorHandler';
+import type {
+  WikiPage,
+  WikiPageSummary,
+  CreateWikiPageInput,
+  UpdateWikiPageInput,
+  Tag,
+} from '@chat-app/shared';
+
+interface WikiPageRow {
+  id: number;
+  channel_id: number;
+  title: string;
+  content: string;
+  created_by: number | null;
+  created_by_username: string | null;
+  updated_by: number | null;
+  updated_by_username: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TagRow {
+  id: number;
+  name: string;
+  created_by: number | null;
+  use_count: number;
+  created_at: string;
+}
+
+const BASE_SELECT = `
+  SELECT
+    w.id, w.channel_id, w.title, w.content,
+    w.created_by, cu.username AS created_by_username,
+    w.updated_by, uu.username AS updated_by_username,
+    w.created_at, w.updated_at
+  FROM wiki_pages w
+  LEFT JOIN users cu ON cu.id = w.created_by
+  LEFT JOIN users uu ON uu.id = w.updated_by
+`;
+
+function rowToTag(row: TagRow): Tag {
+  return {
+    id: row.id,
+    name: row.name,
+    useCount: row.use_count,
+    createdAt: row.created_at,
+  };
+}
+
+async function loadTagsForPage(pageId: number): Promise<Tag[]> {
+  const rows = await query<TagRow>(
+    `SELECT t.id, t.name, t.created_by, t.use_count, t.created_at
+     FROM tags t
+     JOIN wiki_page_tags wpt ON wpt.tag_id = t.id
+     WHERE wpt.wiki_page_id = $1
+     ORDER BY t.name ASC`,
+    [pageId],
+  );
+  return rows.map(rowToTag);
+}
+
+async function loadTagsForPages(pageIds: number[]): Promise<Map<number, Tag[]>> {
+  const map = new Map<number, Tag[]>();
+  if (pageIds.length === 0) return map;
+  const placeholders = pageIds.map((_, i) => `$${i + 1}`).join(', ');
+  const rows = await query<TagRow & { wiki_page_id: number }>(
+    `SELECT wpt.wiki_page_id, t.id, t.name, t.created_by, t.use_count, t.created_at
+     FROM wiki_page_tags wpt
+     JOIN tags t ON t.id = wpt.tag_id
+     WHERE wpt.wiki_page_id IN (${placeholders})
+     ORDER BY t.name ASC`,
+    pageIds,
+  );
+  for (const r of rows) {
+    const list = map.get(r.wiki_page_id) ?? [];
+    list.push(rowToTag(r));
+    map.set(r.wiki_page_id, list);
+  }
+  return map;
+}
+
+function rowToPage(row: WikiPageRow, tags: Tag[]): WikiPage {
+  return {
+    id: row.id,
+    channelId: row.channel_id,
+    title: row.title,
+    content: row.content,
+    createdBy: row.created_by,
+    createdByUsername: row.created_by_username,
+    updatedBy: row.updated_by,
+    updatedByUsername: row.updated_by_username,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    tags,
+  };
+}
+
+function rowToSummary(row: WikiPageRow, tags: Tag[]): WikiPageSummary {
+  return {
+    id: row.id,
+    channelId: row.channel_id,
+    title: row.title,
+    createdBy: row.created_by,
+    createdByUsername: row.created_by_username,
+    updatedBy: row.updated_by,
+    updatedByUsername: row.updated_by_username,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    tags,
+  };
+}
+
+async function assertTagsExist(tagIds: number[]): Promise<void> {
+  if (tagIds.length === 0) return;
+  const unique = Array.from(new Set(tagIds));
+  const placeholders = unique.map((_, i) => `$${i + 1}`).join(', ');
+  const rows = await query<{ id: number }>(
+    `SELECT id FROM tags WHERE id IN (${placeholders})`,
+    unique,
+  );
+  if (rows.length !== unique.length) {
+    throw createError('指定されたタグが存在しません', 400);
+  }
+}
+
+async function replaceTags(pageId: number, tagIds: number[], userId: number): Promise<void> {
+  await execute(`DELETE FROM wiki_page_tags WHERE wiki_page_id = $1`, [pageId]);
+  if (tagIds.length === 0) return;
+  const unique = Array.from(new Set(tagIds));
+  for (const tagId of unique) {
+    await execute(
+      `INSERT INTO wiki_page_tags (wiki_page_id, tag_id, created_by) VALUES ($1, $2, $3)`,
+      [pageId, tagId, userId],
+    );
+  }
+}
+
+export async function createWikiPage(
+  channelId: number,
+  userId: number,
+  input: CreateWikiPageInput,
+): Promise<WikiPage> {
+  const title = (input.title ?? '').trim();
+  if (title.length === 0) {
+    throw createError('タイトルは空にできません', 400);
+  }
+  const content = input.content ?? '';
+  const tagIds = input.tagIds ?? [];
+
+  const channel = await queryOne<{ id: number }>(`SELECT id FROM channels WHERE id = $1`, [
+    channelId,
+  ]);
+  if (!channel) {
+    throw createError('チャンネルが見つかりません', 404);
+  }
+
+  await assertTagsExist(tagIds);
+
+  const inserted = await queryOne<{ id: number }>(
+    `INSERT INTO wiki_pages (channel_id, title, content, created_by, updated_by)
+     VALUES ($1, $2, $3, $4, $4) RETURNING id`,
+    [channelId, title, content, userId],
+  );
+  if (!inserted) {
+    throw createError('Wikiページの作成に失敗しました', 500);
+  }
+  await replaceTags(inserted.id, tagIds, userId);
+
+  const page = await getWikiPage(inserted.id);
+  if (!page) {
+    throw createError('Wikiページの取得に失敗しました', 500);
+  }
+  return page;
+}
+
+export async function getWikiPage(id: number): Promise<WikiPage | null> {
+  const row = await queryOne<WikiPageRow>(`${BASE_SELECT} WHERE w.id = $1`, [id]);
+  if (!row) return null;
+  const tags = await loadTagsForPage(row.id);
+  return rowToPage(row, tags);
+}
+
+export async function listWikiPages(channelId: number, q?: string): Promise<WikiPageSummary[]> {
+  const params: unknown[] = [channelId];
+  let where = `WHERE w.channel_id = $1`;
+  if (q && q.trim().length > 0) {
+    params.push(`%${q.trim()}%`);
+    where += ` AND (w.title ILIKE $${params.length} OR w.content ILIKE $${params.length})`;
+  }
+  const rows = await query<WikiPageRow>(
+    `${BASE_SELECT} ${where} ORDER BY w.updated_at DESC`,
+    params,
+  );
+  const tagMap = await loadTagsForPages(rows.map((r) => r.id));
+  return rows.map((r) => rowToSummary(r, tagMap.get(r.id) ?? []));
+}
+
+export async function updateWikiPage(
+  id: number,
+  userId: number,
+  input: UpdateWikiPageInput,
+): Promise<WikiPage> {
+  const existing = await queryOne<WikiPageRow>(`${BASE_SELECT} WHERE w.id = $1`, [id]);
+  if (!existing) {
+    throw createError('Wikiページが見つかりません', 404);
+  }
+
+  const currentUpdatedAtIso = new Date(existing.updated_at).toISOString();
+  const expectedIso = new Date(input.expectedUpdatedAt).toISOString();
+  if (currentUpdatedAtIso !== expectedIso) {
+    throw createError('他のユーザーによる更新と競合しました', 409);
+  }
+
+  const newTitle = input.title !== undefined ? input.title.trim() : existing.title;
+  if (newTitle.length === 0) {
+    throw createError('タイトルは空にできません', 400);
+  }
+  const newContent = input.content !== undefined ? input.content : existing.content;
+
+  if (input.tagIds !== undefined) {
+    await assertTagsExist(input.tagIds);
+  }
+
+  await execute(
+    `UPDATE wiki_pages
+     SET title = $1, content = $2, updated_by = $3, updated_at = NOW()
+     WHERE id = $4`,
+    [newTitle, newContent, userId, id],
+  );
+
+  if (input.tagIds !== undefined) {
+    await replaceTags(id, input.tagIds, userId);
+  }
+
+  const updated = await getWikiPage(id);
+  if (!updated) {
+    throw createError('Wikiページの取得に失敗しました', 500);
+  }
+  return updated;
+}
+
+export async function deleteWikiPage(id: number): Promise<void> {
+  const result = await execute(`DELETE FROM wiki_pages WHERE id = $1`, [id]);
+  if (result.rowCount === 0) {
+    throw createError('Wikiページが見つかりません', 404);
+  }
+}
+
+interface AuthContext {
+  userId: number;
+  userRole: string;
+}
+
+interface PageAuthInfo {
+  pageId: number;
+  channelId: number;
+  pageCreatedBy: number | null;
+  channelCreatedBy: number | null;
+}
+
+export async function loadPageAuthInfo(id: number): Promise<PageAuthInfo | null> {
+  const row = await queryOne<{
+    id: number;
+    channel_id: number;
+    created_by: number | null;
+    channel_created_by: number | null;
+  }>(
+    `SELECT w.id, w.channel_id, w.created_by, c.created_by AS channel_created_by
+     FROM wiki_pages w JOIN channels c ON c.id = w.channel_id
+     WHERE w.id = $1`,
+    [id],
+  );
+  if (!row) return null;
+  return {
+    pageId: row.id,
+    channelId: row.channel_id,
+    pageCreatedBy: row.created_by,
+    channelCreatedBy: row.channel_created_by,
+  };
+}
+
+export function canEdit(info: PageAuthInfo, auth: AuthContext): boolean {
+  if (auth.userRole === 'admin') return true;
+  if (info.pageCreatedBy === auth.userId) return true;
+  if (info.channelCreatedBy === auth.userId) return true;
+  return false;
+}
+
+export function canDelete(info: PageAuthInfo, auth: AuthContext): boolean {
+  if (auth.userRole === 'admin') return true;
+  if (info.channelCreatedBy === auth.userId) return true;
+  return false;
+}
+
+export async function isChannelMember(channelId: number, userId: number): Promise<boolean> {
+  const row = await queryOne<{ user_id: number }>(
+    `SELECT user_id FROM channel_members WHERE channel_id = $1 AND user_id = $2`,
+    [channelId, userId],
+  );
+  return row !== null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,3 +24,4 @@ export * from './types/guestLink';
 export * from './types/rateLimit';
 export * from './types/calendar';
 export * from './types/thread';
+export * from './types/wikiPage';

--- a/packages/shared/src/types/wikiPage.ts
+++ b/packages/shared/src/types/wikiPage.ts
@@ -1,0 +1,49 @@
+import type { Tag } from './tag';
+
+export interface WikiPage {
+  id: number;
+  channelId: number;
+  title: string;
+  content: string;
+  createdBy: number | null;
+  createdByUsername?: string | null;
+  updatedBy: number | null;
+  updatedByUsername?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tags: Tag[];
+}
+
+export interface WikiPageSummary {
+  id: number;
+  channelId: number;
+  title: string;
+  createdBy: number | null;
+  createdByUsername?: string | null;
+  updatedBy: number | null;
+  updatedByUsername?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tags: Tag[];
+}
+
+export interface CreateWikiPageInput {
+  title: string;
+  content?: string;
+  tagIds?: number[];
+}
+
+export interface UpdateWikiPageInput {
+  title?: string;
+  content?: string;
+  tagIds?: number[];
+  expectedUpdatedAt: string;
+}
+
+export interface WikiPageListResponse {
+  pages: WikiPageSummary[];
+}
+
+export interface WikiPageResponse {
+  page: WikiPage;
+}


### PR DESCRIPTION
## 概要

会話から生まれた知見を、チャンネルの流れに埋もれない Wiki ページとして整理・蓄積できる機能を追加する。

## 変更内容

- **DB スキーマ**: `wiki_pages` / `wiki_page_tags` テーブルを追加
- **Shared 型**: `WikiPage` / `WikiPageSummary` / `CreateWikiPageInput` / `UpdateWikiPageInput`
- **サーバ**
  - `wikiPageService.ts` (作成・取得・一覧+検索・更新・削除・楽観ロック・権限判定)
  - `routes/wikiPages.ts` (`POST/GET /api/channels/:channelId/wiki-pages`, `GET/PATCH/DELETE /api/wiki-pages/:id`)
- **クライアント**
  - `ChannelWikiTab` (2ペインUI: 左一覧+検索+新規 / 右詳細・編集・新規フォーム)
  - `MarkdownRenderer` (react-markdown + remark-gfm)
  - `ChatPage` に Wiki タブ切替アイコンを追加
  - `MessageActions` 3点メニューに「Wikiページ化」を追加 (本文プリフィル経路)
  - `api/client.ts` に `wikiPages.*`
- **依存追加**: `react-markdown` ^10, `remark-gfm` ^4

### 受け入れ条件対応

- [x] Wiki ページを作成・編集・削除できる
- [x] ページにはタイトル、本文、作成者、更新者、作成日時、更新日時を保持する
- [x] Markdown 形式で本文を編集・表示できる (textarea + プレビュータブ)
- [x] Wiki ページ一覧を表示し、タイトルまたは本文で検索できる (ILIKE 部分一致)
- [x] チャットメッセージから Wiki ページ作成へ遷移でき、元メッセージへの参照を保持できる (引用形式でプリフィル + 元メッセージURL)
- [x] ページごとに関連チャンネル (= 所属チャンネル) を設定できる。タグはサーバ実装済 (UIは将来対応)
- [x] 削除前に確認ダイアログを表示する

### 主な設計判断

- **スコープ**: チャンネル所属型 (各ページは1チャンネルに属し、メンバーのみ閲覧)
- **権限**: 編集=作成者+チャンネル作成者+admin、削除=チャンネル作成者+admin
- **同時編集**: 楽観ロック (updated_at の照合で 409 検出)
- **削除**: ハードデリート
- **MVP外**: バージョン履歴 / Socket.IO リアルタイム / `[[ページ名]]` 構文 / タグ追加UI

## 影響範囲

- 新規ファイルが大半。既存ファイルの変更は以下:
  - `db/schema.hcl` (テーブル追加)
  - `packages/server/src/app.ts` (ルートマウント)
  - `packages/client/src/api/client.ts` (wikiPages 追加)
  - `packages/client/src/pages/ChatPage.tsx` (Wikiタブ切替)
  - `packages/client/src/components/Chat/MessageActions.tsx` (Wikiページ化メニュー)
  - `packages/server/src/__tests__/__fixtures__/pgTestHelper.ts` (テーブル定義)
  - `packages/shared/src/index.ts` (型 export)

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする (2525件)
- [x] バックエンドユニットテストがすべてパスする (1736件)
- [x] ビルドが正常に完了すること
- [ ] 手動確認 (ローカルでの操作確認は未実施)

## 関連Issue

Fixes #355

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（README や CLAUDE.md 等）の更新が必要な場合、それらも修正した (今回は追加変更なし)
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)