### PR TITLE
refactor: Socket イベント定義の型安全化（as any 除去） (#374)

### DIFF
--- a/packages/server/src/jobs/scheduledMessageWorker.ts
+++ b/packages/server/src/jobs/scheduledMessageWorker.ts
@@ -1,7 +1,6 @@
 import { pickDue, markSent, markFailed } from '../services/scheduledMessageService';
 import { createMessage } from '../services/messageService';
 import { getSocketServer } from '../socket';
-import type { Message } from '@chat-app/shared';
 
 const PICK_LIMIT = 50;
 const INTERVAL_MS = 30_000;
@@ -14,9 +13,8 @@ export async function runOnce(): Promise<void> {
   const due = await pickDue(PICK_LIMIT);
   if (due.length === 0) return;
 
-  // ServerToClientEvents の型定義が古い場合に備えてキャストする
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const io = getSocketServer() as any;
+  // getSocketServer() は型付き Server<...> を返すため、そのまま使う（#374 で as any を除去）
+  const io = getSocketServer();
 
   for (const sm of due) {
     try {
@@ -24,8 +22,7 @@ export async function runOnce(): Promise<void> {
       await markSent(sm.id, message.id);
 
       // チャンネル購読者へ通常メッセージとして配信
-       
-      io?.to(`channel:${sm.channelId}`).emit('message:new', message as Message);
+      io?.to(`channel:${sm.channelId}`).emit('message:new', message);
     } catch (err: unknown) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       await markFailed(sm.id, errorMessage).catch(() => {
@@ -33,7 +30,7 @@ export async function runOnce(): Promise<void> {
       });
 
       // 予約者へ失敗通知
-       
+
       io?.to(`user:${sm.userId}`).emit('scheduled_message:failed', {
         scheduledMessageId: sm.id,
         error: errorMessage,


### PR DESCRIPTION
## 概要
Socket.IO イベントの型安全性の抜け穴を塞ぐ（#374）。Socket イベント型は既に shared package で一元管理されており、本 PR は唯一残っていた `as any` キャストを除去して emit を型検査下に置く。

## 変更内容
- `jobs/scheduledMessageWorker.ts` の `getSocketServer() as any` を除去し、型付き `Server<...>` をそのまま使用
  - `getSocketServer()` は既に `Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>`（= `ChatServer`）を返す型付け
  - emit している `'message:new'` / `'scheduled_message:failed'` は `ServerToClientEvents` に定義済みのため `as any` 不要
  - `createMessage` は `Promise<Message>` を返すため `message as Message` キャストも除去
  - 未使用になった `Message` import を削除

## 調査結果（受け入れ条件の確認）
- [x] `getSocketServer()` が型付き Server を返す（`socket/index.ts` で既に定義済み・確認）
- [x] `scheduledMessageWorker.ts` の `as any` キャストを除去
- [x] サーバー/クライアントの emit・on がイベント型で検査される（`as any` 除去後も `npm run build` の型チェック通過 = emit のイベント名/ペイロードが型検査されている）
- [x] 既存テストがグリーン
- コードベース全体を確認し、socket 関連の `as any` は本箇所が唯一だった（他の `getSocketServer()` 利用箇所＝channelController/events/reminderService は既に型付き値を使用）

## 影響範囲
- `scheduledMessageWorker.ts` のみ（型のみの変更・実行時挙動は不変）

## 動作確認・テスト結果
- [x] バックエンド: `jest --runInBand` で全 **1771 件パス**（scheduledMessageWorker 7件含む）
- [x] ビルド成功（型チェック通過＝ socket emit の型安全性を担保）

> 注: 並列実行（`--maxWorkers=50%`）の既存フレークは #381 で継続調査中のため、検証は `--runInBand` で実施。

## 関連Issue
Fixes #374

## チェックリスト
- [x] 自己レビュー済み
- [x] 命名規則に従っている
- [x] ドキュメント更新不要
- [x] `it.todo` / 空ボディ `it` なし（型のみの変更のため新規テストなし。型安全性はコンパイラが検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)