### PR TITLE
docs: リファクタ・開発基盤5候補のIssue化に伴い feature-ideas を更新

### DIFF
--- a/doc/feature-ideas.md
+++ b/doc/feature-ideas.md
@@ -98,11 +98,11 @@
 
 ## リファクタリング・開発基盤
 
-- [ ] **API レスポンス形式の統一** — 成功・失敗・バリデーションエラーの JSON 形式を統一し、フロントエンドのエラーハンドリングを簡潔にする｜難易度: 中
-- [ ] **権限判定ロジックの集約** — Admin / Moderator / Member / Guest の判定を共通ガードやサービスに集約し、機能追加時の権限漏れを防ぐ｜難易度: 中
-- [ ] **Socket イベント定義の型安全化** — サーバー・クライアント間の Socket.IO イベント名と payload 型を shared package で一元管理する｜難易度: 中
-- [ ] **検索・一覧 API のページング仕様統一** — `limit` `offset` `cursor` `total` などの扱いを揃え、一覧系 UI の実装差異を減らす｜難易度: 中
-- [ ] **テストフィクスチャの整理** — ユーザー、チャンネル、メッセージ、タスク、イベントの生成ヘルパーを標準化し、テスト実装の重複を減らす｜難易度: 低
+- [x] **API レスポンス形式の統一** — 成功・失敗・バリデーションエラーの JSON 形式を統一し、フロントエンドのエラーハンドリングを簡潔にする｜難易度: 中｜[#372](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/372)
+- [x] **権限判定ロジックの集約** — Admin / Moderator / Member / Guest の判定を共通ガードやサービスに集約し、機能追加時の権限漏れを防ぐ｜難易度: 中｜[#373](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/373)
+- [x] **Socket イベント定義の型安全化** — サーバー・クライアント間の Socket.IO イベント名と payload 型を shared package で一元管理する｜難易度: 中｜[#374](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/374)
+- [x] **検索・一覧 API のページング仕様統一** — `limit` `offset` `cursor` `total` などの扱いを揃え、一覧系 UI の実装差異を減らす｜難易度: 中｜[#375](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/375)
+- [x] **テストフィクスチャの整理** — ユーザー、チャンネル、メッセージ、タスク、イベントの生成ヘルパーを標準化し、テスト実装の重複を減らす｜難易度: 低｜[#376](https://github.com/mokemoke2850/chat-app-for-claudecode-test/issues/376)
 
 ## 運用・管理
 


### PR DESCRIPTION
## 概要
リファクタリング・開発基盤系の未着手5候補を Issue 化したため、`doc/feature-ideas.md` の該当行をチェック済みにし Issue リンクを付与する。

## 変更内容
以下5行を `[ ]` → `[x]` にし、Issue リンクを追加:
- API レスポンス形式の統一 → #372
- 権限判定ロジックの集約 → #373
- Socket イベント定義の型安全化 → #374
- 検索・一覧 API のページング仕様統一 → #375
- テストフィクスチャの整理 → #376

## 影響範囲
- `doc/feature-ideas.md` のみ（ドキュメント変更）。コード・テストへの影響なし。

## 動作確認・テスト結果
- [x] ドキュメントのみの変更のため、ビルド・テストへの影響なし

## 関連Issue
Refs #372, #373, #374, #375, #376

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（該当なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)