### PR TITLE
refactor: 権限判定ロジックを permissionService に集約 (#373)

### DIFF
--- a/packages/server/src/__tests__/unit/permissionService.test.ts
+++ b/packages/server/src/__tests__/unit/permissionService.test.ts
@@ -1,0 +1,124 @@
+/**
+ * テスト対象: services/permissionService.ts（#373 権限判定ロジックの集約）
+ * 戦略: pg-mem のインメモリ DB を使用し、サービス層を直接呼び出して権限判定を検証する。
+ *   - isAdmin / isChannelMember / assertOwnerOrAdmin の新規共通関数を対象とする
+ *   - canPost は移動元の channel-posting-permission.test.ts が網羅済みのため重複させない
+ *     （permissionService からも参照できることのみ確認する）
+ */
+
+import { createTestDatabase } from '../__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+jest.mock('../../db/database', () => testDb);
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import * as permissionService from '../../services/permissionService';
+import * as channelService from '../../services/channelService';
+import { AppError } from '../../middleware/errorHandler';
+
+async function createUser(username: string, role: 'user' | 'admin' = 'user'): Promise<number> {
+  const row = await testDb.queryOne<{ id: number }>(
+    'INSERT INTO users (username, email, password_hash, role) VALUES ($1, $2, $3, $4) RETURNING id',
+    [username, `${username}@example.com`, 'h', role],
+  );
+  return row!.id;
+}
+
+async function createChannel(name: string, createdBy: number): Promise<number> {
+  const row = await testDb.queryOne<{ id: number }>(
+    'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+    [name, createdBy],
+  );
+  return row!.id;
+}
+
+async function addMember(channelId: number, userId: number): Promise<void> {
+  await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+    channelId,
+    userId,
+  ]);
+}
+
+describe('permissionService.isAdmin', () => {
+  it('role = admin のユーザーに true を返す', async () => {
+    const id = await createUser('perm_admin', 'admin');
+    expect(await permissionService.isAdmin(id)).toBe(true);
+  });
+
+  it('role = user のユーザーに false を返す', async () => {
+    const id = await createUser('perm_user', 'user');
+    expect(await permissionService.isAdmin(id)).toBe(false);
+  });
+
+  it('存在しないユーザー ID に false を返す', async () => {
+    expect(await permissionService.isAdmin(999999)).toBe(false);
+  });
+});
+
+describe('permissionService.isChannelMember', () => {
+  let ownerId: number;
+  let channelId: number;
+
+  beforeEach(async () => {
+    ownerId = await createUser(`perm_owner_${Math.random().toString(36).slice(2)}`);
+    channelId = await createChannel(`perm-ch-${Math.random().toString(36).slice(2)}`, ownerId);
+  });
+
+  it('チャンネルメンバーに true を返す', async () => {
+    const memberId = await createUser(`perm_m_${Math.random().toString(36).slice(2)}`);
+    await addMember(channelId, memberId);
+    expect(await permissionService.isChannelMember(memberId, channelId)).toBe(true);
+  });
+
+  it('非メンバーに false を返す', async () => {
+    const outsiderId = await createUser(`perm_out_${Math.random().toString(36).slice(2)}`);
+    expect(await permissionService.isChannelMember(outsiderId, channelId)).toBe(false);
+  });
+
+  it('存在しないチャンネルに false を返す', async () => {
+    expect(await permissionService.isChannelMember(ownerId, 999999)).toBe(false);
+  });
+});
+
+describe('permissionService.assertOwnerOrAdmin', () => {
+  it('所有者本人なら例外を投げない', () => {
+    expect(() => permissionService.assertOwnerOrAdmin(10, 10, false)).not.toThrow();
+  });
+
+  it('管理者なら（所有者でなくても）例外を投げない', () => {
+    expect(() => permissionService.assertOwnerOrAdmin(10, 20, true)).not.toThrow();
+  });
+
+  it('非所有者かつ非管理者なら 403 の AppError を投げる', () => {
+    let caught: AppError | undefined;
+    try {
+      permissionService.assertOwnerOrAdmin(10, 20, false);
+    } catch (e) {
+      caught = e as AppError;
+    }
+    expect(caught?.statusCode).toBe(403);
+  });
+
+  it('指定したメッセージを 403 エラーの message に使う', () => {
+    expect(() => permissionService.assertOwnerOrAdmin(10, 20, false, '権限がありません')).toThrow(
+      '権限がありません',
+    );
+  });
+
+  it('ownerId が null かつ非管理者なら 403 を投げる', () => {
+    expect(() => permissionService.assertOwnerOrAdmin(null, 20, false)).toThrow();
+  });
+});
+
+describe('permissionService.canPost（channelService から移動・再エクスポート）', () => {
+  it('permissionService から canPost を呼び出せる（移動先で同等に動作する）', async () => {
+    const ownerId = await createUser(`cp_owner_${Math.random().toString(36).slice(2)}`);
+    const channelId = await createChannel(`cp-ch-${Math.random().toString(36).slice(2)}`, ownerId);
+    // パブリック・everyone はメンバーでなくても投稿可
+    expect(await permissionService.canPost(ownerId, channelId)).toBe(true);
+  });
+
+  it('channelService.canPost が permissionService.canPost と同一参照である（後方互換の再エクスポート）', () => {
+    expect(channelService.canPost).toBe(permissionService.canPost);
+  });
+});

