### PR TITLE
refactor: API エラーレスポンス形式を { error: { code, message, details? } } に統一 (#372)

### DIFF
--- a/packages/client/src/__tests__/client.test.ts
+++ b/packages/client/src/__tests__/client.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { api } from '../api/client';
+import { api, setRateLimitErrorHandler } from '../api/client';
 
 // fetch のレスポンスを組み立てるヘルパー
 function mockFetch(body: unknown, status = 200) {
@@ -60,6 +60,45 @@ describe('request (fetch ラッパー)', () => {
       vi.stubGlobal('fetch', mockFetch({}, 500));
 
       await expect(api.auth.me()).rejects.toThrow('Request failed');
+    });
+  });
+
+  // #372 統一エラー形式 { error: { code, message, details? } } への対応
+  describe('エラー系（#372 統一エラー形式）', () => {
+    it('error が { code, message } オブジェクトのとき message を持つ Error を throw する', async () => {
+      vi.stubGlobal(
+        'fetch',
+        mockFetch({ error: { code: 'NOT_FOUND', message: '見つかりません' } }, 404),
+      );
+
+      await expect(api.auth.me()).rejects.toThrow('見つかりません');
+    });
+
+    it('error.code を Error のプロパティとして保持する（フロントが code で分岐できる）', async () => {
+      vi.stubGlobal('fetch', mockFetch({ error: { code: 'FORBIDDEN', message: '権限なし' } }, 403));
+
+      await expect(api.auth.me()).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('旧来の文字列 error にもフォールバックして message に使う（後方互換・防御的）', async () => {
+      vi.stubGlobal('fetch', mockFetch({ error: 'legacy string error' }, 400));
+
+      await expect(api.auth.me()).rejects.toThrow('legacy string error');
+    });
+
+    it('新形式でもない・文字列でもないときは "Request failed" を使う', async () => {
+      vi.stubGlobal('fetch', mockFetch({ error: {} }, 500));
+
+      await expect(api.auth.me()).rejects.toThrow('Request failed');
+    });
+
+    it('429 のとき error.message と retryAfterSec でレート制限ハンドラを呼ぶ', async () => {
+      const handler = vi.fn();
+      setRateLimitErrorHandler(handler);
+      vi.stubGlobal('fetch', mockFetch({ error: 'レート制限です', retryAfterSec: 30 }, 429));
+
+      await expect(api.auth.me()).rejects.toThrow('レート制限です');
+      expect(handler).toHaveBeenCalledWith(expect.stringContaining('30秒後'));
     });
   });
 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -102,8 +102,16 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
 
   const body = (await res.json()) as unknown;
   if (!res.ok) {
-    const errorBody = body as { error?: string; retryAfterSec?: number };
-    const message = errorBody.error ?? 'Request failed';
+    // #372 統一エラー形式 { error: { code, message, details? } } に対応。
+    // レート制限(429)の RateLimitErrorBody は error が文字列のため、両形式をフォールバックで解釈する。
+    const errorBody = body as {
+      error?: string | { code?: string; message?: string; details?: unknown };
+      retryAfterSec?: number;
+    };
+    const rawError = errorBody.error;
+    const message =
+      typeof rawError === 'string' ? rawError : (rawError?.message ?? 'Request failed');
+    const code = typeof rawError === 'object' && rawError ? rawError.code : undefined;
 
     if (res.status === 429) {
       // レート制限エラー: グローバルハンドラを呼び出してスナックバー表示
@@ -115,7 +123,9 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
       rateLimitErrorHandler?.(snackbarMessage);
     }
 
-    throw new Error(message);
+    const error = new Error(message) as Error & { code?: string };
+    if (code) error.code = code;
+    throw error;
   }
   return body as T;
 }

--- a/packages/server/src/__tests__/direct-message.test.ts
+++ b/packages/server/src/__tests__/direct-message.test.ts
@@ -74,7 +74,8 @@ describe('DM API', () => {
         .send({ targetUserId: userAId });
 
       expect(res.status).toBe(400);
-      expect(res.body.error).toBe('Cannot create DM with yourself');
+      // #372 統一エラー形式: error は { code, message } オブジェクト
+      expect(res.body.error.message).toBe('Cannot create DM with yourself');
     });
 
     it('存在しないユーザーIDを指定するとエラーになる', async () => {

--- a/packages/server/src/__tests__/integration/errorResponseFormat.test.ts
+++ b/packages/server/src/__tests__/integration/errorResponseFormat.test.ts
@@ -1,0 +1,85 @@
+/**
+ * テスト対象: 全ルート共通のエラーレスポンス形式（#372 APIレスポンス形式の統一）
+ * 戦略: supertest で実エンドポイントを叩き、各種エラーが統一形式
+ *       { error: { code, message, details? } } で返ることを横断的に検証する統合テスト。
+ *       代表ルートとして saved-views（zod バリデーション・id 検証・404）と admin（403）を使う。
+ */
+
+import { createTestDatabase } from '../__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+
+jest.mock('../../db/database', () => testDb);
+
+import request from 'supertest';
+import { createApp } from '../../app';
+import { registerUser } from '../__fixtures__/testHelpers';
+
+const app = createApp();
+
+describe('エラーレスポンス形式の統一（#372）', () => {
+  describe('認証エラー', () => {
+    it('認証なしリクエストは { error: { code, message } } 形式の 401 を返す', async () => {
+      const res = await request(app).get('/api/saved-views');
+      expect(res.status).toBe(401);
+      expect(res.body.error).toMatchObject({ code: 'UNAUTHORIZED', message: expect.any(String) });
+    });
+
+    it('error は文字列ではなくオブジェクトである（旧 { error: string } を返さない）', async () => {
+      const res = await request(app).get('/api/saved-views');
+      expect(typeof res.body.error).toBe('object');
+    });
+  });
+
+  describe('バリデーションエラー（zod）', () => {
+    it('zod バリデーション失敗時は code "VALIDATION_ERROR" の 400 を返す', async () => {
+      const { token } = await registerUser(app, 'err_fmt_zod', 'err_fmt_zod@test.com');
+      const res = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', `token=${token}`)
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('error.details に zod の issues 配列を含む', async () => {
+      const { token } = await registerUser(app, 'err_fmt_zod2', 'err_fmt_zod2@test.com');
+      const res = await request(app)
+        .post('/api/saved-views')
+        .set('Cookie', `token=${token}`)
+        .send({});
+      expect(Array.isArray(res.body.error.details)).toBe(true);
+      expect(res.body.error.details.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('不正なパスパラメータ', () => {
+    it('id が数値でないときは 400 を返し error.code を持つ', async () => {
+      const { token } = await registerUser(app, 'err_fmt_nan', 'err_fmt_nan@test.com');
+      const res = await request(app).delete('/api/saved-views/abc').set('Cookie', `token=${token}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('BAD_REQUEST');
+    });
+  });
+
+  describe('リソース未検出', () => {
+    it('存在しないリソースへの操作は code "NOT_FOUND" の 404 を返す', async () => {
+      const { token } = await registerUser(app, 'err_fmt_404', 'err_fmt_404@test.com');
+      const res = await request(app)
+        .put('/api/saved-views/999999')
+        .set('Cookie', `token=${token}`)
+        .send({ name: 'x', query: {} });
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('権限エラー', () => {
+    it('管理者以外が管理 API を叩くと 403 を返し error はオブジェクト形式である', async () => {
+      const { token } = await registerUser(app, 'err_fmt_403', 'err_fmt_403@test.com');
+      const res = await request(app).get('/api/admin/users').set('Cookie', `token=${token}`);
+      expect(res.status).toBe(403);
+      expect(res.body.error).toMatchObject({ code: 'FORBIDDEN', message: expect.any(String) });
+    });
+  });
+});

--- a/packages/server/src/__tests__/middleware/guestAuth.test.ts
+++ b/packages/server/src/__tests__/middleware/guestAuth.test.ts
@@ -67,6 +67,14 @@ function makeReq(headers: Record<string, string> = {}, cookies: Record<string, s
   return { headers, cookies } as unknown as Request;
 }
 
+// #372: guestAuth は自前で res に書き込まず next(createError(...)) でエラーを委譲する。
+// next に渡された AppError の statusCode を検証する。
+function nextErrorStatus(next: NextFunction): number | undefined {
+  const calls = (next as unknown as jest.Mock).mock.calls;
+  const err = calls[0]?.[0] as { statusCode?: number } | undefined;
+  return err?.statusCode;
+}
+
 beforeEach(async () => {
   await resetTestData(testDb);
   await setupFixtures();
@@ -79,8 +87,9 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
-      expect(next).not.toHaveBeenCalled();
+      // #372: エラーは next(createError(...)) で委譲される
+      expect(next).toHaveBeenCalled();
+      expect(nextErrorStatus(next)).toBe(401);
     });
 
     it('Authorization ヘッダが Bearer 形式でない場合は 401 を返す', async () => {
@@ -88,7 +97,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
 
     it('有効な Bearer ゲストトークンは next() を呼ぶ', async () => {
@@ -107,7 +116,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
 
     it('既に有効期限切れの JWT は 401 になる', async () => {
@@ -118,7 +127,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
 
     it('payload に token が含まれない JWT は 401 になる', async () => {
@@ -127,7 +136,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
 
     it('payload に channelId が含まれない JWT は 401 になる', async () => {
@@ -136,7 +145,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
   });
 
@@ -147,7 +156,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
 
     it('payload の token が is_revoked = true の場合は 410 になる', async () => {
@@ -158,7 +167,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(410);
+      expect(nextErrorStatus(next)).toBe(410);
     });
 
     it('payload の token が expires_at < now の場合は 410 になる', async () => {
@@ -171,7 +180,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(410);
+      expect(nextErrorStatus(next)).toBe(410);
     });
 
     it('payload の channelId が DB の channel_id と一致しない場合は 403 になる', async () => {
@@ -180,7 +189,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(403);
+      expect(nextErrorStatus(next)).toBe(403);
     });
   });
 
@@ -204,7 +213,7 @@ describe('guestAuth ミドルウェア', () => {
       const res = makeRes();
       const next = jest.fn() as unknown as NextFunction;
       await guestAuth(req, res, next);
-      expect((res as unknown as { statusCode: number }).statusCode).toBe(401);
+      expect(nextErrorStatus(next)).toBe(401);
     });
   });
 });

--- a/packages/server/src/__tests__/unit/errorHandler.test.ts
+++ b/packages/server/src/__tests__/unit/errorHandler.test.ts
@@ -1,0 +1,137 @@
+/**
+ * テスト対象: middleware/errorHandler.ts（#372 APIレスポンス形式の統一）
+ * 戦略: errorHandler / createError / バリデーションエラーヘルパーを直接呼び出し、
+ *       統一エラー形式 { error: { code, message, details? } } を検証するユニットテスト。
+ *       Express の res は最小限のモックで代替する。
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import type { Request, Response, NextFunction } from 'express';
+import {
+  errorHandler,
+  createError,
+  createValidationError,
+  AppError,
+} from '../../middleware/errorHandler';
+
+// status().json() をチェーンできる最小限の Response モックを作る
+function mockRes() {
+  const status = jest.fn();
+  const json = jest.fn();
+  const res = { status, json } as Record<string, jest.Mock>;
+  status.mockReturnValue(res);
+  json.mockReturnValue(res);
+  return { res: res as unknown as Response, status, json };
+}
+
+const req = {} as Request;
+const next = (() => {}) as NextFunction;
+
+function run(err: AppError) {
+  const { res, status, json } = mockRes();
+  errorHandler(err, req, res, next);
+  return {
+    status: status.mock.calls[0]?.[0] as number,
+    body: json.mock.calls[0]?.[0] as {
+      error: { code: string; message: string; details?: unknown };
+    },
+  };
+}
+
+describe('errorHandler（統一エラー形式）', () => {
+  describe('レスポンス形式', () => {
+    it('AppError を { error: { code, message } } 形式の JSON で返す', () => {
+      const { body } = run(createError('見つかりません', 404));
+      expect(body).toEqual({ error: { code: 'NOT_FOUND', message: '見つかりません' } });
+    });
+
+    it('err.statusCode をそのまま HTTP ステータスコードに使う', () => {
+      const { status } = run(createError('権限がありません', 403));
+      expect(status).toBe(403);
+    });
+
+    it('statusCode 未指定のときは 500 を返す', () => {
+      const { status, body } = run(new Error('想定外') as AppError);
+      expect(status).toBe(500);
+      expect(body.error.code).toBe('INTERNAL');
+    });
+
+    it('message が空のときは既定メッセージ "Internal server error" を使う', () => {
+      const err = new Error('') as AppError;
+      const { body } = run(err);
+      expect(body.error.message).toBe('Internal server error');
+    });
+
+    it('err.details があるときは error.details に含める', () => {
+      const { body } = run(createError('無効', 400, { details: [{ path: ['name'] }] }));
+      expect(body.error.details).toEqual([{ path: ['name'] }]);
+    });
+
+    it('err.details がないときは error に details キーを含めない', () => {
+      const { body } = run(createError('無効', 400));
+      expect('details' in body.error).toBe(false);
+    });
+  });
+
+  describe('code の導出', () => {
+    it('err.code が指定されていればそれを使う', () => {
+      const { body } = run(createError('レート制限', 429, { code: 'RATE_LIMITED' }));
+      expect(body.error.code).toBe('RATE_LIMITED');
+    });
+
+    it('code 未指定時は statusCode からデフォルト code を導出する（400→BAD_REQUEST 等）', () => {
+      expect(run(createError('x', 400)).body.error.code).toBe('BAD_REQUEST');
+      expect(run(createError('x', 401)).body.error.code).toBe('UNAUTHORIZED');
+      expect(run(createError('x', 403)).body.error.code).toBe('FORBIDDEN');
+      expect(run(createError('x', 404)).body.error.code).toBe('NOT_FOUND');
+      expect(run(createError('x', 409)).body.error.code).toBe('CONFLICT');
+      expect(run(createError('x', 500)).body.error.code).toBe('INTERNAL');
+    });
+
+    it('未知の statusCode のときは code に "ERROR" を使う', () => {
+      const { body } = run(createError('x', 418));
+      expect(body.error.code).toBe('ERROR');
+    });
+  });
+});
+
+describe('createError', () => {
+  it('message と statusCode を受け取り statusCode を持つ AppError を生成する（既存シグネチャ後方互換）', () => {
+    const err = createError('boom', 404);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('boom');
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('options.code を指定すると AppError.code に設定される', () => {
+    const err = createError('boom', 400, { code: 'CUSTOM' });
+    expect(err.code).toBe('CUSTOM');
+  });
+
+  it('options.details を指定すると AppError.details に設定される', () => {
+    const err = createError('boom', 400, { details: { foo: 'bar' } });
+    expect(err.details).toEqual({ foo: 'bar' });
+  });
+});
+
+describe('createValidationError（zod バリデーション失敗ヘルパー）', () => {
+  it('statusCode 400・code "VALIDATION_ERROR" の AppError を生成する', () => {
+    const err = createValidationError([]);
+    expect(err.statusCode).toBe(400);
+    expect(err.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('zod の issues を details に保持する', () => {
+    const issues = [{ path: ['name'], message: 'Required' }];
+    const err = createValidationError(issues);
+    expect(err.details).toEqual(issues);
+  });
+
+  it('errorHandler を通すと details に issues を含む 400 レスポンスになる', () => {
+    const issues = [{ path: ['name'], message: 'Required' }];
+    const { status, body } = run(createValidationError(issues));
+    expect(status).toBe(400);
+    expect(body.error.code).toBe('VALIDATION_ERROR');
+    expect(body.error.details).toEqual(issues);
+  });
+});

--- a/packages/server/src/controllers/authController.ts
+++ b/packages/server/src/controllers/authController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import jwt from 'jsonwebtoken';
 import * as authService from '../services/authService';
 import * as auditLogService from '../services/auditLogService';
@@ -60,7 +61,7 @@ export async function register(req: Request, res: Response, next: NextFunction):
       password?: string;
     };
     if (!username || !email || !password) {
-      res.status(400).json({ error: 'username, email and password are required' });
+      next(createError('username, email and password are required', 400));
       return;
     }
     const user = await authService.register(username, email, password);
@@ -76,7 +77,7 @@ export async function login(req: Request, res: Response, next: NextFunction): Pr
   try {
     const { email, password } = req.body as { email?: string; password?: string };
     if (!email || !password) {
-      res.status(400).json({ error: 'email and password are required' });
+      next(createError('email and password are required', 400));
       return;
     }
     const user = await authService.login(email, password);
@@ -124,7 +125,7 @@ export async function getMe(req: Request, res: Response, next: NextFunction): Pr
   try {
     const user = await authService.getUserById((req as AuthenticatedRequest).userId);
     if (!user) {
-      res.status(404).json({ error: 'User not found' });
+      next(createError('User not found', 404));
       return;
     }
     res.json({ user });
@@ -169,7 +170,7 @@ export async function updateProfile(
       } else if (isAccentColor(ac)) {
         updateData.accentColor = ac as AccentColor;
       } else {
-        res.status(400).json({ error: 'accentColor はプリセット値である必要があります' });
+        next(createError('accentColor はプリセット値である必要があります', 400));
         return;
       }
     }
@@ -208,7 +209,7 @@ export async function updateProfile(
     if ('timezone' in body) {
       const v = body.timezone;
       if (v != null && v !== '' && !isValidIanaTimezone(v)) {
-        res.status(400).json({ error: 'timezone は IANA 形式で指定してください' });
+        next(createError('timezone は IANA 形式で指定してください', 400));
         return;
       }
       updateData.timezone = v == null || v === '' ? null : v;
@@ -216,7 +217,7 @@ export async function updateProfile(
     if ('githubUrl' in body) {
       const v = body.githubUrl;
       if (v != null && v !== '' && !isValidHttpUrl(v)) {
-        res.status(400).json({ error: 'githubUrl は http(s) の URL を指定してください' });
+        next(createError('githubUrl は http(s) の URL を指定してください', 400));
         return;
       }
       updateData.githubUrl = v == null || v === '' ? null : v;
@@ -224,7 +225,7 @@ export async function updateProfile(
     if ('snsUrl' in body) {
       const v = body.snsUrl;
       if (v != null && v !== '' && !isValidHttpUrl(v)) {
-        res.status(400).json({ error: 'snsUrl は http(s) の URL を指定してください' });
+        next(createError('snsUrl は http(s) の URL を指定してください', 400));
         return;
       }
       updateData.snsUrl = v == null || v === '' ? null : v;
@@ -251,15 +252,15 @@ export async function changePassword(
     };
 
     if (!currentPassword || !newPassword) {
-      res.status(400).json({ error: 'currentPassword and newPassword are required' });
+      next(createError('currentPassword and newPassword are required', 400));
       return;
     }
     if (newPassword.length < 8) {
-      res.status(400).json({ error: 'newPassword must be at least 8 characters' });
+      next(createError('newPassword must be at least 8 characters', 400));
       return;
     }
     if (newPassword !== confirmPassword) {
-      res.status(400).json({ error: 'newPassword and confirmPassword do not match' });
+      next(createError('newPassword and confirmPassword do not match', 400));
       return;
     }
 
@@ -280,7 +281,7 @@ export async function getUsers(req: Request, res: Response, next: NextFunction):
     if (channelId !== undefined) {
       const users = await authService.getUsersForChannel(Number(channelId));
       if (users === null) {
-        res.status(404).json({ error: 'Channel not found' });
+        next(createError('Channel not found', 404));
         return;
       }
       res.json({ users: attachPresenceState(users) });

--- a/packages/server/src/controllers/categoryController.ts
+++ b/packages/server/src/controllers/categoryController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { AuthenticatedRequest } from '../middleware/auth';
 import * as categoryService from '../services/categoryService';
 
@@ -26,7 +27,7 @@ export async function createCategory(
     const { name, position } = req.body as { name?: string; position?: number };
 
     if (!name || String(name).trim() === '') {
-      res.status(400).json({ error: 'name is required' });
+      next(createError('name is required', 400));
       return;
     }
 
@@ -35,11 +36,11 @@ export async function createCategory(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Category name already exists') {
-      res.status(409).json({ error: error.message });
+      next(createError(error.message, 409));
       return;
     }
     if (error.message === 'Category name is required') {
-      res.status(400).json({ error: error.message });
+      next(createError(error.message, 400));
       return;
     }
     next(err);
@@ -69,11 +70,11 @@ export async function updateCategory(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Category not found') {
-      res.status(404).json({ error: error.message });
+      next(createError(error.message, 404));
       return;
     }
     if (error.message === 'Forbidden') {
-      res.status(403).json({ error: error.message });
+      next(createError(error.message, 403));
       return;
     }
     next(err);
@@ -94,11 +95,11 @@ export async function deleteCategory(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Category not found') {
-      res.status(404).json({ error: error.message });
+      next(createError(error.message, 404));
       return;
     }
     if (error.message === 'Forbidden') {
-      res.status(403).json({ error: error.message });
+      next(createError(error.message, 403));
       return;
     }
     next(err);
@@ -115,7 +116,7 @@ export async function reorderCategories(
     const { categoryIds } = req.body as { categoryIds?: number[] };
 
     if (!Array.isArray(categoryIds)) {
-      res.status(400).json({ error: 'categoryIds is required' });
+      next(createError('categoryIds is required', 400));
       return;
     }
 
@@ -124,7 +125,7 @@ export async function reorderCategories(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message.startsWith('Invalid category_ids')) {
-      res.status(400).json({ error: error.message });
+      next(createError(error.message, 400));
       return;
     }
     next(err);
@@ -163,15 +164,15 @@ export async function assignChannelToCategory(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Channel not found') {
-      res.status(404).json({ error: error.message });
+      next(createError(error.message, 404));
       return;
     }
     if (error.message === 'Category not found') {
-      res.status(404).json({ error: error.message });
+      next(createError(error.message, 404));
       return;
     }
     if (error.message === 'Forbidden') {
-      res.status(403).json({ error: error.message });
+      next(createError(error.message, 403));
       return;
     }
     next(err);

--- a/packages/server/src/controllers/channelAttachmentsController.ts
+++ b/packages/server/src/controllers/channelAttachmentsController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import * as channelService from '../services/channelService';
 import * as attachmentsService from '../services/channelAttachmentsService';
 
@@ -8,13 +9,13 @@ export async function getChannelAttachments(req: Request, res: Response, next: N
   try {
     const channelId = Number(req.params.id);
     if (isNaN(channelId)) {
-      res.status(400).json({ error: 'Invalid channelId' });
+      next(createError('Invalid channelId', 400));
       return;
     }
 
     const channel = await channelService.getChannelById(channelId);
     if (!channel) {
-      res.status(404).json({ error: 'Channel not found' });
+      next(createError('Channel not found', 404));
       return;
     }
 

--- a/packages/server/src/controllers/channelController.ts
+++ b/packages/server/src/controllers/channelController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import * as channelService from '../services/channelService';
 import * as auditLogService from '../services/auditLogService';
 import { AuthenticatedRequest } from '../middleware/auth';
@@ -19,7 +20,7 @@ export async function getChannel(req: Request, res: Response, next: NextFunction
   try {
     const channel = await channelService.getChannelById(Number(req.params.id));
     if (!channel) {
-      res.status(404).json({ error: 'Channel not found' });
+      next(createError('Channel not found', 404));
       return;
     }
     res.json({ channel });
@@ -42,7 +43,7 @@ export async function createChannel(
       postingPermission?: ChannelPostingPermission;
     };
     if (!name) {
-      res.status(400).json({ error: 'name is required' });
+      next(createError('name is required', 400));
       return;
     }
     const userId = (req as AuthenticatedRequest).userId;
@@ -107,7 +108,7 @@ export async function addMember(req: Request, res: Response, next: NextFunction)
   try {
     const { userId: targetUserId } = req.body as { userId?: number };
     if (!targetUserId) {
-      res.status(400).json({ error: 'userId is required' });
+      next(createError('userId is required', 400));
       return;
     }
     await channelService.addChannelMember(
@@ -176,7 +177,7 @@ export async function markAsRead(req: Request, res: Response, next: NextFunction
     const userId = (req as AuthenticatedRequest).userId;
     const channel = await channelService.getChannelById(channelId);
     if (!channel) {
-      res.status(404).json({ error: 'Channel not found' });
+      next(createError('Channel not found', 404));
       return;
     }
     await channelService.markChannelAsRead(channelId, userId);
@@ -276,7 +277,7 @@ export async function updatePostingPermission(
     const channelId = Number(req.params.id);
     const { postingPermission } = req.body as { postingPermission?: ChannelPostingPermission };
     if (postingPermission === undefined) {
-      res.status(400).json({ error: 'postingPermission is required' });
+      next(createError('postingPermission is required', 400));
       return;
     }
 

--- a/packages/server/src/controllers/messageController.ts
+++ b/packages/server/src/controllers/messageController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import * as messageService from '../services/messageService';
 import * as channelService from '../services/channelService';
 import * as auditLogService from '../services/auditLogService';
@@ -62,7 +63,7 @@ export async function searchMessages(
 
     // q が空でフィルターも未指定なら 400
     if (q === '' && !hasAnyFilter) {
-      res.status(400).json({ error: 'q or at least one filter is required' });
+      next(createError('q or at least one filter is required', 400));
       return;
     }
 
@@ -94,7 +95,7 @@ export async function editMessage(req: Request, res: Response, next: NextFunctio
       mentionedUserIds?: number[];
     };
     if (!content) {
-      res.status(400).json({ error: 'content is required' });
+      next(createError('content is required', 400));
       return;
     }
     const message = await messageService.editMessage(
@@ -158,7 +159,7 @@ export async function forwardMessage(
     };
 
     if (!targetChannelId || isNaN(targetChannelId)) {
-      res.status(400).json({ error: 'targetChannelId is required' });
+      next(createError('targetChannelId is required', 400));
       return;
     }
 
@@ -188,18 +189,18 @@ export async function createMessage(
     };
 
     if (!content) {
-      res.status(400).json({ error: 'content is required' });
+      next(createError('content is required', 400));
       return;
     }
 
     const channel = await channelService.getChannelById(channelId);
     if (!channel) {
-      res.status(404).json({ error: 'Channel not found' });
+      next(createError('Channel not found', 404));
       return;
     }
 
     if (channel.isArchived) {
-      res.status(403).json({ error: 'Cannot send messages to an archived channel' });
+      next(createError('Cannot send messages to an archived channel', 403));
       return;
     }
 

--- a/packages/server/src/controllers/moderationReportController.ts
+++ b/packages/server/src/controllers/moderationReportController.ts
@@ -3,6 +3,7 @@
  */
 
 import { Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { AuthenticatedRequest } from '../middleware/auth';
 import * as moderationReportService from '../services/moderationReportService';
 import type { ReportMessageInput, ReportStatus } from '@chat-app/shared';
@@ -81,7 +82,7 @@ export async function actionReport(
       const updated = await moderationReportService.actionDeleteMessage(reportId, req.userId);
       res.json({ report: updated });
     } else {
-      res.status(400).json({ error: 'Invalid action type' });
+      next(createError('Invalid action type', 400));
     }
   } catch (err) {
     next(err);

--- a/packages/server/src/controllers/pinChannelController.ts
+++ b/packages/server/src/controllers/pinChannelController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { AuthenticatedRequest } from '../middleware/auth';
 import * as pinChannelService from '../services/pinChannelService';
 
@@ -29,11 +30,11 @@ export async function pinChannel(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Channel not found') {
-      res.status(404).json({ error: error.message });
+      next(createError(error.message, 404));
       return;
     }
     if (error.message === 'Channel is already pinned') {
-      res.status(409).json({ error: error.message });
+      next(createError(error.message, 409));
       return;
     }
     next(err);
@@ -53,7 +54,7 @@ export async function unpinChannel(
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Pin not found') {
-      res.status(404).json({ error: error.message });
+      next(createError(error.message, 404));
       return;
     }
     next(err);

--- a/packages/server/src/controllers/pushController.ts
+++ b/packages/server/src/controllers/pushController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import * as pushService from '../services/pushService';
 import { AuthenticatedRequest } from '../middleware/auth';
 
@@ -10,7 +11,7 @@ export async function subscribe(req: Request, res: Response, next: NextFunction)
   try {
     const sub = req.body as pushService.PushSubscriptionInput;
     if (!sub?.endpoint || !sub?.keys?.p256dh || !sub?.keys?.auth) {
-      res.status(400).json({ error: 'Invalid push subscription' });
+      next(createError('Invalid push subscription', 400));
       return;
     }
     await pushService.saveSubscription((req as AuthenticatedRequest).userId, sub);
@@ -21,7 +22,7 @@ export async function subscribe(req: Request, res: Response, next: NextFunction)
 export async function unsubscribe(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const { endpoint } = req.body as { endpoint?: string };
-    if (!endpoint) { res.status(400).json({ error: 'endpoint is required' }); return; }
+    if (!endpoint) { next(createError('endpoint is required', 400)); return; }
     await pushService.removeSubscription((req as AuthenticatedRequest).userId, endpoint);
     res.status(204).send();
   } catch (err) { next(err); }

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { queryOne } from '../db/database';
+import { createError } from './errorHandler';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-please-change-in-production';
 
@@ -9,11 +10,11 @@ export interface AuthenticatedRequest extends Request {
   username: string;
 }
 
-export function authenticateToken(req: Request, res: Response, next: NextFunction): void {
+export function authenticateToken(req: Request, _res: Response, next: NextFunction): void {
   const token = req.cookies?.token as string | undefined;
 
   if (!token) {
-    res.status(401).json({ error: 'Unauthorized' });
+    next(createError('Unauthorized', 401));
     return;
   }
 
@@ -23,7 +24,7 @@ export function authenticateToken(req: Request, res: Response, next: NextFunctio
     (req as AuthenticatedRequest).username = payload.username;
     next();
   } catch {
-    res.status(401).json({ error: 'Invalid token' });
+    next(createError('Invalid token', 401));
   }
 }
 
@@ -32,11 +33,15 @@ export function generateToken(userId: number, username: string): string {
 }
 
 /** authenticateToken の後に使う管理者専用ミドルウェア */
-export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+export async function requireAdmin(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): Promise<void> {
   const userId = (req as AuthenticatedRequest).userId;
   const row = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [userId]);
   if (row?.role !== 'admin') {
-    res.status(403).json({ error: 'Forbidden' });
+    next(createError('Forbidden', 403));
     return;
   }
   next();

--- a/packages/server/src/middleware/errorHandler.ts
+++ b/packages/server/src/middleware/errorHandler.ts
@@ -1,17 +1,73 @@
 import { Request, Response, NextFunction } from 'express';
+import type { ApiErrorResponse } from '@chat-app/shared';
 
 export interface AppError extends Error {
   statusCode?: number;
+  /** フロントが機械的に分岐するためのエラーコード（未指定時は statusCode から導出） */
+  code?: string;
+  /** zod issues などの補足情報（任意） */
+  details?: unknown;
 }
 
-export function errorHandler(err: AppError, _req: Request, res: Response, _next: NextFunction): void {
+/** HTTP ステータスコード → 既定エラーコードの対応表 */
+const STATUS_CODE_MAP: Record<number, string> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  409: 'CONFLICT',
+  429: 'RATE_LIMITED',
+  500: 'INTERNAL',
+};
+
+/** statusCode から既定の code を導出する */
+export function codeFromStatus(statusCode: number): string {
+  return STATUS_CODE_MAP[statusCode] ?? 'ERROR';
+}
+
+export function errorHandler(
+  err: AppError,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
   console.error(err.stack);
   const statusCode = err.statusCode ?? 500;
-  res.status(statusCode).json({ error: err.message || 'Internal server error' });
+  const code = err.code ?? codeFromStatus(statusCode);
+  const message = err.message || 'Internal server error';
+
+  const body: ApiErrorResponse = { error: { code, message } };
+  if (err.details !== undefined) {
+    body.error.details = err.details;
+  }
+
+  res.status(statusCode).json(body);
 }
 
-export function createError(message: string, statusCode: number): AppError {
+/**
+ * AppError を生成する。
+ * 既存シグネチャ createError(message, statusCode) は後方互換のため維持し、
+ * code / details は任意の第3引数で指定する。
+ */
+export function createError(
+  message: string,
+  statusCode: number,
+  options?: { code?: string; details?: unknown },
+): AppError {
   const err = new Error(message) as AppError;
   err.statusCode = statusCode;
+  if (options?.code !== undefined) err.code = options.code;
+  if (options?.details !== undefined) err.details = options.details;
   return err;
+}
+
+/**
+ * zod バリデーション失敗用の AppError を生成する。
+ * statusCode 400 / code 'VALIDATION_ERROR' で、details に issues を保持する。
+ */
+export function createValidationError(
+  details: unknown,
+  message = '無効なリクエストです',
+): AppError {
+  return createError(message, 400, { code: 'VALIDATION_ERROR', details });
 }

--- a/packages/server/src/middleware/guestAuth.ts
+++ b/packages/server/src/middleware/guestAuth.ts
@@ -7,6 +7,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import { createError } from './errorHandler';
 import jwt from 'jsonwebtoken';
 import { queryOne } from '../db/database';
 
@@ -37,13 +38,13 @@ interface GuestLinkRow {
 export async function guestAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
   const auth = req.headers.authorization;
   if (!auth || !auth.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'ゲストトークンが必要です' });
+    next(createError('ゲストトークンが必要です', 401));
     return;
   }
 
   const token = auth.substring('Bearer '.length).trim();
   if (!token) {
-    res.status(401).json({ error: 'ゲストトークンが必要です' });
+    next(createError('ゲストトークンが必要です', 401));
     return;
   }
 
@@ -51,12 +52,12 @@ export async function guestAuth(req: Request, res: Response, next: NextFunction)
   try {
     payload = jwt.verify(token, JWT_SECRET) as GuestPayload;
   } catch {
-    res.status(401).json({ error: 'ゲストトークンが無効です' });
+    next(createError('ゲストトークンが無効です', 401));
     return;
   }
 
   if (payload.type !== 'guest' || !payload.token || !payload.channelId) {
-    res.status(401).json({ error: 'ゲストトークンが無効です' });
+    next(createError('ゲストトークンが無効です', 401));
     return;
   }
 
@@ -66,19 +67,19 @@ export async function guestAuth(req: Request, res: Response, next: NextFunction)
     [payload.token],
   );
   if (!row) {
-    res.status(401).json({ error: 'ゲストリンクが見つかりません' });
+    next(createError('ゲストリンクが見つかりません', 401));
     return;
   }
   if (row.is_revoked) {
-    res.status(410).json({ error: 'ゲストリンクは無効化されています' });
+    next(createError('ゲストリンクは無効化されています', 410));
     return;
   }
   if (row.expires_at && new Date(row.expires_at) < new Date()) {
-    res.status(410).json({ error: 'ゲストリンクの有効期限が切れています' });
+    next(createError('ゲストリンクの有効期限が切れています', 410));
     return;
   }
   if (row.channel_id !== payload.channelId) {
-    res.status(403).json({ error: 'チャンネル ID が一致しません' });
+    next(createError('チャンネル ID が一致しません', 403));
     return;
   }
 

--- a/packages/server/src/routes/bookmarkTags.ts
+++ b/packages/server/src/routes/bookmarkTags.ts
@@ -1,23 +1,24 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as bookmarkService from '../services/bookmarkService';
 
 const router = Router();
 
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const tags = await bookmarkService.listTags(userId);
   return res.json({ tags });
 });
 
-router.post('/', authenticateToken, async (req, res) => {
+router.post('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const body = (req.body as { name?: unknown; color?: unknown } | undefined) ?? {};
   const name = typeof body.name === 'string' ? body.name : '';
   const color = typeof body.color === 'string' ? body.color : body.color === null ? null : null;
 
   if (name.trim() === '') {
-    return res.status(400).json({ error: 'Tag name is required' });
+    return next(createError('Tag name is required', 400));
   }
 
   try {
@@ -26,20 +27,20 @@ router.post('/', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Tag name already exists') {
-      return res.status(409).json({ error: error.message });
+      return next(createError(error.message, 409));
     }
     if (error.message === 'Tag name is required') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.patch('/:tagId', authenticateToken, async (req, res) => {
+router.patch('/:tagId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const tagId = parseInt(req.params.tagId, 10);
   if (isNaN(tagId)) {
-    return res.status(400).json({ error: 'Invalid tagId' });
+    return next(createError('Invalid tagId', 400));
   }
 
   const body = (req.body as { name?: unknown; color?: unknown } | undefined) ?? {};
@@ -55,26 +56,26 @@ router.patch('/:tagId', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Tag not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Forbidden') {
-      return res.status(403).json({ error: error.message });
+      return next(createError(error.message, 403));
     }
     if (error.message === 'Tag name already exists') {
-      return res.status(409).json({ error: error.message });
+      return next(createError(error.message, 409));
     }
     if (error.message === 'Tag name is required') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.delete('/:tagId', authenticateToken, async (req, res) => {
+router.delete('/:tagId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const tagId = parseInt(req.params.tagId, 10);
   if (isNaN(tagId)) {
-    return res.status(400).json({ error: 'Invalid tagId' });
+    return next(createError('Invalid tagId', 400));
   }
 
   try {
@@ -83,12 +84,12 @@ router.delete('/:tagId', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Tag not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Forbidden') {
-      return res.status(403).json({ error: error.message });
+      return next(createError(error.message, 403));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/server/src/routes/bookmarks.ts
+++ b/packages/server/src/routes/bookmarks.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as bookmarkService from '../services/bookmarkService';
 import type { BookmarkListFilters } from '@chat-app/shared';
@@ -16,7 +17,7 @@ function parseTagIds(raw: unknown): number[] {
     .filter((n) => Number.isInteger(n) && n > 0);
 }
 
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
 
   const filters: BookmarkListFilters = {};
@@ -38,12 +39,12 @@ router.get('/', authenticateToken, async (req, res) => {
   return res.json({ bookmarks });
 });
 
-router.post('/:messageId', authenticateToken, async (req, res) => {
+router.post('/:messageId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const messageId = parseInt(req.params.messageId, 10);
 
   if (isNaN(messageId)) {
-    return res.status(400).json({ error: 'Invalid messageId' });
+    return next(createError('Invalid messageId', 400));
   }
 
   // tagIds はオプション（後方互換）
@@ -61,27 +62,27 @@ router.post('/:messageId', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Message not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Message is already bookmarked') {
-      return res.status(409).json({ error: error.message });
+      return next(createError(error.message, 409));
     }
     if (error.message === 'Cannot bookmark a deleted message') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
     if (error.message === 'Invalid tag ids') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.delete('/:messageId', authenticateToken, async (req, res) => {
+router.delete('/:messageId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const messageId = parseInt(req.params.messageId, 10);
 
   if (isNaN(messageId)) {
-    return res.status(400).json({ error: 'Invalid messageId' });
+    return next(createError('Invalid messageId', 400));
   }
 
   try {
@@ -90,23 +91,23 @@ router.delete('/:messageId', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Message not found' || error.message === 'Bookmark not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // #304 ブックマークのタグ更新
-router.patch('/:messageId/tags', authenticateToken, async (req, res) => {
+router.patch('/:messageId/tags', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const messageId = parseInt(req.params.messageId, 10);
   if (isNaN(messageId)) {
-    return res.status(400).json({ error: 'Invalid messageId' });
+    return next(createError('Invalid messageId', 400));
   }
 
   const rawTagIds = (req.body as { tagIds?: unknown } | undefined)?.tagIds;
   if (!Array.isArray(rawTagIds)) {
-    return res.status(400).json({ error: 'tagIds must be an array' });
+    return next(createError('tagIds must be an array', 400));
   }
   const tagIds = rawTagIds
     .map((v) => (typeof v === 'number' ? v : parseInt(String(v), 10)))
@@ -118,12 +119,12 @@ router.patch('/:messageId/tags', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Bookmark not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Invalid tag ids') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/server/src/routes/calendar.ts
+++ b/packages/server/src/routes/calendar.ts
@@ -2,7 +2,8 @@
 // /api/calendar/events 系: イベント CRUD + RSVP（Phase B）
 // /api/calendar/polls  系: 日程調整 CRUD + 投票 + 確定（Phase C）
 
-import { Router, Response } from 'express';
+import { Router, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as calendarService from '../services/calendarService';
 import type {
@@ -15,10 +16,10 @@ const VALID_EDIT_SCOPES: readonly RecurrenceEditScope[] = ['one', 'following', '
 
 const router = Router();
 
-function handleError(err: unknown, res: Response): Response {
+function handleError(err: unknown, next: NextFunction): void {
   const e = err as { statusCode?: number; message?: string };
   const status = typeof e.statusCode === 'number' ? e.statusCode : 500;
-  return res.status(status).json({ error: e.message ?? 'Internal server error' });
+  next(createError(e.message ?? 'Internal server error', status));
 }
 
 function parseChannelIdsParam(raw: unknown): number[] | undefined {
@@ -41,7 +42,7 @@ function defaultMonthRange(): { from: string; to: string } {
 
 // ===== Events =====
 
-router.get('/events', authenticateToken, async (req, res) => {
+router.get('/events', authenticateToken, async (req, res, next) => {
   const fromQ = typeof req.query.from === 'string' ? req.query.from : undefined;
   const toQ = typeof req.query.to === 'string' ? req.query.to : undefined;
   const channelIds = parseChannelIdsParam(req.query.channelIds);
@@ -54,11 +55,11 @@ router.get('/events', authenticateToken, async (req, res) => {
     const events = await calendarService.listEventsInRange({ from, to, channelIds });
     return res.json({ events });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.post('/events', authenticateToken, async (req, res) => {
+router.post('/events', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const body = req.body as Partial<CreateCalendarEventInput>;
 
@@ -67,11 +68,11 @@ router.post('/events', authenticateToken, async (req, res) => {
     typeof body.startsAt !== 'string' ||
     typeof body.endsAt !== 'string'
   ) {
-    return res.status(400).json({ error: 'Invalid input' });
+    return next(createError('Invalid input', 400));
   }
   // channelId は number または null のみ受け付け（undefined は不許可）
   if (body.channelId !== null && typeof body.channelId !== 'number') {
-    return res.status(400).json({ error: 'Invalid channelId' });
+    return next(createError('Invalid channelId', 400));
   }
 
   try {
@@ -89,48 +90,48 @@ router.post('/events', authenticateToken, async (req, res) => {
     });
     return res.status(201).json({ event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.get('/events/:id', authenticateToken, async (req, res) => {
+router.get('/events/:id', authenticateToken, async (req, res, next) => {
   const eventId = parseInt(req.params.id, 10);
-  if (Number.isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(eventId)) return next(createError('Invalid id', 400));
   try {
     const event = await calendarService.getEventById(eventId);
-    if (!event) return res.status(404).json({ error: 'Event not found' });
+    if (!event) return next(createError('Event not found', 404));
     return res.json({ event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.patch('/events/:id', authenticateToken, async (req, res) => {
+router.patch('/events/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const eventId = parseInt(req.params.id, 10);
-  if (Number.isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(eventId)) return next(createError('Invalid id', 400));
 
   const body = req.body as UpdateCalendarEventInput;
   if (body.scope !== undefined && !VALID_EDIT_SCOPES.includes(body.scope)) {
-    return res.status(400).json({ error: 'Invalid scope' });
+    return next(createError('Invalid scope', 400));
   }
   try {
     const event = await calendarService.updateEvent(userId, eventId, body);
     return res.json({ event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.delete('/events/:id', authenticateToken, async (req, res) => {
+router.delete('/events/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const eventId = parseInt(req.params.id, 10);
-  if (Number.isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(eventId)) return next(createError('Invalid id', 400));
   const scopeRaw = req.query.scope;
   let scope: RecurrenceEditScope | undefined;
   if (typeof scopeRaw === 'string') {
     if (!VALID_EDIT_SCOPES.includes(scopeRaw as RecurrenceEditScope)) {
-      return res.status(400).json({ error: 'Invalid scope' });
+      return next(createError('Invalid scope', 400));
     }
     scope = scopeRaw as RecurrenceEditScope;
   }
@@ -138,47 +139,47 @@ router.delete('/events/:id', authenticateToken, async (req, res) => {
     await calendarService.deleteEvent(userId, eventId, { scope });
     return res.status(204).send();
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
 // ===== RSVP =====
 
-router.post('/events/:id/rsvp', authenticateToken, async (req, res) => {
+router.post('/events/:id/rsvp', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const eventId = parseInt(req.params.id, 10);
-  if (Number.isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(eventId)) return next(createError('Invalid id', 400));
 
   const status = (req.body as { status?: unknown }).status;
   if (typeof status !== 'string') {
-    return res.status(400).json({ error: 'Invalid status' });
+    return next(createError('Invalid status', 400));
   }
   try {
     const attendee = await calendarService.setRsvp(userId, eventId, status as never);
     return res.json({ attendee });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
 // ===== Polls =====
 
-router.get('/polls', authenticateToken, async (req, res) => {
+router.get('/polls', authenticateToken, async (req, res, next) => {
   const channelIdRaw = req.query.channelId;
   if (typeof channelIdRaw !== 'string') {
-    return res.status(400).json({ error: 'channelId is required' });
+    return next(createError('channelId is required', 400));
   }
   const channelId = parseInt(channelIdRaw, 10);
-  if (Number.isNaN(channelId)) return res.status(400).json({ error: 'Invalid channelId' });
+  if (Number.isNaN(channelId)) return next(createError('Invalid channelId', 400));
   try {
     const polls = await calendarService.listPollsByChannel(channelId);
     return res.json({ polls });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.post('/polls', authenticateToken, async (req, res) => {
+router.post('/polls', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const body = req.body as {
     channelId?: unknown;
@@ -188,15 +189,15 @@ router.post('/polls', authenticateToken, async (req, res) => {
   };
 
   if (typeof body.channelId !== 'number' || typeof body.title !== 'string') {
-    return res.status(400).json({ error: 'Invalid input' });
+    return next(createError('Invalid input', 400));
   }
   if (!Array.isArray(body.candidates)) {
-    return res.status(400).json({ error: 'candidates must be an array' });
+    return next(createError('candidates must be an array', 400));
   }
   const candidates = body.candidates as { startsAt?: unknown; endsAt?: unknown }[];
   for (const c of candidates) {
     if (typeof c.startsAt !== 'string' || typeof c.endsAt !== 'string') {
-      return res.status(400).json({ error: 'Invalid candidate' });
+      return next(createError('Invalid candidate', 400));
     }
   }
 
@@ -209,63 +210,63 @@ router.post('/polls', authenticateToken, async (req, res) => {
     });
     return res.status(201).json({ poll });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.get('/polls/:id', authenticateToken, async (req, res) => {
+router.get('/polls/:id', authenticateToken, async (req, res, next) => {
   const pollId = parseInt(req.params.id, 10);
-  if (Number.isNaN(pollId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(pollId)) return next(createError('Invalid id', 400));
   try {
     const poll = await calendarService.getPollWithVotes(pollId);
-    if (!poll) return res.status(404).json({ error: 'Poll not found' });
+    if (!poll) return next(createError('Poll not found', 404));
     return res.json({ poll });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.delete('/polls/:id', authenticateToken, async (req, res) => {
+router.delete('/polls/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const pollId = parseInt(req.params.id, 10);
-  if (Number.isNaN(pollId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(pollId)) return next(createError('Invalid id', 400));
   try {
     await calendarService.deletePoll(userId, pollId);
     return res.status(204).send();
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.post('/polls/:id/votes', authenticateToken, async (req, res) => {
+router.post('/polls/:id/votes', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const pollId = parseInt(req.params.id, 10);
-  if (Number.isNaN(pollId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(pollId)) return next(createError('Invalid id', 400));
   const body = req.body as { votes?: unknown };
   if (!Array.isArray(body.votes)) {
-    return res.status(400).json({ error: 'votes must be an array' });
+    return next(createError('votes must be an array', 400));
   }
   try {
     const poll = await calendarService.castVote(userId, pollId, body.votes as never);
     return res.json({ poll });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.post('/polls/:id/confirm', authenticateToken, async (req, res) => {
+router.post('/polls/:id/confirm', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const pollId = parseInt(req.params.id, 10);
-  if (Number.isNaN(pollId)) return res.status(400).json({ error: 'Invalid id' });
+  if (Number.isNaN(pollId)) return next(createError('Invalid id', 400));
   const candidateId = (req.body as { candidateId?: unknown }).candidateId;
   if (typeof candidateId !== 'number') {
-    return res.status(400).json({ error: 'candidateId is required' });
+    return next(createError('candidateId is required', 400));
   }
   try {
     const event = await calendarService.confirmPoll(userId, pollId, candidateId);
     return res.json({ event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 

--- a/packages/server/src/routes/dm.ts
+++ b/packages/server/src/routes/dm.ts
@@ -1,16 +1,17 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { createRateLimitMiddleware } from '../middleware/rateLimit';
 import * as dmService from '../services/dmService';
 
 const router = Router();
 
-router.post('/conversations', authenticateToken, async (req, res) => {
+router.post('/conversations', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { targetUserId } = req.body as { targetUserId?: number };
 
   if (!targetUserId || isNaN(Number(targetUserId))) {
-    return res.status(400).json({ error: 'targetUserId is required' });
+    return next(createError('targetUserId is required', 400));
   }
 
   try {
@@ -19,32 +20,32 @@ router.post('/conversations', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'User not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Cannot create DM with yourself') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.get('/conversations', authenticateToken, async (req, res) => {
+router.get('/conversations', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const conversations = await dmService.getConversations(userId);
   return res.json({ conversations });
 });
 
-router.get('/conversations/:conversationId/messages', authenticateToken, async (req, res) => {
+router.get('/conversations/:conversationId/messages', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const conversationId = parseInt(req.params.conversationId, 10);
 
   if (isNaN(conversationId)) {
-    return res.status(400).json({ error: 'Invalid conversationId' });
+    return next(createError('Invalid conversationId', 400));
   }
 
   const conv = await dmService.getConversationWithDetails(conversationId, userId);
   if (!conv) {
-    return res.status(404).json({ error: 'Conversation not found' });
+    return next(createError('Conversation not found', 404));
   }
 
   const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
@@ -56,9 +57,9 @@ router.get('/conversations/:conversationId/messages', authenticateToken, async (
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Conversation not found or access denied') {
-      return res.status(403).json({ error: error.message });
+      return next(createError(error.message, 403));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
@@ -66,21 +67,21 @@ router.post(
   '/conversations/:conversationId/messages',
   authenticateToken,
   createRateLimitMiddleware('dm'),
-  async (req, res) => {
+  async (req, res, next) => {
     const userId = (req as AuthenticatedRequest).userId;
     const conversationId = parseInt(req.params.conversationId, 10);
 
     if (isNaN(conversationId)) {
-      return res.status(400).json({ error: 'Invalid conversationId' });
+      return next(createError('Invalid conversationId', 400));
     }
 
     const { content } = req.body as { content?: string };
     if (!content || content.trim() === '') {
-      return res.status(400).json({ error: 'Content is required' });
+      return next(createError('Content is required', 400));
     }
 
     if (!(await dmService.checkAccess(conversationId, userId))) {
-      return res.status(403).json({ error: 'Access denied' });
+      return next(createError('Access denied', 403));
     }
 
     try {
@@ -89,22 +90,22 @@ router.post(
     } catch (err: unknown) {
       const error = err as Error;
       if (error.message === 'Conversation not found or access denied') {
-        return res.status(403).json({ error: error.message });
+        return next(createError(error.message, 403));
       }
       if (error.message === 'Content is required') {
-        return res.status(400).json({ error: error.message });
+        return next(createError(error.message, 400));
       }
-      return res.status(500).json({ error: 'Internal server error' });
+      return next(createError('Internal server error', 500));
     }
   },
 );
 
-router.put('/conversations/:conversationId/read', authenticateToken, async (req, res) => {
+router.put('/conversations/:conversationId/read', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const conversationId = parseInt(req.params.conversationId, 10);
 
   if (isNaN(conversationId)) {
-    return res.status(400).json({ error: 'Invalid conversationId' });
+    return next(createError('Invalid conversationId', 400));
   }
 
   try {
@@ -113,9 +114,9 @@ router.put('/conversations/:conversationId/read', authenticateToken, async (req,
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Conversation not found or access denied') {
-      return res.status(403).json({ error: error.message });
+      return next(createError(error.message, 403));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/server/src/routes/drafts.ts
+++ b/packages/server/src/routes/drafts.ts
@@ -1,28 +1,29 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as draftService from '../services/draftService';
 
 const router = Router();
 
 // GET /drafts — 自分の全下書きを取得
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const drafts = await draftService.getDraftsByUser(userId);
   return res.json({ drafts });
 });
 
 // PUT /drafts/channels/:channelId — チャンネル下書きを保存
-router.put('/channels/:channelId', authenticateToken, async (req, res) => {
+router.put('/channels/:channelId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const channelId = parseInt(req.params.channelId, 10);
 
   if (isNaN(channelId)) {
-    return res.status(400).json({ error: 'Invalid channelId' });
+    return next(createError('Invalid channelId', 400));
   }
 
   const { content } = req.body as { content?: string };
   if (content === undefined) {
-    return res.status(400).json({ error: 'content is required' });
+    return next(createError('content is required', 400));
   }
 
   const draft = await draftService.upsertChannelDraft(userId, channelId, content);
@@ -34,17 +35,17 @@ router.put('/channels/:channelId', authenticateToken, async (req, res) => {
 });
 
 // PUT /drafts/dm/:conversationId — DM下書きを保存
-router.put('/dm/:conversationId', authenticateToken, async (req, res) => {
+router.put('/dm/:conversationId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const conversationId = parseInt(req.params.conversationId, 10);
 
   if (isNaN(conversationId)) {
-    return res.status(400).json({ error: 'Invalid conversationId' });
+    return next(createError('Invalid conversationId', 400));
   }
 
   const { content } = req.body as { content?: string };
   if (content === undefined) {
-    return res.status(400).json({ error: 'content is required' });
+    return next(createError('content is required', 400));
   }
 
   const draft = await draftService.upsertDmDraft(userId, conversationId, content);
@@ -55,12 +56,12 @@ router.put('/dm/:conversationId', authenticateToken, async (req, res) => {
 });
 
 // DELETE /drafts/channels/:channelId — チャンネル下書きを明示削除
-router.delete('/channels/:channelId', authenticateToken, async (req, res) => {
+router.delete('/channels/:channelId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const channelId = parseInt(req.params.channelId, 10);
 
   if (isNaN(channelId)) {
-    return res.status(400).json({ error: 'Invalid channelId' });
+    return next(createError('Invalid channelId', 400));
   }
 
   await draftService.deleteChannelDraft(userId, channelId);
@@ -68,12 +69,12 @@ router.delete('/channels/:channelId', authenticateToken, async (req, res) => {
 });
 
 // DELETE /drafts/dm/:conversationId — DM下書きを明示削除
-router.delete('/dm/:conversationId', authenticateToken, async (req, res) => {
+router.delete('/dm/:conversationId', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const conversationId = parseInt(req.params.conversationId, 10);
 
   if (isNaN(conversationId)) {
-    return res.status(400).json({ error: 'Invalid conversationId' });
+    return next(createError('Invalid conversationId', 400));
   }
 
   await draftService.deleteDmDraft(userId, conversationId);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -5,7 +5,8 @@
 // POST /api/events/:id/rsvp        参加可否登録・更新
 // GET /api/events/:id/rsvps        参加者一覧
 
-import { Router, Response } from 'express';
+import { Router, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as eventService from '../services/eventService';
 import * as messageService from '../services/messageService';
@@ -14,13 +15,13 @@ import type { CreateEventInput, RsvpStatus, UpdateEventInput } from '@chat-app/s
 
 const router = Router();
 
-function handleError(err: unknown, res: Response): Response {
+function handleError(err: unknown, next: NextFunction): void {
   const e = err as { statusCode?: number; message?: string };
   const status = typeof e.statusCode === 'number' ? e.statusCode : 500;
-  return res.status(status).json({ error: e.message ?? 'Internal server error' });
+  next(createError(e.message ?? 'Internal server error', status));
 }
 
-router.post('/', authenticateToken, async (req, res) => {
+router.post('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const body = req.body as Partial<CreateEventInput>;
 
@@ -29,7 +30,7 @@ router.post('/', authenticateToken, async (req, res) => {
     typeof body.title !== 'string' ||
     typeof body.startsAt !== 'string'
   ) {
-    return res.status(400).json({ error: 'Invalid input' });
+    return next(createError('Invalid input', 400));
   }
 
   try {
@@ -52,44 +53,44 @@ router.post('/', authenticateToken, async (req, res) => {
 
     return res.status(201).json({ event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.patch('/:id', authenticateToken, async (req, res) => {
+router.patch('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const eventId = parseInt(req.params.id, 10);
-  if (isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (isNaN(eventId)) return next(createError('Invalid id', 400));
 
   const body = req.body as UpdateEventInput;
   try {
     const event = await eventService.update(userId, eventId, body);
     return res.json({ event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.delete('/:id', authenticateToken, async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const eventId = parseInt(req.params.id, 10);
-  if (isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (isNaN(eventId)) return next(createError('Invalid id', 400));
 
   try {
     await eventService.deleteEvent(userId, eventId);
     return res.status(204).send();
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.post('/:id/rsvp', authenticateToken, async (req, res) => {
+router.post('/:id/rsvp', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const eventId = parseInt(req.params.id, 10);
-  if (isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (isNaN(eventId)) return next(createError('Invalid id', 400));
 
   const status = (req.body as { status?: RsvpStatus }).status;
-  if (!status) return res.status(400).json({ error: 'status is required' });
+  if (!status) return next(createError('status is required', 400));
 
   try {
     const result = await eventService.setRsvp(userId, eventId, status);
@@ -111,19 +112,19 @@ router.post('/:id/rsvp', authenticateToken, async (req, res) => {
 
     return res.json({ event: result.event });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 
-router.get('/:id/rsvps', authenticateToken, async (req, res) => {
+router.get('/:id/rsvps', authenticateToken, async (req, res, next) => {
   const eventId = parseInt(req.params.id, 10);
-  if (isNaN(eventId)) return res.status(400).json({ error: 'Invalid id' });
+  if (isNaN(eventId)) return next(createError('Invalid id', 400));
 
   try {
     const users = await eventService.getRsvpUsers(eventId);
     return res.json({ users });
   } catch (err) {
-    return handleError(err, res);
+    return handleError(err, next);
   }
 });
 

--- a/packages/server/src/routes/guestLinks.ts
+++ b/packages/server/src/routes/guestLinks.ts
@@ -13,6 +13,7 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { guestAuth, GuestRequest } from '../middleware/guestAuth';
 import { queryOne } from '../db/database';
@@ -33,7 +34,7 @@ channelGuestLinksRouter.post(
           (req.params as { channelId?: string }).channelId,
       );
       if (!channelId || Number.isNaN(channelId)) {
-        res.status(400).json({ error: 'チャンネル ID が不正です' });
+        next(createError('チャンネル ID が不正です', 400));
         return;
       }
 
@@ -46,7 +47,7 @@ channelGuestLinksRouter.post(
         channelId,
       ]);
       if (!channel) {
-        res.status(404).json({ error: 'チャンネルが見つかりません' });
+        next(createError('チャンネルが見つかりません', 404));
         return;
       }
 
@@ -56,7 +57,7 @@ channelGuestLinksRouter.post(
           [channelId, userId],
         );
         if (!member) {
-          res.status(403).json({ error: 'ゲストリンクを発行する権限がありません' });
+          next(createError('ゲストリンクを発行する権限がありません', 403));
           return;
         }
       }
@@ -97,7 +98,7 @@ channelGuestLinksRouter.get(
           (req.params as { channelId?: string }).channelId,
       );
       if (!channelId || Number.isNaN(channelId)) {
-        res.status(400).json({ error: 'チャンネル ID が不正です' });
+        next(createError('チャンネル ID が不正です', 400));
         return;
       }
 
@@ -112,7 +113,7 @@ channelGuestLinksRouter.get(
           [channelId, userId],
         );
         if (!member) {
-          res.status(403).json({ error: 'ゲストリンク一覧を取得する権限がありません' });
+          next(createError('ゲストリンク一覧を取得する権限がありません', 403));
           return;
         }
       }
@@ -137,7 +138,7 @@ router.delete(
       const userId = (req as AuthenticatedRequest).userId;
       const linkId = Number(req.params.id);
       if (!linkId || Number.isNaN(linkId)) {
-        res.status(400).json({ error: 'ID が不正です' });
+        next(createError('ID が不正です', 400));
         return;
       }
 
@@ -169,7 +170,7 @@ router.get('/:token', async (req: Request, res: Response, next: NextFunction) =>
     const { token } = req.params;
     const result = await guestLinkService.lookup(token);
     if (!result) {
-      res.status(404).json({ error: 'ゲストリンクが見つかりません' });
+      next(createError('ゲストリンクが見つかりません', 404));
       return;
     }
     res.json({ guestLink: result });
@@ -200,7 +201,7 @@ router.get(
       const tokenParam = req.params.token;
       // パス上のトークンと JWT 内のトークンが一致することを再確認
       if (tokenParam !== guest.token) {
-        res.status(403).json({ error: 'トークンが一致しません' });
+        next(createError('トークンが一致しません', 403));
         return;
       }
       const messages = await guestLinkService.listGuestMessages(guest.channelId);

--- a/packages/server/src/routes/invites.ts
+++ b/packages/server/src/routes/invites.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { queryOne } from '../db/database';
 import * as inviteService from '../services/inviteService';
@@ -37,7 +38,7 @@ router.post('/', authenticateToken, async (req: Request, res: Response, next: Ne
         userId,
       ]);
       if (!member && !creator) {
-        res.status(403).json({ error: '招待リンクを作成する権限がありません' });
+        next(createError('招待リンクを作成する権限がありません', 403));
         return;
       }
     }
@@ -77,7 +78,7 @@ router.get('/', authenticateToken, async (req: Request, res: Response, next: Nex
       invites = await inviteService.listByChannel(channelId);
     } else {
       if (!isAdmin) {
-        res.status(403).json({ error: '管理者のみ全招待リンクを取得できます' });
+        next(createError('管理者のみ全招待リンクを取得できます', 403));
         return;
       }
       invites = await inviteService.listAll();
@@ -98,7 +99,7 @@ router.get('/:token', async (req: Request, res: Response, next: NextFunction) =>
     const { token } = req.params;
     const result = await inviteService.lookup(token);
     if (!result) {
-      res.status(404).json({ error: '招待リンクが見つかりません' });
+      next(createError('招待リンクが見つかりません', 404));
       return;
     }
     res.json({ invite: result });

--- a/packages/server/src/routes/messageTemplates.ts
+++ b/packages/server/src/routes/messageTemplates.ts
@@ -1,26 +1,27 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as templateService from '../services/messageTemplateService';
 
 const router = Router();
 
 // GET /api/templates — テンプレート一覧取得
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const templates = await templateService.listTemplates(userId);
   return res.json({ templates });
 });
 
 // POST /api/templates — テンプレート作成
-router.post('/', authenticateToken, async (req, res) => {
+router.post('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { title, body } = req.body as { title?: string; body?: string };
 
   if (!title || String(title).trim() === '') {
-    return res.status(400).json({ error: 'Title is required' });
+    return next(createError('Title is required', 400));
   }
   if (!body || String(body).trim() === '') {
-    return res.status(400).json({ error: 'Body is required' });
+    return next(createError('Body is required', 400));
   }
 
   try {
@@ -28,17 +29,17 @@ router.post('/', authenticateToken, async (req, res) => {
     return res.status(201).json({ template });
   } catch (err: unknown) {
     const error = err as Error;
-    return res.status(400).json({ error: error.message });
+    return next(createError(error.message, 400));
   }
 });
 
 // PATCH /api/templates/:id — テンプレート更新
-router.patch('/:id', authenticateToken, async (req, res) => {
+router.patch('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const templateId = parseInt(req.params.id, 10);
 
   if (isNaN(templateId)) {
-    return res.status(400).json({ error: 'Invalid template id' });
+    return next(createError('Invalid template id', 400));
   }
 
   const { title, body, position } = req.body as {
@@ -57,19 +58,19 @@ router.patch('/:id', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Template not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
-    return res.status(400).json({ error: error.message });
+    return next(createError(error.message, 400));
   }
 });
 
 // DELETE /api/templates/:id — テンプレート削除
-router.delete('/:id', authenticateToken, async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const templateId = parseInt(req.params.id, 10);
 
   if (isNaN(templateId)) {
-    return res.status(400).json({ error: 'Invalid template id' });
+    return next(createError('Invalid template id', 400));
   }
 
   try {
@@ -78,19 +79,19 @@ router.delete('/:id', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Template not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // PUT /api/templates/reorder — 並び替え
-router.put('/reorder', authenticateToken, async (req, res) => {
+router.put('/reorder', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { orderedIds } = req.body as { orderedIds?: unknown };
 
   if (!Array.isArray(orderedIds)) {
-    return res.status(400).json({ error: 'orderedIds must be an array' });
+    return next(createError('orderedIds must be an array', 400));
   }
 
   try {
@@ -98,7 +99,7 @@ router.put('/reorder', authenticateToken, async (req, res) => {
     return res.json({ success: true });
   } catch (err: unknown) {
     const error = err as Error;
-    return res.status(400).json({ error: error.message });
+    return next(createError(error.message, 400));
   }
 });
 

--- a/packages/server/src/routes/pins.ts
+++ b/packages/server/src/routes/pins.ts
@@ -1,25 +1,26 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as pinService from '../services/pinMessageService';
 
 const router = Router({ mergeParams: true });
 
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const channelId = parseInt(req.params.channelId, 10);
   if (isNaN(channelId)) {
-    return res.status(400).json({ error: 'Invalid channelId' });
+    return next(createError('Invalid channelId', 400));
   }
   const pinnedMessages = await pinService.getPinnedMessages(channelId);
   return res.json({ pinnedMessages });
 });
 
-router.post('/:messageId', authenticateToken, async (req, res) => {
+router.post('/:messageId', authenticateToken, async (req, res, next) => {
   const channelId = parseInt(req.params.channelId, 10);
   const messageId = parseInt(req.params.messageId, 10);
   const userId = (req as AuthenticatedRequest).userId;
 
   if (isNaN(channelId) || isNaN(messageId)) {
-    return res.status(400).json({ error: 'Invalid parameters' });
+    return next(createError('Invalid parameters', 400));
   }
 
   try {
@@ -28,24 +29,24 @@ router.post('/:messageId', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Message not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Message is already pinned in this channel') {
-      return res.status(409).json({ error: error.message });
+      return next(createError(error.message, 409));
     }
     if (error.message === 'Cannot pin a deleted message') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.delete('/:messageId', authenticateToken, async (req, res) => {
+router.delete('/:messageId', authenticateToken, async (req, res, next) => {
   const channelId = parseInt(req.params.channelId, 10);
   const messageId = parseInt(req.params.messageId, 10);
 
   if (isNaN(channelId) || isNaN(messageId)) {
-    return res.status(400).json({ error: 'Invalid parameters' });
+    return next(createError('Invalid parameters', 400));
   }
 
   try {
@@ -54,9 +55,9 @@ router.delete('/:messageId', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Message not found' || error.message === 'Pin not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/server/src/routes/reminders.ts
+++ b/packages/server/src/routes/reminders.ts
@@ -1,28 +1,29 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as reminderService from '../services/reminderService';
 
 const router = Router();
 
-router.post('/', authenticateToken, async (req, res) => {
+router.post('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { messageId, remindAt } = req.body as { messageId?: number; remindAt?: string };
 
   if (!messageId || typeof messageId !== 'number') {
-    return res.status(400).json({ error: 'messageId is required' });
+    return next(createError('messageId is required', 400));
   }
 
   if (!remindAt) {
-    return res.status(400).json({ error: 'remindAt is required' });
+    return next(createError('remindAt is required', 400));
   }
 
   const remindAtDate = new Date(remindAt);
   if (isNaN(remindAtDate.getTime())) {
-    return res.status(400).json({ error: 'remindAt is invalid date' });
+    return next(createError('remindAt is invalid date', 400));
   }
 
   if (remindAtDate <= new Date()) {
-    return res.status(400).json({ error: 'remindAt must be a future date' });
+    return next(createError('remindAt must be a future date', 400));
   }
 
   try {
@@ -31,28 +32,28 @@ router.post('/', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Message not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   try {
     const reminders = await reminderService.getReminders(userId);
     return res.json({ reminders });
   } catch {
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
-router.delete('/:id', authenticateToken, async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const reminderId = parseInt(req.params.id, 10);
 
   if (isNaN(reminderId)) {
-    return res.status(400).json({ error: 'Invalid id' });
+    return next(createError('Invalid id', 400));
   }
 
   try {
@@ -61,9 +62,9 @@ router.delete('/:id', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Reminder not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/server/src/routes/savedViews.ts
+++ b/packages/server/src/routes/savedViews.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { createError, createValidationError } from '../middleware/errorHandler';
 import { z } from 'zod';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as savedViewService from '../services/savedViewService';
@@ -33,18 +34,18 @@ const reorderBodySchema = z.object({
 });
 
 // GET /saved-views
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const savedViews = await savedViewService.getSavedViews(userId);
   return res.json({ savedViews });
 });
 
 // PUT /saved-views/order — 並べ替え（:id より前に定義して優先させる）
-router.put('/order', authenticateToken, async (req, res) => {
+router.put('/order', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const parsed = reorderBodySchema.safeParse(req.body);
   if (!parsed.success) {
-    return res.status(400).json({ error: '無効なリクエストです', details: parsed.error.issues });
+    return next(createValidationError(parsed.error.issues, '無効なリクエストです'));
   }
 
   try {
@@ -52,17 +53,17 @@ router.put('/order', authenticateToken, async (req, res) => {
     return res.json({ success: true });
   } catch (err) {
     const msg = err instanceof Error ? err.message : '並べ替えに失敗しました';
-    if (msg.includes('他ユーザー')) return res.status(403).json({ error: msg });
-    return res.status(400).json({ error: msg });
+    if (msg.includes('他ユーザー')) return next(createError(msg, 403));
+    return next(createError(msg, 400));
   }
 });
 
 // POST /saved-views
-router.post('/', authenticateToken, async (req, res) => {
+router.post('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const parsed = createBodySchema.safeParse(req.body);
   if (!parsed.success) {
-    return res.status(400).json({ error: '無効なリクエストです', details: parsed.error.issues });
+    return next(createValidationError(parsed.error.issues, '無効なリクエストです'));
   }
 
   try {
@@ -81,21 +82,21 @@ router.post('/', authenticateToken, async (req, res) => {
       msg.includes('一意制約') ||
       msg.toLowerCase().includes('already exists')
     ) {
-      return res.status(409).json({ error: '同じ名前の保存ビューが既に存在します' });
+      return next(createError('同じ名前の保存ビューが既に存在します', 409));
     }
-    return res.status(500).json({ error: msg });
+    return next(createError(msg, 500));
   }
 });
 
 // PUT /saved-views/:id
-router.put('/:id', authenticateToken, async (req, res) => {
+router.put('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const viewId = parseInt(req.params.id, 10);
-  if (isNaN(viewId)) return res.status(400).json({ error: '無効な id です' });
+  if (isNaN(viewId)) return next(createError('無効な id です', 400));
 
   const parsed = updateBodySchema.safeParse(req.body);
   if (!parsed.success) {
-    return res.status(400).json({ error: '無効なリクエストです', details: parsed.error.issues });
+    return next(createValidationError(parsed.error.issues, '無効なリクエストです'));
   }
 
   try {
@@ -103,34 +104,34 @@ router.put('/:id', authenticateToken, async (req, res) => {
     return res.json({ savedView });
   } catch (err) {
     const msg = err instanceof Error ? err.message : '更新に失敗しました';
-    if (msg.includes('見つかりません')) return res.status(404).json({ error: msg });
-    if (msg.includes('他ユーザー')) return res.status(403).json({ error: msg });
+    if (msg.includes('見つかりません')) return next(createError(msg, 404));
+    if (msg.includes('他ユーザー')) return next(createError(msg, 403));
     if (
       msg.includes('unique') ||
       msg.includes('duplicate') ||
       msg.includes('一意制約') ||
       msg.toLowerCase().includes('already exists')
     ) {
-      return res.status(409).json({ error: '同じ名前の保存ビューが既に存在します' });
+      return next(createError('同じ名前の保存ビューが既に存在します', 409));
     }
-    return res.status(500).json({ error: msg });
+    return next(createError(msg, 500));
   }
 });
 
 // DELETE /saved-views/:id
-router.delete('/:id', authenticateToken, async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const viewId = parseInt(req.params.id, 10);
-  if (isNaN(viewId)) return res.status(400).json({ error: '無効な id です' });
+  if (isNaN(viewId)) return next(createError('無効な id です', 400));
 
   try {
     await savedViewService.deleteSavedView(userId, viewId);
     return res.status(204).send();
   } catch (err) {
     const msg = err instanceof Error ? err.message : '削除に失敗しました';
-    if (msg.includes('見つかりません')) return res.status(404).json({ error: msg });
-    if (msg.includes('他ユーザー')) return res.status(403).json({ error: msg });
-    return res.status(500).json({ error: msg });
+    if (msg.includes('見つかりません')) return next(createError(msg, 404));
+    if (msg.includes('他ユーザー')) return next(createError(msg, 403));
+    return next(createError(msg, 500));
   }
 });
 

--- a/packages/server/src/routes/scheduledMessages.ts
+++ b/packages/server/src/routes/scheduledMessages.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { createRateLimitMiddleware } from '../middleware/rateLimit';
 import * as scheduledMessageService from '../services/scheduledMessageService';
@@ -6,7 +7,7 @@ import * as scheduledMessageService from '../services/scheduledMessageService';
 const router = Router();
 
 // POST /api/scheduled-messages — 予約作成
-router.post('/', authenticateToken, createRateLimitMiddleware('scheduled'), async (req, res) => {
+router.post('/', authenticateToken, createRateLimitMiddleware('scheduled'), async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { channelId, content, scheduledAt } = req.body as {
     channelId?: number;
@@ -15,21 +16,21 @@ router.post('/', authenticateToken, createRateLimitMiddleware('scheduled'), asyn
   };
 
   if (!channelId || typeof channelId !== 'number') {
-    return res.status(400).json({ error: 'channelId is required' });
+    return next(createError('channelId is required', 400));
   }
   if (!content || typeof content !== 'string' || content.trim() === '') {
-    return res.status(400).json({ error: 'content is required' });
+    return next(createError('content is required', 400));
   }
   if (!scheduledAt) {
-    return res.status(400).json({ error: 'scheduledAt is required' });
+    return next(createError('scheduledAt is required', 400));
   }
 
   const scheduledAtDate = new Date(scheduledAt);
   if (isNaN(scheduledAtDate.getTime())) {
-    return res.status(400).json({ error: 'scheduledAt is invalid date' });
+    return next(createError('scheduledAt is invalid date', 400));
   }
   if (scheduledAtDate <= new Date()) {
-    return res.status(400).json({ error: 'scheduledAt must be a future date' });
+    return next(createError('scheduledAt must be a future date', 400));
   }
 
   try {
@@ -41,27 +42,27 @@ router.post('/', authenticateToken, createRateLimitMiddleware('scheduled'), asyn
     return res.status(201).json({ scheduledMessage });
   } catch (err: unknown) {
     const error = err as Error & { statusCode?: number };
-    return res.status(error.statusCode ?? 500).json({ error: error.message });
+    return next(createError(error.message, error.statusCode ?? 500));
   }
 });
 
 // GET /api/scheduled-messages — 予約一覧取得
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   try {
     const scheduledMessages = await scheduledMessageService.listScheduledMessages(userId);
     return res.json({ scheduledMessages });
   } catch {
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // PATCH /api/scheduled-messages/:id — 予約更新
-router.patch('/:id', authenticateToken, async (req, res) => {
+router.patch('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) {
-    return res.status(400).json({ error: 'Invalid id' });
+    return next(createError('Invalid id', 400));
   }
 
   const { content, scheduledAt } = req.body as {
@@ -72,10 +73,10 @@ router.patch('/:id', authenticateToken, async (req, res) => {
   if (scheduledAt !== undefined) {
     const scheduledAtDate = new Date(scheduledAt);
     if (isNaN(scheduledAtDate.getTime())) {
-      return res.status(400).json({ error: 'scheduledAt is invalid date' });
+      return next(createError('scheduledAt is invalid date', 400));
     }
     if (scheduledAtDate <= new Date()) {
-      return res.status(400).json({ error: 'scheduledAt must be a future date' });
+      return next(createError('scheduledAt must be a future date', 400));
     }
   }
 
@@ -88,16 +89,16 @@ router.patch('/:id', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error & { statusCode?: number };
     const status = error.statusCode ?? 500;
-    return res.status(status).json({ error: error.message });
+    return next(createError(error.message, status));
   }
 });
 
 // DELETE /api/scheduled-messages/:id — 予約キャンセル
-router.delete('/:id', authenticateToken, async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) {
-    return res.status(400).json({ error: 'Invalid id' });
+    return next(createError('Invalid id', 400));
   }
 
   try {
@@ -106,7 +107,7 @@ router.delete('/:id', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error & { statusCode?: number };
     const status = error.statusCode ?? 500;
-    return res.status(status).json({ error: error.message });
+    return next(createError(error.message, status));
   }
 });
 

--- a/packages/server/src/routes/tags.ts
+++ b/packages/server/src/routes/tags.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as tagService from '../services/tagService';
 
@@ -30,7 +31,7 @@ router.post('/messages/:id/tags', authenticateToken, async (req, res, next) => {
     const userId = (req as AuthenticatedRequest).userId;
     const names: string[] = Array.isArray(req.body.names) ? req.body.names : [];
 
-    if (isNaN(messageId)) return res.status(400).json({ error: 'Invalid message ID' });
+    if (isNaN(messageId)) return next(createError('Invalid message ID', 400));
 
     const tags = await Promise.all(names.map((n) => tagService.findOrCreate(n, userId)));
     const tagIds = tags.map((t) => t.id);
@@ -51,7 +52,7 @@ router.delete('/messages/:id/tags/:tagId', authenticateToken, async (req, res, n
     const tagId = parseInt(req.params.tagId, 10);
 
     if (isNaN(messageId) || isNaN(tagId)) {
-      return res.status(400).json({ error: 'Invalid parameters' });
+      return next(createError('Invalid parameters', 400));
     }
 
     await tagService.detachFromMessage(messageId, [tagId]);
@@ -72,7 +73,7 @@ router.post('/channels/:id/tags', authenticateToken, async (req, res, next) => {
     const userId = (req as AuthenticatedRequest).userId;
     const names: string[] = Array.isArray(req.body.names) ? req.body.names : [];
 
-    if (isNaN(channelId)) return res.status(400).json({ error: 'Invalid channel ID' });
+    if (isNaN(channelId)) return next(createError('Invalid channel ID', 400));
 
     const tags = await Promise.all(names.map((n) => tagService.findOrCreate(n, userId)));
     const tagIds = tags.map((t) => t.id);
@@ -93,7 +94,7 @@ router.delete('/channels/:id/tags/:tagId', authenticateToken, async (req, res, n
     const tagId = parseInt(req.params.tagId, 10);
 
     if (isNaN(channelId) || isNaN(tagId)) {
-      return res.status(400).json({ error: 'Invalid parameters' });
+      return next(createError('Invalid parameters', 400));
     }
 
     await tagService.detachFromChannel(channelId, [tagId]);

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as taskService from '../services/taskService';
 
 const router = Router();
 
 // GET /tasks
-router.get('/', authenticateToken, async (req, res) => {
+router.get('/', authenticateToken, async (req, res, next) => {
   const { status, assignee, channel, includeHidden } = req.query;
 
   const filters: {
@@ -29,12 +30,12 @@ router.get('/', authenticateToken, async (req, res) => {
     const tasks = await taskService.getTasks(filters);
     return res.json({ tasks });
   } catch {
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // POST /tasks
-router.post('/', authenticateToken, async (req, res) => {
+router.post('/', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const { title, description, assigneeId, dueAt, sourceMessageId, sourceChannelId } = req.body as {
     title?: string;
@@ -46,7 +47,7 @@ router.post('/', authenticateToken, async (req, res) => {
   };
 
   if (!title || String(title).trim() === '') {
-    return res.status(400).json({ error: 'Title is required' });
+    return next(createError('Title is required', 400));
   }
 
   try {
@@ -62,25 +63,25 @@ router.post('/', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Assignee not found' || error.message === 'Source message not found') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // PUT /tasks/order — 並べ替え（PATCH /:id より先に定義する必要がある）
-router.put('/order', authenticateToken, async (req, res) => {
+router.put('/order', authenticateToken, async (req, res, next) => {
   const { items } = req.body as {
     items?: { id: number; status: string; position: number }[];
   };
 
   if (!Array.isArray(items)) {
-    return res.status(400).json({ error: 'items must be an array' });
+    return next(createError('items must be an array', 400));
   }
 
   for (const item of items) {
     if (typeof item.id !== 'number' || typeof item.position !== 'number' || !item.status) {
-      return res.status(400).json({ error: 'Invalid item format' });
+      return next(createError('Invalid item format', 400));
     }
   }
 
@@ -96,17 +97,17 @@ router.put('/order', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Invalid status') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // PATCH /tasks/:id
-router.patch('/:id', authenticateToken, async (req, res) => {
+router.patch('/:id', authenticateToken, async (req, res, next) => {
   const taskId = parseInt(req.params.id, 10);
   if (isNaN(taskId)) {
-    return res.status(400).json({ error: 'Invalid task ID' });
+    return next(createError('Invalid task ID', 400));
   }
 
   const { title, description, status, assigneeId, dueAt, isHidden } = req.body as {
@@ -131,34 +132,34 @@ router.patch('/:id', authenticateToken, async (req, res) => {
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Task not found') {
-      return res.status(404).json({ error: error.message });
+      return next(createError(error.message, 404));
     }
     if (error.message === 'Invalid status') {
-      return res.status(400).json({ error: error.message });
+      return next(createError(error.message, 400));
     }
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
 // DELETE /tasks/:id
-router.delete('/:id', authenticateToken, async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res, next) => {
   const taskId = parseInt(req.params.id, 10);
   if (isNaN(taskId)) {
-    return res.status(400).json({ error: 'Invalid task ID' });
+    return next(createError('Invalid task ID', 400));
   }
 
   // 存在チェック
   const tasks = await taskService.getTasks();
   const exists = tasks.some((t) => t.id === taskId);
   if (!exists) {
-    return res.status(404).json({ error: 'Task not found' });
+    return next(createError('Task not found', 404));
   }
 
   try {
     await taskService.deleteTask(taskId);
     return res.status(204).send();
   } catch {
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/server/src/routes/threads.ts
+++ b/packages/server/src/routes/threads.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import * as threadService from '../services/threadService';
 
@@ -8,13 +9,13 @@ const router = Router();
  * GET /api/threads/subscribed
  * 自分が返信したスレッドのサマリー一覧を返す (Inbox のスレッドタブで使用)。
  */
-router.get('/subscribed', authenticateToken, async (req, res) => {
+router.get('/subscribed', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   try {
     const threads = await threadService.listSubscribedThreads(userId);
     return res.json({ threads });
   } catch {
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 
@@ -22,17 +23,17 @@ router.get('/subscribed', authenticateToken, async (req, res) => {
  * PUT /api/threads/:rootMessageId/read
  * 指定スレッドを既読にする (thread_reads を UPSERT して last_read_at を現在時刻に更新)。
  */
-router.put('/:rootMessageId/read', authenticateToken, async (req, res) => {
+router.put('/:rootMessageId/read', authenticateToken, async (req, res, next) => {
   const userId = (req as AuthenticatedRequest).userId;
   const rootMessageId = Number(req.params.rootMessageId);
   if (isNaN(rootMessageId)) {
-    return res.status(400).json({ error: 'Invalid rootMessageId' });
+    return next(createError('Invalid rootMessageId', 400));
   }
   try {
     await threadService.markThreadAsRead(userId, rootMessageId);
     return res.status(204).send();
   } catch {
-    return res.status(500).json({ error: 'Internal server error' });
+    return next(createError('Internal server error', 500));
   }
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -25,3 +25,4 @@ export * from './types/rateLimit';
 export * from './types/calendar';
 export * from './types/thread';
 export * from './types/wikiPage';
+export * from './types/apiResponse';

--- a/packages/shared/src/types/apiResponse.ts
+++ b/packages/shared/src/types/apiResponse.ts
@@ -1,0 +1,29 @@
+/**
+ * API 共通レスポンス形式（#372 APIレスポンス形式の統一）
+ *
+ * エラーレスポンスは全ルートで以下の形式に統一する。
+ *   { error: { code, message, details? } }
+ *
+ * - code: フロントが機械的に分岐するためのエラーコード（HTTP ステータスから導出）
+ * - message: ユーザー向け/開発者向けのメッセージ
+ * - details: zod バリデーション issues など補足情報（任意）
+ */
+export interface ApiErrorResponse {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+/** よく使うエラーコード。HTTP ステータスコードから導出される既定値を含む。 */
+export type ApiErrorCode =
+  | 'BAD_REQUEST'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'VALIDATION_ERROR'
+  | 'RATE_LIMITED'
+  | 'INTERNAL'
+  | 'ERROR';


### PR DESCRIPTION
## 概要
サーバーの各ルートでバラついていたエラーレスポンスを、統一形式 `{ error: { code, message, details? } }` に集約する（#372）。フロントが `code` で機械的に分岐でき、zod バリデーションエラーも `details` 付きで一貫して返せるようにする。

スコープは「エラー形式の統一」に集中。成功レスポンス（リソース名キー）は現状維持。

## 変更内容
**基盤**
- `packages/shared/src/types/apiResponse.ts`（新規）: `ApiErrorResponse` / `ApiErrorCode` を定義
- `middleware/errorHandler.ts`: 新形式出力に拡張。`createError(message, statusCode, options?)`（既存シグネチャ後方互換）、`createValidationError(details, message?)`、`codeFromStatus()` を追加。statusCode→code を導出（400=BAD_REQUEST / 401=UNAUTHORIZED / 403=FORBIDDEN / 404=NOT_FOUND / 409=CONFLICT / 429=RATE_LIMITED / 500=INTERNAL）

**エラー経路の統一（直接 `res.status().json({error})` → `next(createError())`）**
- ミドルウェア: `auth.ts`, `guestAuth.ts`
- ルート 16 ファイル（reminders / savedViews / dm / calendar / events / tasks / bookmarks / pins / invites / guestLinks / bookmarkTags / drafts / messageTemplates / scheduledMessages / tags / threads）
- controller 8 ファイル（auth / channel / message / category / moderationReport / pinChannel / push / channelAttachments）※ auth/channels/messages/admin の主要ルートは controller 層でエラーを返すため対象に含めた
- zod バリデーション失敗を `createValidationError(issues)` に統一
- `calendar.ts` / `events.ts` の `handleError` ヘルパーを `next` 委譲へ変更

**フロント**
- `api/client.ts` の `request()`: `error` がオブジェクトなら `error.message` / `error.code` を読み、旧来の文字列にもフォールバック。`error.code` を Error に保持。レート制限 429 の `RateLimitErrorBody`（トップレベル `error: string` + `retryAfterSec`）互換を維持

## 影響範囲
- サーバー: 全エラーレスポンスの JSON 形状が `{ error: string }` → `{ error: { code, message, details? } }` に変更
- フロント: `request()` が両形式を解釈するため後方互換。エラー文字列を直接参照していた一部テストを更新
- `rateLimit.ts` の `RateLimitErrorBody` は既存の共有型契約のため**意図的に維持**（フロントの両形式フォールバックで吸収）

## 動作確認・テスト結果
- [x] フロントエンドユニットテスト: 変更分（client.test.ts 18件）パス。※ `MessageActions` の `useNavigate` 起因の既存失敗86件（main でも失敗）は本PR対象外（別Issue化）
- [x] バックエンドユニットテスト: `jest --runInBand` で全 1758 件パス。※ 公式 `npm run test`（`--maxWorkers=50%` 並列）は pg-mem 状態共有による既存フレークで稀に赤くなるが、直列・個別実行では全緑
- [x] ビルド正常完了（server tsc + client vite）
- 新規テスト: errorHandler.test.ts(15) / errorResponseFormat.test.ts(7) / client.test.ts 追記(5)

### 既存テストの変更
| ファイル | 変更 | 理由 |
|---|---|---|
| `direct-message.test.ts` | `res.body.error` → `.error.message` 検証 | 仕様変更（文字列→オブジェクト） |
| `middleware/guestAuth.test.ts` | `res.statusCode` 検証 → `next` の AppError statusCode 検証（11箇所） | 仕様変更（自前 res 書込→`next()` 委譲） |

## 関連Issue
Fixes #372

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した（一時 codemod スクリプトは削除済み）
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント更新は不要（仕様は型定義とテストで表現）
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)