### PR TITLE
test: MessageItem 系テストの Router コンテキスト不足を共通 render ヘルパーで解消 (#379)

### DIFF
--- a/packages/client/src/__tests__/ArchivedChannels.test.tsx
+++ b/packages/client/src/__tests__/ArchivedChannels.test.tsx
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, vi, expect, beforeEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import type { Channel } from '@chat-app/shared';
 import { makeChannel } from './__fixtures__/channels';

--- a/packages/client/src/__tests__/MessageDensity.test.tsx
+++ b/packages/client/src/__tests__/MessageDensity.test.tsx
@@ -2,7 +2,7 @@
 // 戦略: 密度モード（cozy/compact）の切替・永続化・CSS変数適用・UI を複数コンポーネントにまたがって検証する
 // 対象ソースファイルが DensityContext・MessageItem・MessageList・ProfilePage と複数にまたがるため独立ファイルとして作成
 
-import { act, render, screen, fireEvent } from '@testing-library/react';
+import { act, render, screen, fireEvent } from './test-utils';
 import { renderHook } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DensityProvider, useDensity } from '../contexts/DensityContext';

--- a/packages/client/src/__tests__/MessageItem.test.tsx
+++ b/packages/client/src/__tests__/MessageItem.test.tsx
@@ -9,7 +9,7 @@
  *   - userEvent でホバー・クリックをシミュレートする
  */
 
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { PresenceMap } from '../hooks/usePresence';

--- a/packages/client/src/__tests__/MessageItemAttachment.test.tsx
+++ b/packages/client/src/__tests__/MessageItemAttachment.test.tsx
@@ -8,7 +8,7 @@
  *   - Message 型に attachments を含む形でダミーデータを構築する
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen } from './test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Message, User } from '@chat-app/shared';
 import MessageItem from '../components/Chat/MessageItem';

--- a/packages/client/src/__tests__/MessageItemReaction.test.tsx
+++ b/packages/client/src/__tests__/MessageItemReaction.test.tsx
@@ -13,7 +13,7 @@
  *   - userEvent でホバー・クリックをシミュレートする
  */
 
-import { render, screen, act, waitFor } from '@testing-library/react';
+import { render, screen, act, waitFor } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { Reaction } from '@chat-app/shared';

--- a/packages/client/src/__tests__/MessageItemThread.test.tsx
+++ b/packages/client/src/__tests__/MessageItemThread.test.tsx
@@ -3,7 +3,7 @@
  * 戦略: Socket モックを注入し、replyCount バッジ表示と「返信」ボタンの振る舞いをテストする
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import MessageItem from '../components/Chat/MessageItem';

--- a/packages/client/src/__tests__/MessagePermalink.test.tsx
+++ b/packages/client/src/__tests__/MessagePermalink.test.tsx
@@ -7,7 +7,7 @@
  *   - URL 形式の変更（ハッシュ形式 → クエリ形式）を確認する
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import MessageActions from '../components/Chat/MessageActions';

--- a/packages/client/src/__tests__/QuoteReply.test.tsx
+++ b/packages/client/src/__tests__/QuoteReply.test.tsx
@@ -10,7 +10,7 @@
  *   - userEvent でホバー・クリックをシミュレートする
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { describe, it, vi, beforeEach, expect } from 'vitest';
 import MessageItem from '../components/Chat/MessageItem';

--- a/packages/client/src/__tests__/test-utils.tsx
+++ b/packages/client/src/__tests__/test-utils.tsx
@@ -1,0 +1,26 @@
+/**
+ * テスト共通レンダリングユーティリティ（#379）
+ *
+ * MessageActions など react-router の `useNavigate` をトップレベルで呼ぶコンポーネントは、
+ * Router コンテキスト無しでレンダリングすると例外になる。
+ * そのため `render` を `MemoryRouter` でラップしたカスタム版に差し替えて提供する。
+ *
+ * 使い方: `import { render, screen } from './test-utils';`
+ * （`@testing-library/react` の他のエクスポートはそのまま再エクスポートする）
+ */
+import { render as rtlRender, type RenderOptions } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+function RouterWrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+function render(ui: ReactElement, options?: Omit<RenderOptions, 'wrapper'>) {
+  return rtlRender(ui, { wrapper: RouterWrapper, ...options });
+}
+
+// @testing-library/react の screen / waitFor / fireEvent / act / renderHook 等を再エクスポート。
+// 下の明示的な render エクスポートが star エクスポートの render を上書きする。
+export * from '@testing-library/react';
+export { render };


### PR DESCRIPTION
## 概要
`MessageActions` がトップレベルで `useNavigate()`（react-router）を呼ぶため、Router でラップせず `MessageItem` / `MessageActions` を描画していた8テストファイル・計86件が `useNavigate() may be used only in the context of a <Router> component.` で失敗していた（#379）。共通 render ヘルパーで Router を供給して解消する。

## 変更内容
- `src/__tests__/test-utils.tsx`（新規）: `@testing-library/react` の `render` を `MemoryRouter` でラップしたカスタム版に差し替え、その他のエクスポートは再エクスポートする標準パターン
- 対象8ファイルの `render` import 元を `@testing-library/react` → `./test-utils` に変更（変更は import 1行/ファイル）
  - MessageItem / MessageItemThread / MessageItemAttachment / MessageItemReaction / QuoteReply / ArchivedChannels / MessagePermalink / MessageDensity

## 影響範囲
- テストのみ。プロダクションコードは無変更
- `MessageActions` の `useNavigate` 依存は描画時必須（フックはトップレベル呼び出し）のため、テスト側で Router を供給する方針を採用（Issue 案1）
- 既存38ファイルが個別に使う MemoryRouter は今回は変更せず、対象8ファイルの重複を本ヘルパーで吸収

## 動作確認・テスト結果
- [x] フロントエンドユニットテスト: **全2536件パス**（対象8ファイル134件を含む。従来86件失敗 → 0件）
- [x] バックエンドユニットテスト: サーバー無変更・全1758件パス（`--runInBand`）
- [x] ビルド正常完了

## 関連Issue
Fixes #379

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント更新は不要
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)