--- a/packages/server/src/controllers/channelController.ts
+++ b/packages/server/src/controllers/channelController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { createError } from '../middleware/errorHandler';
 import * as channelService from '../services/channelService';
 import * as auditLogService from '../services/auditLogService';
+import * as permissionService from '../services/permissionService';
 import { AuthenticatedRequest } from '../middleware/auth';
 import { queryOne } from '../db/database';
 import type { ChannelPostingPermission } from '@chat-app/shared';
@@ -153,10 +154,7 @@ export async function updateTopic(req: Request, res: Response, next: NextFunctio
     };
     const userId = (req as AuthenticatedRequest).userId;
 
-    const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-      userId,
-    ]);
-    const isAdmin = userRow?.role === 'admin';
+    const isAdmin = await permissionService.isAdmin(userId);
 
     const channel = await channelService.updateChannelTopic(
       channelId,
@@ -208,10 +206,7 @@ export async function archiveChannel(
   try {
     const channelId = Number(req.params.id);
     const userId = (req as AuthenticatedRequest).userId;
-    const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-      userId,
-    ]);
-    const isAdmin = userRow?.role === 'admin';
+    const isAdmin = await permissionService.isAdmin(userId);
     const channel = await channelService.archiveChannel(channelId, userId, isAdmin);
     await auditLogService.record({
       actorUserId: userId,
@@ -236,10 +231,7 @@ export async function unarchiveChannel(
   try {
     const channelId = Number(req.params.id);
     const userId = (req as AuthenticatedRequest).userId;
-    const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-      userId,
-    ]);
-    const isAdmin = userRow?.role === 'admin';
+    const isAdmin = await permissionService.isAdmin(userId);
     const channel = await channelService.unarchiveChannel(channelId, userId, isAdmin);
     await auditLogService.record({
       actorUserId: userId,
@@ -282,10 +274,7 @@ export async function updatePostingPermission(
     }
 
     const userId = (req as AuthenticatedRequest).userId;
-    const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-      userId,
-    ]);
-    const isAdmin = userRow?.role === 'admin';
+    const isAdmin = await permissionService.isAdmin(userId);
 
     const channel = await channelService.updateChannelPostingPermission(
       channelId,

--- a/packages/server/src/middleware/auth.ts
+++ b/packages/server/src/middleware/auth.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
-import { queryOne } from '../db/database';
 import { createError } from './errorHandler';
+import { isAdmin } from '../services/permissionService';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-please-change-in-production';
 
@@ -39,8 +39,7 @@ export async function requireAdmin(
   next: NextFunction,
 ): Promise<void> {
   const userId = (req as AuthenticatedRequest).userId;
-  const row = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [userId]);
-  if (row?.role !== 'admin') {
+  if (!(await isAdmin(userId))) {
     next(createError('Forbidden', 403));
     return;
   }

--- a/packages/server/src/routes/guestLinks.ts
+++ b/packages/server/src/routes/guestLinks.ts
@@ -18,6 +18,7 @@ import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { guestAuth, GuestRequest } from '../middleware/guestAuth';
 import { queryOne } from '../db/database';
 import * as guestLinkService from '../services/guestLinkService';
+import * as permissionService from '../services/permissionService';
 import * as auditLogService from '../services/auditLogService';
 
 // 管理者・チャンネル別の発行/一覧用ルーター（/api/channels/:id/guest-links 配下）
@@ -38,10 +39,7 @@ channelGuestLinksRouter.post(
         return;
       }
 
-      const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-        userId,
-      ]);
-      const isAdmin = userRow?.role === 'admin';
+      const isAdmin = await permissionService.isAdmin(userId);
 
       const channel = await queryOne<{ id: number }>('SELECT id FROM channels WHERE id = $1', [
         channelId,
@@ -102,10 +100,7 @@ channelGuestLinksRouter.get(
         return;
       }
 
-      const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-        userId,
-      ]);
-      const isAdmin = userRow?.role === 'admin';
+      const isAdmin = await permissionService.isAdmin(userId);
 
       if (!isAdmin) {
         const member = await queryOne(
@@ -142,10 +137,7 @@ router.delete(
         return;
       }
 
-      const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-        userId,
-      ]);
-      const isAdmin = userRow?.role === 'admin';
+      const isAdmin = await permissionService.isAdmin(userId);
 
       const guestLink = await guestLinkService.revoke(userId, linkId, isAdmin);
 

--- a/packages/server/src/routes/invites.ts
+++ b/packages/server/src/routes/invites.ts
@@ -3,6 +3,7 @@ import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { queryOne } from '../db/database';
 import * as inviteService from '../services/inviteService';
+import * as permissionService from '../services/permissionService';
 import * as auditLogService from '../services/auditLogService';
 
 const router = Router();
@@ -22,10 +23,7 @@ router.post('/', authenticateToken, async (req: Request, res: Response, next: Ne
 
     // 権限チェック: channel_id が指定された場合はメンバーであることを確認
     // admin は常に許可
-    const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-      userId,
-    ]);
-    const isAdmin = userRow?.role === 'admin';
+    const isAdmin = await permissionService.isAdmin(userId);
 
     if (!isAdmin && channelId != null) {
       const member = await queryOne(
@@ -68,10 +66,7 @@ router.get('/', authenticateToken, async (req: Request, res: Response, next: Nex
     const userId = (req as AuthenticatedRequest).userId;
     const channelId = req.query.channelId ? Number(req.query.channelId) : undefined;
 
-    const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-      userId,
-    ]);
-    const isAdmin = userRow?.role === 'admin';
+    const isAdmin = await permissionService.isAdmin(userId);
 
     let invites;
     if (channelId !== undefined) {
@@ -149,10 +144,7 @@ router.delete(
       const userId = (req as AuthenticatedRequest).userId;
       const inviteId = Number(req.params.id);
 
-      const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-        userId,
-      ]);
-      const isAdmin = userRow?.role === 'admin';
+      const isAdmin = await permissionService.isAdmin(userId);
 
       const invite = await inviteService.revoke(userId, inviteId, isAdmin);
 

--- a/packages/server/src/routes/wikiPages.ts
+++ b/packages/server/src/routes/wikiPages.ts
@@ -3,12 +3,14 @@ import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { queryOne } from '../db/database';
 import { createError } from '../middleware/errorHandler';
 import * as wikiPageService from '../services/wikiPageService';
+import * as permissionService from '../services/permissionService';
 
 const router = Router();
 
+// #373 admin 判定は permissionService に集約。canEdit/canDelete が要求する userRole 形は維持する。
 async function loadAuthCtx(userId: number): Promise<{ userId: number; userRole: string }> {
-  const row = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [userId]);
-  return { userId, userRole: row?.role ?? 'user' };
+  const admin = await permissionService.isAdmin(userId);
+  return { userId, userRole: admin ? 'admin' : 'user' };
 }
 
 async function assertChannelAccess(channelId: number, userId: number): Promise<void> {
@@ -18,10 +20,8 @@ async function assertChannelAccess(channelId: number, userId: number): Promise<v
   if (!channel) {
     throw createError('チャンネルが見つかりません', 404);
   }
-  const auth = await loadAuthCtx(userId);
-  if (auth.userRole === 'admin') return;
-  const member = await wikiPageService.isChannelMember(channelId, userId);
-  if (!member) {
+  if (await permissionService.isAdmin(userId)) return;
+  if (!(await permissionService.isChannelMember(userId, channelId))) {
     throw createError('チャンネルメンバーではありません', 403);
   }
 }

--- a/packages/server/src/services/channelService.ts
+++ b/packages/server/src/services/channelService.ts
@@ -1,6 +1,7 @@
 import { query, queryOne, execute } from '../db/database';
 import { Channel, ChannelPostingPermission, User } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
+import { assertOwnerOrAdmin } from './permissionService';
 
 interface ChannelRow {
   id: number;
@@ -281,7 +282,7 @@ export async function updateChannelTopic(
 ): Promise<Channel> {
   const channel = await queryOne<ChannelRow>('SELECT * FROM channels WHERE id = $1', [channelId]);
   if (!channel) throw createError('Channel not found', 404);
-  if (!isAdmin && channel.created_by !== requesterId) throw createError('Forbidden', 403);
+  assertOwnerOrAdmin(channel.created_by, requesterId, isAdmin);
 
   const newTopic = topic !== undefined ? topic : channel.topic;
   const newDescription = description !== undefined ? description : channel.description;
@@ -315,7 +316,7 @@ export async function archiveChannel(
 ): Promise<Channel> {
   const channel = await queryOne<ChannelRow>('SELECT * FROM channels WHERE id = $1', [channelId]);
   if (!channel) throw createError('Channel not found', 404);
-  if (!isAdmin && channel.created_by !== requesterId) throw createError('Forbidden', 403);
+  assertOwnerOrAdmin(channel.created_by, requesterId, isAdmin);
   if (channel.is_archived) throw createError('Channel is already archived', 409);
 
   const updated = await queryOne<ChannelRow>(
@@ -332,7 +333,7 @@ export async function unarchiveChannel(
 ): Promise<Channel> {
   const channel = await queryOne<ChannelRow>('SELECT * FROM channels WHERE id = $1', [channelId]);
   if (!channel) throw createError('Channel not found', 404);
-  if (!isAdmin && channel.created_by !== requesterId) throw createError('Forbidden', 403);
+  assertOwnerOrAdmin(channel.created_by, requesterId, isAdmin);
   if (!channel.is_archived) throw createError('Channel is not archived', 409);
 
   const updated = await queryOne<ChannelRow>(
@@ -373,38 +374,8 @@ export async function setChannelRecommended(
 }
 
 // #113 投稿権限制御チャンネル
-export async function canPost(userId: number, channelId: number): Promise<boolean> {
-  const channel = await queryOne<{
-    id: number;
-    is_private: boolean;
-    posting_permission: ChannelPostingPermission;
-  }>('SELECT id, is_private, posting_permission FROM channels WHERE id = $1', [channelId]);
-  if (!channel) return false;
-
-  const permission = channel.posting_permission ?? 'everyone';
-
-  if (permission === 'readonly') return false;
-
-  const userRow = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [
-    userId,
-  ]);
-  const isAdmin = userRow?.role === 'admin';
-
-  if (permission === 'admins') {
-    return isAdmin;
-  }
-
-  // permission === 'everyone'
-  // プライベートチャンネルはメンバーシップが必要、パブリックは誰でも投稿可
-  if (channel.is_private) {
-    const member = await queryOne<{ user_id: number }>(
-      'SELECT user_id FROM channel_members WHERE channel_id = $1 AND user_id = $2',
-      [channelId, userId],
-    );
-    return member !== null;
-  }
-  return true;
-}
+// #373 実装は permissionService に移動。後方互換のため再エクスポートする。
+export { canPost } from './permissionService';
 
 export async function updateChannelPostingPermission(
   channelId: number,
@@ -419,9 +390,7 @@ export async function updateChannelPostingPermission(
   const channel = await queryOne<ChannelRow>('SELECT * FROM channels WHERE id = $1', [channelId]);
   if (!channel) throw createError('Channel not found', 404);
 
-  if (!isAdmin && channel.created_by !== requesterId) {
-    throw createError('Forbidden', 403);
-  }
+  assertOwnerOrAdmin(channel.created_by, requesterId, isAdmin);
 
   const updated = await queryOne<ChannelRow>(
     'UPDATE channels SET posting_permission = $1 WHERE id = $2 RETURNING *',

--- a/packages/server/src/services/eventService.ts
+++ b/packages/server/src/services/eventService.ts
@@ -4,7 +4,7 @@
 
 import { query, queryOne, execute } from '../db/database';
 import { createError } from '../middleware/errorHandler';
-import { canPost } from './channelService';
+import { canPost } from './permissionService';
 import * as calendarService from './calendarService';
 import type {
   ChatEvent,

--- a/packages/server/src/services/guestLinkService.ts
+++ b/packages/server/src/services/guestLinkService.ts
@@ -17,6 +17,7 @@ import type {
   GuestLinkVerifyResult,
 } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
+import { assertOwnerOrAdmin } from './permissionService';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-please-change-in-production';
 const GUEST_JWT_EXPIRES_IN = '2h'; // ゲストセッションは短期
@@ -108,9 +109,12 @@ export async function revoke(userId: number, linkId: number, isAdmin: boolean): 
     linkId,
   ]);
   if (!existing) throw createError('ゲストリンクが見つかりません', 404);
-  if (!isAdmin && existing.created_by !== userId) {
-    throw createError('このゲストリンクを失効する権限がありません', 403);
-  }
+  assertOwnerOrAdmin(
+    existing.created_by,
+    userId,
+    isAdmin,
+    'このゲストリンクを失効する権限がありません',
+  );
 
   const row = await queryOne<GuestLinkRow>(
     'UPDATE guest_links SET is_revoked = true WHERE id = $1 RETURNING *',

--- a/packages/server/src/services/inviteService.ts
+++ b/packages/server/src/services/inviteService.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { query, queryOne, execute } from '../db/database';
 import type { InviteLink, CreateInviteLinkInput, InviteLinkLookupResult } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
+import { assertOwnerOrAdmin } from './permissionService';
 
 interface InviteLinkRow {
   id: number;
@@ -76,9 +77,12 @@ export async function revoke(
     inviteId,
   ]);
   if (!existing) throw createError('招待リンクが見つかりません', 404);
-  if (!isAdmin && existing.created_by !== userId) {
-    throw createError('この招待リンクを無効化する権限がありません', 403);
-  }
+  assertOwnerOrAdmin(
+    existing.created_by,
+    userId,
+    isAdmin,
+    'この招待リンクを無効化する権限がありません',
+  );
 
   const row = await queryOne<InviteLinkRow>(
     'UPDATE invite_links SET is_revoked = true WHERE id = $1 RETURNING *',

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -10,7 +10,7 @@ import {
 } from '@chat-app/shared';
 import { createError } from '../middleware/errorHandler';
 import { getForMessages } from './tagService';
-import { canPost } from './channelService';
+import { canPost } from './permissionService';
 import { checkContent } from './moderationService';
 import { getByMessageIds as getEventsByMessageIds } from './eventService';
 import { deleteChannelDraft } from './draftService';

--- a/packages/server/src/services/permissionService.ts
+++ b/packages/server/src/services/permissionService.ts
@@ -1,0 +1,74 @@
+/**
+ * 権限判定の共通モジュール（#373 権限判定ロジックの集約）
+ *
+ * サービス・コントローラ・ルートに散在していた権限判定を一元化する。
+ * - 本アプリのロールは users.role = 'user' | 'admin' の2種
+ * - 権限軸: 管理者(admin) / チャンネルメンバー / リソース所有者(created_by)
+ * - チャンネル投稿権限(canPost)もここに集約する（旧 channelService から移動）
+ */
+import { queryOne } from '../db/database';
+import { createError } from '../middleware/errorHandler';
+import type { ChannelPostingPermission } from '@chat-app/shared';
+
+/** 管理者ロールの識別子 */
+export const ROLE_ADMIN = 'admin';
+
+/** ユーザーが管理者かどうかを判定する */
+export async function isAdmin(userId: number): Promise<boolean> {
+  const row = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = $1', [userId]);
+  return row?.role === ROLE_ADMIN;
+}
+
+/** ユーザーが指定チャンネルのメンバーかどうかを判定する */
+export async function isChannelMember(userId: number, channelId: number): Promise<boolean> {
+  const row = await queryOne<{ user_id: number }>(
+    'SELECT user_id FROM channel_members WHERE channel_id = $1 AND user_id = $2',
+    [channelId, userId],
+  );
+  return row !== null;
+}
+
+/**
+ * リソースの所有者本人、または管理者でなければ 403 を投げる。
+ * 「自分のリソースは編集可、ただし管理者は他人のものも可」という頻出パターンを集約する。
+ */
+export function assertOwnerOrAdmin(
+  ownerId: number | null,
+  userId: number,
+  admin: boolean,
+  message = 'Forbidden',
+): void {
+  if (!admin && ownerId !== userId) {
+    throw createError(message, 403);
+  }
+}
+
+/**
+ * チャンネルへの投稿可否を判定する（旧 channelService.canPost を移動）。
+ * - readonly: 常に false
+ * - admins:   管理者のみ true
+ * - everyone: プライベートはメンバーのみ true、パブリックは誰でも true
+ */
+export async function canPost(userId: number, channelId: number): Promise<boolean> {
+  const channel = await queryOne<{
+    id: number;
+    is_private: boolean;
+    posting_permission: ChannelPostingPermission;
+  }>('SELECT id, is_private, posting_permission FROM channels WHERE id = $1', [channelId]);
+  if (!channel) return false;
+
+  const permission = channel.posting_permission ?? 'everyone';
+
+  if (permission === 'readonly') return false;
+
+  if (permission === 'admins') {
+    return isAdmin(userId);
+  }
+
+  // permission === 'everyone'
+  // プライベートチャンネルはメンバーシップが必要、パブリックは誰でも投稿可
+  if (channel.is_private) {
+    return isChannelMember(userId, channelId);
+  }
+  return true;
+}

--- a/packages/server/src/services/wikiPageService.ts
+++ b/packages/server/src/services/wikiPageService.ts
@@ -293,11 +293,3 @@ export function canDelete(info: PageAuthInfo, auth: AuthContext): boolean {
   if (info.channelCreatedBy === auth.userId) return true;
   return false;
 }
-
-export async function isChannelMember(channelId: number, userId: number): Promise<boolean> {
-  const row = await queryOne<{ user_id: number }>(
-    `SELECT user_id FROM channel_members WHERE channel_id = $1 AND user_id = $2`,
-    [channelId, userId],
-  );
-  return row !== null;
-}


### PR DESCRIPTION
## 概要
サービス・コントローラ・ルートに散在していた権限判定（約40箇所）を `services/permissionService.ts` に一元化する（#373）。振る舞いは不変で、重複の削減と権限チェック漏れの防止を目的とする。

## 変更内容
**新規モジュール `services/permissionService.ts`**
| 関数 | 役割 |
|---|---|
| `isAdmin(userId)` | `SELECT role`+`==='admin'` の集約 |
| `isChannelMember(userId, channelId)` | チャンネルメンバー判定の集約 |
| `assertOwnerOrAdmin(ownerId, userId, isAdmin, message?)` | 「自分のリソース or 管理者」パターンの集約（非該当は 403） |
| `canPost(userId, channelId)` | channelService から**移動**（投稿権限判定） |
| `ROLE_ADMIN` | ロール識別子の定数化 |

**置換（振る舞い不変）**
- `SELECT role`+admin 判定 → `isAdmin()`: `middleware/auth.ts`(requireAdmin) / `channelController`(×4) / `routes`(invites×3, guestLinks×3, wikiPages)
- 所有者-or-admin（`!isAdmin && created_by !== userId`）→ `assertOwnerOrAdmin()`: `channelService`(×4) / `inviteService.revoke` / `guestLinkService.revoke`
- `canPost` を permissionService へ移動し、`channelService` は後方互換で再エクスポート。`messageService` / `eventService` は permissionService から import
- `wikiPageService` の重複 `isChannelMember` を削除し permissionService に統一

> 補足: 本アプリのロールは `users.role = 'user' | 'admin'` の2種のみ（Issue 記載の moderator は型に存在しない）。実権限軸の admin / チャンネルメンバー / リソース所有者(created_by) で集約した。wiki の `canEdit/canDelete`（既存テストが直接検証）は AuthContext 形を維持し回帰を避けた。

## 影響範囲
- 13ファイル変更（正味 -59行）。エラーメッセージ・ステータス・成功応答はすべて不変。

## 動作確認・テスト結果
- [x] バックエンド: `jest --runInBand` で全 **1771 件パス**（新規 `permissionService.test.ts` 13件含む）
- [x] ビルド成功（型チェック）
- [ ] フロントエンド: 変更なし

> 注: 並列実行（`--maxWorkers=50%`）では #381 の既存フレークが残るため検証は `--runInBand` で実施。本 PR は権限ロジックのみの変更で #381 とは独立。

## 関連Issue
Fixes #373

## チェックリスト
- [x] 自己レビュー済み（デバッグコードなし）
- [x] 命名規則に従っている
- [x] ドキュメント更新不要（仕様は型とテストで表現）
- [x] `it.todo` / 空ボディ `it` なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)