### PR TITLE
refactor: 検索・一覧 API のページング仕様を統一 (#375)

### DIFF
--- a/doc/api-pagination-guide.md
+++ b/doc/api-pagination-guide.md
@@ -1,0 +1,73 @@
+# API ページング標準仕様ガイド（#375）
+
+一覧・検索系 API のページング方式を統一するための正本ドキュメント。
+新しい一覧/検索エンドポイントを追加する際は、本ガイドのいずれかの方式に準拠すること。
+
+## 方針
+
+返却キーはドメイン名（`messages` / `logs` / `events` など）ではなく、**汎用の `items`** に統一する。
+これによりフロントの一覧取得ロジック（`use()` + `<Suspense>` / 共通フック）を方式ごとに 1 本化できる。
+
+共通型は `packages/shared/src/types/pagination.ts` に定義する。
+
+| 用途 | 方式 | 型 | 形状 |
+|------|------|----|------|
+| 時系列・無限スクロール（チャンネル/DM のメッセージタイムライン） | カーソル系 | `CursorPaged<T>` | `{ items, nextCursor, hasMore }` |
+| ページャ・総件数表示が必要な一覧（管理画面の監査ログ、検索結果など） | オフセット系 | `OffsetPaged<T>` | `{ items, total, limit, offset }` |
+
+## オフセット系 `OffsetPaged<T>`
+
+```ts
+interface OffsetPaged<T> {
+  items: T[];
+  total: number; // フィルタ適用後の総件数（limit で切られても全件数）
+  limit: number; // 実効 limit（サーバ側でクランプ済み）
+  offset: number; // 先頭からのスキップ件数
+}
+```
+
+- クエリパラメータ: `limit`（既定値はエンドポイント定義・上限はサーバでクランプ） / `offset`（既定 0）。
+- `limit` / `offset` が数値以外・負数の場合は `400`（`{ error: { code, message } }`）を返す。
+- `total` は `limit` で切り詰められても**フィルタ適用後の全件数**を表す。
+
+### 適用済みエンドポイント
+- `GET /api/messages/search`
+- `GET /api/admin/audit-logs`
+
+### フロント
+- 共通フック `useOffsetPagination(fetchPage, filters, { limit })` を使う。
+  - `offset` 状態・`nextPage` / `prevPage` / `hasNext` / `hasPrev` / `total` を提供する。
+  - `filters` が変わると `offset` を 0 にリセットする。
+  - React 19 構成に合わせ、安定化済み `fetchPromise` を返す（`items` は `use(fetchPromise)` で読む）。
+- 適用例: `AuditLogView`（Suspense + ページャ）、`SearchPage`（ヒット件数表示に `total` を使用）。
+
+## カーソル系 `CursorPaged<T>`
+
+```ts
+interface CursorPaged<T> {
+  items: T[]; // 時系列昇順
+  nextCursor: string | null; // 次に遡る際に渡す不透明なカーソル。続きが無ければ null
+  hasMore: boolean;
+}
+```
+
+- クエリパラメータ: `limit` / `before`（= 前ページで受け取った `nextCursor`）。
+- サーバは `limit + 1` 件取得して `hasMore` を判定し、超過分を切り落とす。
+- `nextCursor` は現在表示中の最古メッセージ ID（文字列）。クライアントは値を解釈せず `before` にそのまま渡す。
+
+### 適用済みエンドポイント
+- `GET /api/channels/:channelId/messages`
+
+### フロント
+- `useMessages` が `items` を取り込み、`nextCursor` / `hasMore` を保持して `loadMore()` で前方（より古いメッセージ）を読み込む。
+
+## 段階移行（追従 Issue）
+
+#375 では代表的な 3 エンドポイント（メッセージ検索 / 監査ログ / チャンネルメッセージ）と共通フックを整備した。
+以下は本仕様への追従が未対応のため、別 Issue で段階移行する。
+
+- DM メッセージ（`GET /api/dm/conversations/:id/messages`、カーソル系候補）
+- ゲストリンクメッセージ
+- スレッド返信一覧
+- tags サジェスト（`limit` のみ）
+- その他 `{ pages }` / `{ events }` 等のドメイン名一覧

--- a/packages/client/src/__tests__/AuditLogView.test.tsx
+++ b/packages/client/src/__tests__/AuditLogView.test.tsx
@@ -146,7 +146,12 @@ beforeEach(() => {
   mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
   mockedApi.admin.getUsers.mockResolvedValue({ users: mockAdminUsers });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: mockAdminChannels });
-  mockedApi.admin.getAuditLogs.mockResolvedValue({ logs: mockAuditLogs, total: 2 });
+  mockedApi.admin.getAuditLogs.mockResolvedValue({
+    items: mockAuditLogs,
+    total: 2,
+    limit: 50,
+    offset: 0,
+  });
 });
 
 async function renderAdminPage(): Promise<void> {
@@ -223,7 +228,7 @@ describe('AuditLogView', () => {
     });
 
     it('ログが 0 件の場合は「監査ログがありません」と表示される', async () => {
-      mockedApi.admin.getAuditLogs.mockResolvedValue({ logs: [], total: 0 });
+      mockedApi.admin.getAuditLogs.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
       await renderAuditLogView();
       await waitFor(() => expect(screen.getByText('監査ログがありません')).toBeInTheDocument());
     });
@@ -319,7 +324,12 @@ describe('AuditLogView', () => {
 
   describe('ページネーション', () => {
     it('total > limit のとき「次へ」ボタンが活性になる', async () => {
-      mockedApi.admin.getAuditLogs.mockResolvedValue({ logs: mockAuditLogs, total: 100 });
+      mockedApi.admin.getAuditLogs.mockResolvedValue({
+        items: mockAuditLogs,
+        total: 100,
+        limit: 50,
+        offset: 0,
+      });
       await renderAuditLogView();
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
       expect(screen.getByRole('button', { name: '次へ' })).not.toBeDisabled();
@@ -332,7 +342,12 @@ describe('AuditLogView', () => {
     });
 
     it('「次へ」をクリックすると offset が +limit されて再フェッチされる', async () => {
-      mockedApi.admin.getAuditLogs.mockResolvedValue({ logs: mockAuditLogs, total: 200 });
+      mockedApi.admin.getAuditLogs.mockResolvedValue({
+        items: mockAuditLogs,
+        total: 200,
+        limit: 50,
+        offset: 0,
+      });
       await renderAuditLogView();
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
       await userEvent.click(screen.getByRole('button', { name: '次へ' }));
@@ -345,7 +360,12 @@ describe('AuditLogView', () => {
     });
 
     it('最終ページでは「次へ」ボタンが非活性になる', async () => {
-      mockedApi.admin.getAuditLogs.mockResolvedValue({ logs: mockAuditLogs, total: 2 });
+      mockedApi.admin.getAuditLogs.mockResolvedValue({
+        items: mockAuditLogs,
+        total: 2,
+        limit: 50,
+        offset: 0,
+      });
       await renderAuditLogView();
       await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
       expect(screen.getByRole('button', { name: '次へ' })).toBeDisabled();
@@ -449,6 +469,54 @@ describe('AuditLogView エクスポートボタン', () => {
       expect(params.from).toBeUndefined();
       expect(params.to).toBeUndefined();
       openSpy.mockRestore();
+    });
+  });
+
+  // #375 ページング統一: getAuditLogs が OffsetPaged（items/total/limit/offset）を返す
+  describe('ページング統一（#375）', () => {
+    it('監査ログ一覧を OffsetPaged.items から描画する（旧 logs から変更）', async () => {
+      mockedApi.admin.getAuditLogs.mockResolvedValue({
+        items: mockAuditLogs,
+        total: 2,
+        limit: 50,
+        offset: 0,
+      });
+      await renderAuditLogView();
+      // items の各ログが表示される
+      await waitFor(() => expect(screen.getByText('チャンネル作成')).toBeInTheDocument());
+      expect(screen.getByText('（削除済みユーザー）')).toBeInTheDocument();
+    });
+
+    it('total に基づく総件数・ページ位置が表示される', async () => {
+      mockedApi.admin.getAuditLogs.mockResolvedValue({
+        items: mockAuditLogs,
+        total: 120,
+        limit: 50,
+        offset: 0,
+      });
+      await renderAuditLogView();
+      await waitFor(() => expect(screen.getByTestId('audit-log-page-info')).toBeInTheDocument());
+      expect(screen.getByTestId('audit-log-page-info').textContent).toContain('120');
+    });
+
+    it('次ページ操作で offset が limit 単位で進み再取得される', async () => {
+      mockedApi.admin.getAuditLogs.mockResolvedValue({
+        items: mockAuditLogs,
+        total: 200,
+        limit: 50,
+        offset: 0,
+      });
+      await renderAuditLogView();
+      await waitFor(() => expect(screen.getByText('alice')).toBeInTheDocument());
+
+      await userEvent.click(screen.getByRole('button', { name: '次へ' }));
+
+      await waitFor(() => {
+        const hit = mockedApi.admin.getAuditLogs.mock.calls.find(
+          ([arg]) => (arg as { offset?: number })?.offset === 50,
+        );
+        expect(hit).toBeDefined();
+      });
     });
   });
 });

--- a/packages/client/src/__tests__/ChatPagePermalink.test.tsx
+++ b/packages/client/src/__tests__/ChatPagePermalink.test.tsx
@@ -82,7 +82,9 @@ const mockChannelsList = vi.hoisted(() => vi.fn().mockResolvedValue({ channels: 
 
 vi.mock('../api/client', () => ({
   api: {
-    messages: { search: vi.fn().mockResolvedValue({ messages: [] }) },
+    messages: {
+      search: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 }),
+    },
     bookmarks: { list: mockBookmarksList },
     drafts: { getAll: mockDraftsGetAll },
     channels: { list: mockChannelsList },

--- a/packages/client/src/__tests__/SearchPage.test.tsx
+++ b/packages/client/src/__tests__/SearchPage.test.tsx
@@ -219,7 +219,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 beforeEach(() => {
   mockSearch.mockReset();
-  mockSearch.mockResolvedValue({ messages: [] });
+  mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
   mockSavedViewsCreate.mockReset();
   mockSavedViewsCreate.mockResolvedValue({ savedView: { id: 1, name: 'view1' } });
   mockSavedViewsList.mockReset();
@@ -409,7 +409,7 @@ describe('SearchPage', () => {
 
     describe('検索実行後の表示', () => {
       it('クエリを入力して検索した結果が 0 件のときに「見つかりませんでした」が表示される', async () => {
-        mockSearch.mockResolvedValue({ messages: [] });
+        mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
         renderSearch();
         const input = screen.getByLabelText('メッセージ検索');
         await userEvent.type(input, 'hello');
@@ -428,7 +428,10 @@ describe('SearchPage', () => {
 
       it('クエリ入力後に結果がある場合は空状態 UI が消えて結果一覧が表示される', async () => {
         mockSearch.mockResolvedValue({
-          messages: [
+          total: 1,
+          limit: 50,
+          offset: 0,
+          items: [
             {
               id: 99,
               channelId: 7,
@@ -473,7 +476,7 @@ describe('SearchPage', () => {
 
     describe('フィルタ設定時の表示切替', () => {
       it('フィルタ (タグ) を設定した時点で空状態 UI から結果ペインに切り替わる', async () => {
-        mockSearch.mockResolvedValue({ messages: [] });
+        mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
         renderSearch();
         // 初期は空状態 UI が出ている
         await screen.findByTestId('search-empty-state');
@@ -494,7 +497,7 @@ describe('SearchPage', () => {
       });
 
       it('フィルタ設定後の結果が 0 件のときは「見つかりませんでした」が表示される', async () => {
-        mockSearch.mockResolvedValue({ messages: [] });
+        mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
         renderSearch();
         await act(async () => {
           await userEvent.click(screen.getByTestId('set-tag-filter'));
@@ -513,7 +516,7 @@ describe('SearchPage', () => {
 
     describe('リセット動作', () => {
       it('クエリをクリアすると空状態 UI に戻る', async () => {
-        mockSearch.mockResolvedValue({ messages: [] });
+        mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
         renderSearch();
         const input = screen.getByLabelText('メッセージ検索') as HTMLInputElement;
         // クエリを入力して検索状態にする
@@ -540,7 +543,7 @@ describe('SearchPage', () => {
       });
 
       it('クエリクリア後は「見つかりませんでした」が表示されない', async () => {
-        mockSearch.mockResolvedValue({ messages: [] });
+        mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
         renderSearch();
         const input = screen.getByLabelText('メッセージ検索') as HTMLInputElement;
         await userEvent.type(input, 'hi');
@@ -681,6 +684,66 @@ describe('SearchPage', () => {
           expect(screen.queryByTestId('search-syntax-help-panel')).not.toBeInTheDocument();
         });
       });
+    });
+  });
+
+  // #375 ページング統一: search が OffsetPaged を返す
+  describe('検索ページング統一（#375）', () => {
+    // 検索結果 1 件分のフィクスチャ
+    function makeResult(id: number, text: string) {
+      return {
+        id,
+        channelId: 7,
+        channelName: 'general',
+        userId: 1,
+        username: 'alice',
+        avatarUrl: null,
+        content: JSON.stringify({ ops: [{ insert: `${text}\n` }] }),
+        isEdited: false,
+        isDeleted: false,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-01T00:00:00Z',
+        mentions: [],
+        reactions: [],
+        parentMessageId: null,
+        rootMessageId: null,
+        replyCount: 0,
+        rootMessageContent: null,
+        quotedMessageId: null,
+        quotedMessage: null,
+        tags: [],
+      };
+    }
+
+    it('検索結果を OffsetPaged.items から描画する（旧 messages から変更）', async () => {
+      mockSearch.mockResolvedValue({
+        items: [makeResult(99, 'ヒットした本文')],
+        total: 1,
+        limit: 50,
+        offset: 0,
+      });
+      renderSearch();
+      await userEvent.type(screen.getByLabelText('メッセージ検索'), 'ヒット');
+      // items の各要素が result-{id} として描画される
+      await waitFor(() => expect(screen.getByTestId('result-99')).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+    });
+
+    it('total を検索ヒット件数表示に利用する', async () => {
+      mockSearch.mockResolvedValue({
+        items: [makeResult(1, 'a'), makeResult(2, 'b')],
+        total: 42,
+        limit: 50,
+        offset: 0,
+      });
+      renderSearch();
+      await userEvent.type(screen.getByLabelText('メッセージ検索'), 'foo');
+      await waitFor(() => expect(screen.getByTestId('search-hit-count')).toBeInTheDocument(), {
+        timeout: 1000,
+      });
+      // items.length(2) ではなく total(42) を表示する
+      expect(screen.getByTestId('search-hit-count').textContent).toContain('42');
     });
   });
 });

--- a/packages/client/src/__tests__/client.test.ts
+++ b/packages/client/src/__tests__/client.test.ts
@@ -198,3 +198,58 @@ describe('api.messages.search', () => {
     expect(calledUrl).toContain('dateFrom=2024-01-01');
   });
 });
+
+// #375 ページング仕様統一: API クライアントが標準封筒を返す
+describe('api ページング封筒（#375）', () => {
+  it('api.messages.list が CursorPaged（items / nextCursor / hasMore）を返す', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [{ id: 1 }], nextCursor: '1', hasMore: true }));
+
+    const res = await api.messages.list(1, { limit: 50 });
+
+    expect(res.items).toEqual([{ id: 1 }]);
+    expect(res.nextCursor).toBe('1');
+    expect(res.hasMore).toBe(true);
+  });
+
+  it('api.messages.list が cursor（before）と limit をクエリに付与する', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [], nextCursor: null, hasMore: false }));
+
+    await api.messages.list(1, { limit: 30, before: '99' });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('limit=30');
+    expect(calledUrl).toContain('before=99');
+  });
+
+  it('api.messages.search が OffsetPaged（items / total / limit / offset）を返す', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [{ id: 5 }], total: 12, limit: 50, offset: 0 }));
+
+    const res = await api.messages.search('hello');
+
+    expect(res.items).toEqual([{ id: 5 }]);
+    expect(res.total).toBe(12);
+    expect(res.limit).toBe(50);
+    expect(res.offset).toBe(0);
+  });
+
+  it('api.messages.search が limit / offset をクエリに付与できる', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [], total: 0, limit: 10, offset: 20 }));
+
+    await api.messages.search('hello', { limit: 10, offset: 20 });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('limit=10');
+    expect(calledUrl).toContain('offset=20');
+  });
+
+  it('api.admin.getAuditLogs が OffsetPaged（items / total / limit / offset）を返す', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [{ id: 1 }], total: 3, limit: 50, offset: 0 }));
+
+    const res = await api.admin.getAuditLogs();
+
+    expect(res.items).toEqual([{ id: 1 }]);
+    expect(res.total).toBe(3);
+    expect(res.limit).toBe(50);
+    expect(res.offset).toBe(0);
+  });
+});

--- a/packages/client/src/__tests__/useMessages.test.tsx
+++ b/packages/client/src/__tests__/useMessages.test.tsx
@@ -95,7 +95,11 @@ describe('useMessages', () => {
 
     it('channelId が渡されたとき API を呼び出しメッセージをセットする', async () => {
       mockUseSocket.mockReturnValue(createMockSocket());
-      mockList.mockResolvedValue({ messages: [makeMessage(1), makeMessage(2)] });
+      mockList.mockResolvedValue({
+        items: [makeMessage(1), makeMessage(2)],
+        nextCursor: null,
+        hasMore: false,
+      });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
 
@@ -108,7 +112,7 @@ describe('useMessages', () => {
     it('channelId が変わると以前のメッセージをクリアして再取得する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [makeMessage(1, 1)] });
+      mockList.mockResolvedValue({ items: [makeMessage(1, 1)], nextCursor: null, hasMore: false });
 
       const { result, rerender } = renderHook(({ ch }: { ch: number }) => useMessages(ch), {
         wrapper,
@@ -117,7 +121,11 @@ describe('useMessages', () => {
       await waitFor(() => expect(result.current.messages).toHaveLength(1));
 
       // チャンネルを切り替える
-      mockList.mockResolvedValue({ messages: [makeMessage(10, 2), makeMessage(11, 2)] });
+      mockList.mockResolvedValue({
+        items: [makeMessage(10, 2), makeMessage(11, 2)],
+        nextCursor: null,
+        hasMore: false,
+      });
       rerender({ ch: 2 });
 
       // 切り替え直後はメッセージがクリアされる
@@ -130,7 +138,7 @@ describe('useMessages', () => {
     it('channelId がセットされると join_channel イベントを emit する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [] });
+      mockList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
 
       renderHook(() => useMessages(5), { wrapper });
 
@@ -140,7 +148,7 @@ describe('useMessages', () => {
     it('channelId が変わる（クリーンアップ）と leave_channel イベントを emit する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [] });
+      mockList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
 
       const { rerender } = renderHook(({ ch }: { ch: number }) => useMessages(ch), {
         wrapper,
@@ -159,7 +167,7 @@ describe('useMessages', () => {
     it('socket の new_message イベントを受信すると、対象 channelId のメッセージをリストに追加する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [] });
+      mockList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -175,7 +183,7 @@ describe('useMessages', () => {
     it('socket の new_message イベントで channelId が異なるメッセージは無視する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [] });
+      mockList.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.loading).toBe(false));
@@ -191,7 +199,7 @@ describe('useMessages', () => {
     it('socket の message_edited イベントを受信すると、対象メッセージを置き換える', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [makeMessage(1)] });
+      mockList.mockResolvedValue({ items: [makeMessage(1)], nextCursor: null, hasMore: false });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.messages).toHaveLength(1));
@@ -207,7 +215,7 @@ describe('useMessages', () => {
     it('socket の message_deleted イベントを受信すると、対象メッセージの isDeleted を true にする', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [makeMessage(1)] });
+      mockList.mockResolvedValue({ items: [makeMessage(1)], nextCursor: null, hasMore: false });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.messages).toHaveLength(1));
@@ -224,12 +232,16 @@ describe('useMessages', () => {
     it('refetch を呼ぶと before 指定なしで API を再取得する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [makeMessage(1)] });
+      mockList.mockResolvedValue({ items: [makeMessage(1)], nextCursor: null, hasMore: false });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.messages).toHaveLength(1));
 
-      mockList.mockResolvedValue({ messages: [makeMessage(1), makeMessage(2)] });
+      mockList.mockResolvedValue({
+        items: [makeMessage(1), makeMessage(2)],
+        nextCursor: null,
+        hasMore: false,
+      });
 
       act(() => {
         result.current.refetch();
@@ -246,34 +258,51 @@ describe('useMessages', () => {
   });
 
   describe('loadMore（ページネーション）', () => {
-    it('loadMore を呼ぶと先頭メッセージの id を before に指定して追加取得する', async () => {
+    it('loadMore を呼ぶとサーバの nextCursor を before に指定して追加取得する', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [makeMessage(10), makeMessage(11)] });
+      // #375 カーソル系: 続きがある初回応答（nextCursor='10', hasMore=true）
+      mockList.mockResolvedValue({
+        items: [makeMessage(10), makeMessage(11)],
+        nextCursor: '10',
+        hasMore: true,
+      });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.messages).toHaveLength(2));
 
-      mockList.mockResolvedValue({ messages: [makeMessage(8), makeMessage(9)] });
+      mockList.mockResolvedValue({
+        items: [makeMessage(8), makeMessage(9)],
+        nextCursor: null,
+        hasMore: false,
+      });
 
       act(() => {
         result.current.loadMore();
       });
 
       await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
-      // 先頭メッセージの id=10 を before に指定して呼ばれること
-      expect(mockList).toHaveBeenLastCalledWith(1, expect.objectContaining({ before: 10 }));
+      // nextCursor='10' を before に指定して呼ばれること
+      expect(mockList).toHaveBeenLastCalledWith(1, expect.objectContaining({ before: '10' }));
     });
 
     it('追加取得したメッセージは既存メッセージの前に結合される', async () => {
       const socket = createMockSocket();
       mockUseSocket.mockReturnValue(socket);
-      mockList.mockResolvedValue({ messages: [makeMessage(10), makeMessage(11)] });
+      mockList.mockResolvedValue({
+        items: [makeMessage(10), makeMessage(11)],
+        nextCursor: '10',
+        hasMore: true,
+      });
 
       const { result } = renderHook(() => useMessages(1), { wrapper });
       await waitFor(() => expect(result.current.messages).toHaveLength(2));
 
-      mockList.mockResolvedValue({ messages: [makeMessage(8), makeMessage(9)] });
+      mockList.mockResolvedValue({
+        items: [makeMessage(8), makeMessage(9)],
+        nextCursor: null,
+        hasMore: false,
+      });
       act(() => {
         result.current.loadMore();
       });
@@ -282,6 +311,60 @@ describe('useMessages', () => {
       // 古いメッセージが先頭に来ること
       expect(result.current.messages[0].id).toBe(8);
       expect(result.current.messages[2].id).toBe(10);
+    });
+  });
+
+  // #375 カーソルページング統一（api.messages.list が CursorPaged を返す前提）
+  describe('カーソルページング（#375）', () => {
+    it('初回ロードで CursorPaged.items をメッセージにセットする', async () => {
+      const socket = createMockSocket();
+      mockUseSocket.mockReturnValue(socket);
+      mockList.mockResolvedValue({
+        items: [makeMessage(1), makeMessage(2)],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+      const { result } = renderHook(() => useMessages(1), { wrapper });
+
+      await waitFor(() => expect(result.current.messages).toHaveLength(2));
+      expect(result.current.messages.map((m) => m.id)).toEqual([1, 2]);
+    });
+
+    it('サーバの hasMore を hasMore として公開する', async () => {
+      const socket = createMockSocket();
+      mockUseSocket.mockReturnValue(socket);
+      mockList.mockResolvedValue({
+        items: [makeMessage(10), makeMessage(11)],
+        nextCursor: '10',
+        hasMore: true,
+      });
+
+      const { result } = renderHook(() => useMessages(1), { wrapper });
+
+      await waitFor(() => expect(result.current.hasMore).toBe(true));
+    });
+
+    it('hasMore=false のとき loadMore は追加の取得を行わない', async () => {
+      const socket = createMockSocket();
+      mockUseSocket.mockReturnValue(socket);
+      mockList.mockResolvedValue({
+        items: [makeMessage(1)],
+        nextCursor: null,
+        hasMore: false,
+      });
+
+      const { result } = renderHook(() => useMessages(1), { wrapper });
+      await waitFor(() => expect(result.current.messages).toHaveLength(1));
+      expect(mockList).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        result.current.loadMore();
+      });
+
+      // hasMore=false なので追加フェッチは発生しない
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockList).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/client/src/__tests__/useOffsetPagination.test.tsx
+++ b/packages/client/src/__tests__/useOffsetPagination.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * オフセットページング共通フック useOffsetPagination のテスト
+ *
+ * テスト対象: src/hooks/useOffsetPagination.ts
+ * 戦略:
+ *   - オフセットページング状態（offset/limit、ページ送り、total/hasNext/hasPrev 算出、
+ *     フィルタ変更での offset リセット）を共通化するフック。
+ *   - React 19 の use() + Suspense 構成に合わせ、本フックは安定化済みの fetchPromise と
+ *     ページャ制御値を返す（items 自体は呼び出し側が use(fetchPromise) で読む）。
+ *   - フェッチ関数を vi.fn で注入し、renderHook で状態遷移と呼び出し引数を検証する。
+ *   - 複数コンポーネント（AuditLogView / SearchPage 等）が共用するため機能名ファイルとして配置する（AGENTS.md 準拠）。
+ */
+
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useOffsetPagination } from '../hooks/useOffsetPagination';
+import type { OffsetPaged } from '@chat-app/shared';
+
+type Row = { id: number };
+
+function makePage(overrides: Partial<OffsetPaged<Row>> = {}): OffsetPaged<Row> {
+  return { items: [{ id: 1 }], total: 100, limit: 10, offset: 0, ...overrides };
+}
+
+describe('useOffsetPagination（#375 一覧取得の共通パターン）', () => {
+  it('初期状態で offset=0 のページを取得し total を保持する', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(makePage());
+    const { result } = renderHook(() => useOffsetPagination(fetchPage, { q: 'x' }, { limit: 10 }));
+
+    await waitFor(() => expect(result.current.total).toBe(100));
+    expect(result.current.offset).toBe(0);
+    expect(fetchPage).toHaveBeenCalledWith(
+      expect.objectContaining({ q: 'x', limit: 10, offset: 0 }),
+    );
+  });
+
+  it('nextPage で offset が limit 単位で進み再取得される', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(makePage());
+    const { result } = renderHook(() => useOffsetPagination(fetchPage, { q: 'x' }, { limit: 10 }));
+    await waitFor(() => expect(result.current.total).toBe(100));
+
+    act(() => result.current.nextPage());
+
+    await waitFor(() => expect(result.current.offset).toBe(10));
+    expect(fetchPage).toHaveBeenLastCalledWith(expect.objectContaining({ offset: 10 }));
+  });
+
+  it('prevPage で offset が limit 単位で戻り、0 未満にはならない', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(makePage());
+    const { result } = renderHook(() => useOffsetPagination(fetchPage, { q: 'x' }, { limit: 10 }));
+    await waitFor(() => expect(result.current.total).toBe(100));
+
+    act(() => result.current.nextPage());
+    await waitFor(() => expect(result.current.offset).toBe(10));
+
+    act(() => result.current.prevPage());
+    await waitFor(() => expect(result.current.offset).toBe(0));
+
+    // すでに先頭なので prevPage を呼んでも 0 のまま
+    act(() => result.current.prevPage());
+    expect(result.current.offset).toBe(0);
+  });
+
+  it('offset + limit < total のとき hasNext=true / offset>0 のとき hasPrev=true を返す', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(makePage({ total: 25, limit: 10 }));
+    const { result } = renderHook(() => useOffsetPagination(fetchPage, { q: 'x' }, { limit: 10 }));
+    await waitFor(() => expect(result.current.total).toBe(25));
+
+    expect(result.current.hasPrev).toBe(false);
+    expect(result.current.hasNext).toBe(true);
+
+    act(() => result.current.nextPage());
+    await waitFor(() => expect(result.current.offset).toBe(10));
+    expect(result.current.hasPrev).toBe(true);
+  });
+
+  it('最終ページでは hasNext=false となり nextPage で範囲外に進まない', async () => {
+    // total=10, limit=10 → 1ページのみ。offset 0 で hasNext=false
+    const fetchPage = vi.fn().mockResolvedValue(makePage({ total: 10, limit: 10 }));
+    const { result } = renderHook(() => useOffsetPagination(fetchPage, { q: 'x' }, { limit: 10 }));
+    await waitFor(() => expect(result.current.total).toBe(10));
+
+    expect(result.current.hasNext).toBe(false);
+  });
+
+  it('フィルタ依存が変わると offset を 0 にリセットして取得し直す', async () => {
+    const fetchPage = vi.fn().mockResolvedValue(makePage());
+    const { result, rerender } = renderHook(
+      ({ filters }) => useOffsetPagination(fetchPage, filters, { limit: 10 }),
+      { initialProps: { filters: { q: 'x' } } },
+    );
+    await waitFor(() => expect(result.current.total).toBe(100));
+
+    act(() => result.current.nextPage());
+    await waitFor(() => expect(result.current.offset).toBe(10));
+
+    // フィルタ変更 → offset が 0 に戻り、新フィルタで再取得される
+    rerender({ filters: { q: 'y' } });
+    await waitFor(() => expect(result.current.offset).toBe(0));
+    expect(fetchPage).toHaveBeenLastCalledWith(expect.objectContaining({ q: 'y', offset: 0 }));
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -6,6 +6,8 @@ import type {
   Message,
   MessageSearchFilters,
   MessageSearchResult,
+  OffsetPaged,
+  CursorPaged,
   PinnedMessage,
   PinnedChannel,
   Bookmark,
@@ -238,11 +240,12 @@ export const api = {
       }),
   },
   messages: {
-    list: (channelId: number, params?: { limit?: number; before?: number }) => {
+    list: (channelId: number, params?: { limit?: number; before?: number | string }) => {
       const q = new URLSearchParams();
       if (params?.limit) q.set('limit', String(params.limit));
       if (params?.before) q.set('before', String(params.before));
-      return request<{ messages: Message[] }>(`/channels/${channelId}/messages?${q}`);
+      // #375 カーソル系ページング: { items, nextCursor, hasMore }
+      return request<CursorPaged<Message>>(`/channels/${channelId}/messages?${q}`);
     },
     edit: (id: number, data: { content: string; mentionedUserIds?: number[] }) =>
       request<{ message: Message }>(`/messages/${id}`, {
@@ -262,7 +265,10 @@ export const api = {
       if (filters?.mentionedToMe) params.set('mentionedToMe', 'true');
       if (filters?.unreadOnly) params.set('unreadOnly', 'true');
       if (filters?.channelId !== undefined) params.set('channelId', String(filters.channelId));
-      return request<{ messages: MessageSearchResult[] }>(`/messages/search?${params.toString()}`);
+      if (filters?.limit !== undefined) params.set('limit', String(filters.limit));
+      if (filters?.offset !== undefined) params.set('offset', String(filters.offset));
+      // #375 オフセット系ページング: { items, total, limit, offset }
+      return request<OffsetPaged<MessageSearchResult>>(`/messages/search?${params.toString()}`);
     },
     getReplies: (messageId: number) =>
       request<{ replies: Message[] }>(`/messages/${messageId}/replies`),

--- a/packages/client/src/components/AuditLogView.tsx
+++ b/packages/client/src/components/AuditLogView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, use, Suspense, Component, ReactNode } from 'react';
+import { useState, useCallback, use, Suspense, Component, ReactNode } from 'react';
 import {
   Box,
   Paper,
@@ -17,6 +17,7 @@ import {
   InputLabel,
 } from '@mui/material';
 import { api } from '../api/client';
+import { useOffsetPagination } from '../hooks/useOffsetPagination';
 import type { AuditLog, AuditActionType, AuditLogListResponse } from '../types/admin';
 
 const PAGE_LIMIT = 50;
@@ -55,12 +56,11 @@ const ACTION_TYPE_LABELS: Record<AuditActionType, string> = {
 
 const ACTION_TYPE_OPTIONS: AuditActionType[] = Object.keys(ACTION_TYPE_LABELS) as AuditActionType[];
 
-interface FilterState {
+interface FilterState extends Record<string, unknown> {
   actionType: string;
   actorUserId: string;
   from: string;
   to: string;
-  offset: number;
 }
 
 interface ActorOption {
@@ -94,7 +94,8 @@ function formatMetadata(metadata: Record<string, unknown> | null): string {
 
 function AuditLogContent({ fetchPromise }: AuditLogContentProps) {
   const result = use(fetchPromise);
-  const { logs } = result;
+  // #375: API レスポンスが { items, total, limit, offset }（OffsetPaged）に統一された
+  const { items: logs } = result;
 
   if (logs.length === 0) {
     return (
@@ -195,32 +196,26 @@ export default function AuditLogView({ actors = [] }: AuditLogViewProps) {
     actorUserId: '',
     from: '',
     to: '',
-    offset: 0,
   });
-  const [total, setTotal] = useState<number>(0);
 
-  // filter の各値が変わるたびに新しい Promise を作る（useMemo で安定化）
-  const fetchPromise = useMemo(() => {
+  // #375 オフセットページングは共通フック useOffsetPagination に集約
+  const fetchPage = useCallback((args: FilterState & { limit: number; offset: number }) => {
     const params: Parameters<typeof api.admin.getAuditLogs>[0] = {
-      limit: PAGE_LIMIT,
-      offset: filter.offset,
+      limit: args.limit,
+      offset: args.offset,
     };
-    if (filter.actionType) params.actionType = filter.actionType;
-    if (filter.actorUserId) params.actorUserId = Number(filter.actorUserId);
-    if (filter.from) params.from = filter.from;
-    if (filter.to) params.to = filter.to;
+    if (args.actionType) params.actionType = args.actionType;
+    if (args.actorUserId) params.actorUserId = Number(args.actorUserId);
+    if (args.from) params.from = args.from;
+    if (args.to) params.to = args.to;
+    return api.admin.getAuditLogs(params);
+  }, []);
 
-    return api.admin.getAuditLogs(params).then((res) => {
-      setTotal(res.total);
-      return res;
-    });
-  }, [filter]);
-
-  const hasPrev = filter.offset > 0;
-  const hasNext = filter.offset + PAGE_LIMIT < total;
+  const { fetchPromise, offset, limit, total, hasPrev, hasNext, nextPage, prevPage } =
+    useOffsetPagination(fetchPage, filter, { limit: PAGE_LIMIT });
 
   const handleReset = () => {
-    setFilter({ actionType: '', actorUserId: '', from: '', to: '', offset: 0 });
+    setFilter({ actionType: '', actorUserId: '', from: '', to: '' });
   };
 
   return (
@@ -233,9 +228,7 @@ export default function AuditLogView({ actors = [] }: AuditLogViewProps) {
             labelId="audit-action-type-label"
             label="操作"
             value={filter.actionType}
-            onChange={(e) =>
-              setFilter((f) => ({ ...f, actionType: String(e.target.value), offset: 0 }))
-            }
+            onChange={(e) => setFilter((f) => ({ ...f, actionType: String(e.target.value) }))}
             inputProps={{ 'aria-label': '操作' }}
           >
             <MenuItem value="">すべて</MenuItem>
@@ -253,9 +246,7 @@ export default function AuditLogView({ actors = [] }: AuditLogViewProps) {
             labelId="audit-actor-label"
             label="実行者"
             value={filter.actorUserId}
-            onChange={(e) =>
-              setFilter((f) => ({ ...f, actorUserId: String(e.target.value), offset: 0 }))
-            }
+            onChange={(e) => setFilter((f) => ({ ...f, actorUserId: String(e.target.value) }))}
             inputProps={{ 'aria-label': '実行者' }}
           >
             <MenuItem value="">すべて</MenuItem>
@@ -273,7 +264,7 @@ export default function AuditLogView({ actors = [] }: AuditLogViewProps) {
           label="開始日"
           InputLabelProps={{ shrink: true }}
           value={filter.from}
-          onChange={(e) => setFilter((f) => ({ ...f, from: e.target.value, offset: 0 }))}
+          onChange={(e) => setFilter((f) => ({ ...f, from: e.target.value }))}
           inputProps={{ 'aria-label': '開始日' }}
         />
 
@@ -283,7 +274,7 @@ export default function AuditLogView({ actors = [] }: AuditLogViewProps) {
           label="終了日"
           InputLabelProps={{ shrink: true }}
           value={filter.to}
-          onChange={(e) => setFilter((f) => ({ ...f, to: e.target.value, offset: 0 }))}
+          onChange={(e) => setFilter((f) => ({ ...f, to: e.target.value }))}
           inputProps={{ 'aria-label': '終了日' }}
         />
 
@@ -321,21 +312,22 @@ export default function AuditLogView({ actors = [] }: AuditLogViewProps) {
       </ErrorBoundary>
 
       {/* ページネーション */}
-      <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mt: 2 }}>
-        <Button
-          variant="outlined"
-          disabled={!hasPrev}
-          onClick={() => setFilter((f) => ({ ...f, offset: Math.max(f.offset - PAGE_LIMIT, 0) }))}
-        >
-          前へ
-        </Button>
-        <Button
-          variant="outlined"
-          disabled={!hasNext}
-          onClick={() => setFilter((f) => ({ ...f, offset: f.offset + PAGE_LIMIT }))}
-        >
-          次へ
-        </Button>
+      <Box
+        sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 2, mt: 2 }}
+      >
+        {total > 0 && (
+          <Typography variant="caption" color="text.secondary" data-testid="audit-log-page-info">
+            全{total}件（{offset + 1}–{Math.min(offset + limit, total)}）
+          </Typography>
+        )}
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button variant="outlined" disabled={!hasPrev} onClick={prevPage}>
+            前へ
+          </Button>
+          <Button variant="outlined" disabled={!hasNext} onClick={nextPage}>
+            次へ
+          </Button>
+        </Box>
       </Box>
     </Box>
   );

--- a/packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx
+++ b/packages/client/src/hooks/__tests__/useMentionUnreadCount.test.tsx
@@ -54,16 +54,19 @@ beforeEach(() => {
 describe('useMentionUnreadCount', () => {
   describe('初期取得', () => {
     it('初回マウント時に api.messages.search を mentionedToMe / unreadOnly フィルタで呼ぶ', async () => {
-      mockSearch.mockResolvedValue({ messages: [] });
+      mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
       renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
       await waitFor(() => {
         expect(mockSearch).toHaveBeenCalledWith('', { mentionedToMe: true, unreadOnly: true });
       });
     });
 
-    it('レスポンスの messages.length をカウントとして返す', async () => {
+    it('レスポンスの total をカウントとして返す', async () => {
       mockSearch.mockResolvedValue({
-        messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        items: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        total: 3,
+        limit: 50,
+        offset: 0,
       });
       const { result } = renderHook(() => useMentionUnreadCount(), {
         wrapper: wrapperFactory('/chat'),
@@ -87,7 +90,7 @@ describe('useMentionUnreadCount', () => {
 
   describe('Socket 受信による再フェッチ', () => {
     it('mention_updated イベントを受信すると api.messages.search が再フェッチされる', async () => {
-      mockSearch.mockResolvedValue({ messages: [] });
+      mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
       renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
 
       await waitFor(() => {
@@ -110,8 +113,13 @@ describe('useMentionUnreadCount', () => {
     it('再フェッチ後の件数が count に反映される', async () => {
       // 初回は 1 件、再フェッチ後は 3 件
       mockSearch
-        .mockResolvedValueOnce({ messages: [{ id: 1 }] })
-        .mockResolvedValueOnce({ messages: [{ id: 1 }, { id: 2 }, { id: 3 }] });
+        .mockResolvedValueOnce({ items: [{ id: 1 }], total: 1, limit: 50, offset: 0 })
+        .mockResolvedValueOnce({
+          items: [{ id: 1 }, { id: 2 }, { id: 3 }],
+          total: 3,
+          limit: 50,
+          offset: 0,
+        });
 
       const { result } = renderHook(() => useMentionUnreadCount(), {
         wrapper: wrapperFactory('/chat'),
@@ -136,7 +144,7 @@ describe('useMentionUnreadCount', () => {
     });
 
     it('mention_updated を複数回受信するたびに再フェッチが走る', async () => {
-      mockSearch.mockResolvedValue({ messages: [] });
+      mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
       renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
 
       await waitFor(() => {
@@ -161,7 +169,7 @@ describe('useMentionUnreadCount', () => {
 
     it('socket が null のとき mention_updated の購読は行わない', async () => {
       socketReturnValue = null;
-      mockSearch.mockResolvedValue({ messages: [] });
+      mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
       renderHook(() => useMentionUnreadCount(), { wrapper: wrapperFactory('/chat') });
       await waitFor(() => {
         expect(mockSearch).toHaveBeenCalled();
@@ -170,7 +178,7 @@ describe('useMentionUnreadCount', () => {
     });
 
     it('unmount 時に mention_updated の購読が解除される', async () => {
-      mockSearch.mockResolvedValue({ messages: [] });
+      mockSearch.mockResolvedValue({ items: [], total: 0, limit: 50, offset: 0 });
       const { unmount } = renderHook(() => useMentionUnreadCount(), {
         wrapper: wrapperFactory('/chat'),
       });
@@ -185,7 +193,10 @@ describe('useMentionUnreadCount', () => {
   describe('現在パスによる挙動', () => {
     it('現在パスが / (Inbox) のときは 0 を返す（内部 state は保持される）', async () => {
       mockSearch.mockResolvedValue({
-        messages: [{ id: 1 }, { id: 2 }],
+        items: [{ id: 1 }, { id: 2 }],
+        total: 2,
+        limit: 50,
+        offset: 0,
       });
       const { result } = renderHook(() => useMentionUnreadCount(), {
         wrapper: wrapperFactory('/'),
@@ -199,7 +210,10 @@ describe('useMentionUnreadCount', () => {
 
     it('現在パスが /chat など / 以外のときは集計値を返す', async () => {
       mockSearch.mockResolvedValue({
-        messages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        items: [{ id: 1 }, { id: 2 }, { id: 3 }],
+        total: 3,
+        limit: 50,
+        offset: 0,
       });
       const { result } = renderHook(() => useMentionUnreadCount(), {
         wrapper: wrapperFactory('/chat'),

--- a/packages/client/src/hooks/useMentionUnreadCount.ts
+++ b/packages/client/src/hooks/useMentionUnreadCount.ts
@@ -20,9 +20,9 @@ export function useMentionUnreadCount(): number {
     let cancelled = false;
     api.messages
       .search('', { mentionedToMe: true, unreadOnly: true })
-      .then(({ messages }) => {
+      .then(({ total }) => {
         if (cancelled) return;
-        setCount(messages.length);
+        setCount(total);
       })
       .catch(() => {
         // 取得失敗時は 0 のまま
@@ -38,8 +38,8 @@ export function useMentionUnreadCount(): number {
     const handler = () => {
       api.messages
         .search('', { mentionedToMe: true, unreadOnly: true })
-        .then(({ messages }) => {
-          setCount(messages.length);
+        .then(({ total }) => {
+          setCount(total);
         })
         .catch(() => {
           // 取得失敗時は現在値を維持

--- a/packages/client/src/hooks/useMessages.ts
+++ b/packages/client/src/hooks/useMessages.ts
@@ -6,15 +6,27 @@ import { useSocket } from '../contexts/SocketContext';
 export function useMessages(channelId: number | null) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [loading, setLoading] = useState(false);
+  // #375 カーソル系ページング: サーバが返す nextCursor / hasMore を保持して loadMore に利用する
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
   const socket = useSocket();
 
   const fetchMessages = useCallback(
-    async (before?: number) => {
+    async (before?: string) => {
       if (!channelId) return;
       setLoading(true);
       try {
-        const { messages: fetched } = await api.messages.list(channelId, { limit: 50, before });
-        setMessages((prev) => (before ? [...fetched, ...prev] : fetched));
+        const {
+          items,
+          nextCursor: cursor,
+          hasMore: more,
+        } = await api.messages.list(channelId, {
+          limit: 50,
+          before,
+        });
+        setMessages((prev) => (before ? [...items, ...prev] : items));
+        setNextCursor(cursor);
+        setHasMore(more);
       } finally {
         setLoading(false);
       }
@@ -25,6 +37,8 @@ export function useMessages(channelId: number | null) {
   // Reload when channel changes
   useEffect(() => {
     setMessages([]);
+    setNextCursor(null);
+    setHasMore(false);
     if (!channelId) return;
 
     void fetchMessages();
@@ -90,7 +104,11 @@ export function useMessages(channelId: number | null) {
   return {
     messages,
     loading,
-    loadMore: () => void fetchMessages(messages[0]?.id),
+    hasMore,
+    // nextCursor（= 現在表示中の最古メッセージの ID 文字列）を before に渡して続きを読み込む
+    loadMore: () => {
+      if (hasMore && nextCursor) void fetchMessages(nextCursor);
+    },
     refetch: () => void fetchMessages(),
   };
 }

--- a/packages/client/src/hooks/useOffsetPagination.ts
+++ b/packages/client/src/hooks/useOffsetPagination.ts
@@ -1,0 +1,59 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { OffsetPaged } from '@chat-app/shared';
+
+/**
+ * オフセット系ページング（#375）の共通フック。
+ *
+ * 一覧/検索 UI のページャ実装を共通化する。React 19 の `use()` + `<Suspense>` 構成に合わせ、
+ * データそのものではなく安定化済みの `fetchPromise` を返す。呼び出し側は子コンポーネントで
+ * `use(fetchPromise)` して `{ items }` を読み取り、本フックが返す `total` / `hasNext` /
+ * `hasPrev` / `nextPage` / `prevPage` でページャ UI を制御する。
+ *
+ * - offset は本フックが state として保持し、nextPage / prevPage で limit 単位に増減する。
+ * - フィルタ（filters）が変わると offset を 0 にリセットして 1 ページ目から取得し直す。
+ * - total はレスポンスから取得して保持し、hasNext = offset + limit < total で算出する。
+ *
+ * @param fetchPage  limit / offset とフィルタを受け取り OffsetPaged を返すフェッチ関数
+ * @param filters    フェッチに渡すフィルタ条件（変化で offset リセット）
+ * @param options    limit（既定 50）
+ */
+export function useOffsetPagination<T, F extends Record<string, unknown>>(
+  fetchPage: (args: F & { limit: number; offset: number }) => Promise<OffsetPaged<T>>,
+  filters: F,
+  options?: { limit?: number },
+) {
+  const limit = options?.limit ?? 50;
+  const [offset, setOffset] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  // フィルタ条件の同一性は内容ベースで判定する（参照は毎レンダリングで変わりうるため）
+  const filtersKey = JSON.stringify(filters);
+
+  // フィルタが変わったら 1 ページ目に戻す
+  useEffect(() => {
+    setOffset(0);
+  }, [filtersKey]);
+
+  const fetchPromise = useMemo(() => {
+    return fetchPage({ ...filters, limit, offset }).then((res) => {
+      setTotal(res.total);
+      return res;
+    });
+    // filters は filtersKey で同一性を判定する（filters 直接参照は毎回変化しうる）
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchPage, filtersKey, limit, offset]);
+
+  const hasPrev = offset > 0;
+  const hasNext = offset + limit < total;
+
+  return {
+    fetchPromise,
+    offset,
+    limit,
+    total,
+    hasPrev,
+    hasNext,
+    nextPage: () => setOffset((o) => o + limit),
+    prevPage: () => setOffset((o) => Math.max(0, o - limit)),
+  };
+}

--- a/packages/client/src/pages/InboxPage.tsx
+++ b/packages/client/src/pages/InboxPage.tsx
@@ -20,7 +20,13 @@ import ThreadsList from '../components/Inbox/ThreadsList';
 import type { DraftResumeTarget } from '../components/Inbox/DraftsList';
 import { api } from '../api/client';
 import { useAuth } from '../contexts/AuthContext';
-import type { Draft, MessageSearchResult, Reminder, ThreadSummary } from '@chat-app/shared';
+import type {
+  Draft,
+  MessageSearchResult,
+  OffsetPaged,
+  Reminder,
+  ThreadSummary,
+} from '@chat-app/shared';
 
 type TabKey = 'mentions' | 'threads' | 'reminders' | 'drafts' | 'all';
 
@@ -88,13 +94,14 @@ function MentionsSection({
   onShowAllTabs,
   onOpenNotificationSettings,
 }: {
-  promise: Promise<{ messages: MessageSearchResult[] }>;
+  promise: Promise<OffsetPaged<MessageSearchResult>>;
   unreadOnly?: boolean;
   onClearUnreadFilter?: () => void;
   onShowAllTabs?: () => void;
   onOpenNotificationSettings?: () => void;
 }) {
-  const { messages } = use(promise);
+  // #375: 検索 API が OffsetPaged を返すようになったため items を取り出す
+  const { items: messages } = use(promise);
   return (
     <MentionsList
       messages={messages}
@@ -123,12 +130,12 @@ function AllSection({
   draftsPromise,
   unreadOnly,
 }: {
-  mentionsPromise: Promise<{ messages: MessageSearchResult[] }>;
+  mentionsPromise: Promise<OffsetPaged<MessageSearchResult>>;
   remindersPromise: Promise<{ reminders: Reminder[] }>;
   draftsPromise: Promise<{ drafts: Draft[] }>;
   unreadOnly?: boolean;
 }) {
-  const { messages } = use(mentionsPromise);
+  const { items: messages } = use(mentionsPromise);
   const { reminders } = use(remindersPromise);
   const { drafts } = use(draftsPromise);
   return (

--- a/packages/client/src/pages/SearchPage.tsx
+++ b/packages/client/src/pages/SearchPage.tsx
@@ -167,6 +167,8 @@ export default function SearchPage() {
   // チップ入力欄の生テキスト
   const [rawSearchText, setRawSearchText] = useState('');
   const [searchResults, setSearchResults] = useState<MessageSearchResult[]>([]);
+  // #375 検索結果の総ヒット件数（オフセット系ページングの total）
+  const [searchTotal, setSearchTotal] = useState(0);
   const [searching, setSearching] = useState(false);
   // Issue #325: 検索構文ヘルプパネルの開閉状態
   const [helpOpen, setHelpOpen] = useState(false);
@@ -200,6 +202,7 @@ export default function SearchPage() {
     const trimmedQuery = searchQuery.trim();
     if (!trimmedQuery && !hasAnyFilter) {
       setSearchResults([]);
+      setSearchTotal(0);
       setSearching(false);
       return;
     }
@@ -207,7 +210,10 @@ export default function SearchPage() {
       setSearching(true);
       api.messages
         .search(trimmedQuery, effectiveFilters)
-        .then(({ messages }) => setSearchResults(messages))
+        .then(({ items, total }) => {
+          setSearchResults(items);
+          setSearchTotal(total);
+        })
         .catch((err) => {
           console.error(err);
         })
@@ -465,16 +471,28 @@ export default function SearchPage() {
                 <CircularProgress size={24} />
               </Box>
             ) : (
-              <SearchResultsArea
-                results={searchResults}
-                onNavigate={handleNavigate}
-                keyword={searchQuery}
-                hasSearched={hasSearched}
-                searchQuery={searchQuery}
-                effectiveFilters={effectiveFilters}
-                onRemoveFilter={handleRemoveFilter}
-                onResetAll={handleResetAll}
-              />
+              <>
+                {hasSearched && searchTotal > 0 && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ display: 'block', px: 2, pt: 1 }}
+                    data-testid="search-hit-count"
+                  >
+                    {searchTotal}件ヒット
+                  </Typography>
+                )}
+                <SearchResultsArea
+                  results={searchResults}
+                  onNavigate={handleNavigate}
+                  keyword={searchQuery}
+                  hasSearched={hasSearched}
+                  searchQuery={searchQuery}
+                  effectiveFilters={effectiveFilters}
+                  onRemoveFilter={handleRemoveFilter}
+                  onResetAll={handleResetAll}
+                />
+              </>
             )}
           </Box>
         </Box>

--- a/packages/server/src/__tests__/advanced-search.test.ts
+++ b/packages/server/src/__tests__/advanced-search.test.ts
@@ -102,7 +102,7 @@ beforeAll(async () => {
 describe('高度検索API', () => {
   describe('日付範囲フィルタ', () => {
     it('dateFrom を指定すると指定日以降のメッセージのみ返る', async () => {
-      const results = await searchMessages('keyword', { dateFrom: '2024-03-01' });
+      const { items: results } = await searchMessages('keyword', { dateFrom: '2024-03-01' });
       const ids = results.map((r) => r.id);
       expect(ids).not.toContain(msgOld);
       expect(ids).toContain(msgNew);
@@ -110,7 +110,7 @@ describe('高度検索API', () => {
     });
 
     it('dateTo を指定すると指定日以前のメッセージのみ返る', async () => {
-      const results = await searchMessages('keyword', { dateTo: '2024-03-31' });
+      const { items: results } = await searchMessages('keyword', { dateTo: '2024-03-31' });
       const ids = results.map((r) => r.id);
       expect(ids).toContain(msgOld);
       expect(ids).toContain(msgUser2);
@@ -118,7 +118,7 @@ describe('高度検索API', () => {
     });
 
     it('dateFrom と dateTo を両方指定すると範囲内のメッセージのみ返る', async () => {
-      const results = await searchMessages('keyword', {
+      const { items: results } = await searchMessages('keyword', {
         dateFrom: '2024-02-01',
         dateTo: '2024-04-30',
       });
@@ -129,7 +129,7 @@ describe('高度検索API', () => {
     });
 
     it('dateFrom > dateTo のとき空配列を返す', async () => {
-      const results = await searchMessages('keyword', {
+      const { items: results } = await searchMessages('keyword', {
         dateFrom: '2024-12-01',
         dateTo: '2024-01-01',
       });
@@ -137,7 +137,7 @@ describe('高度検索API', () => {
     });
 
     it('日付フォーマットが不正なとき全件返る（フィルタが無視される）', async () => {
-      const results = await searchMessages('keyword', { dateFrom: 'not-a-date' });
+      const { items: results } = await searchMessages('keyword', { dateFrom: 'not-a-date' });
       // 不正な日付は無視されるので全件（keyword を含む4件）が返る
       expect(results.length).toBeGreaterThanOrEqual(1);
     });
@@ -145,44 +145,44 @@ describe('高度検索API', () => {
 
   describe('ユーザー絞り込みフィルタ', () => {
     it('userId を指定すると該当ユーザーのメッセージのみ返る', async () => {
-      const results = await searchMessages('keyword', { userId: userId2 });
+      const { items: results } = await searchMessages('keyword', { userId: userId2 });
       expect(results).toHaveLength(1);
       expect(results[0].id).toBe(msgUser2);
       expect(results[0].userId).toBe(userId2);
     });
 
     it('存在しない userId を指定すると空配列を返す', async () => {
-      const results = await searchMessages('keyword', { userId: 99999 });
+      const { items: results } = await searchMessages('keyword', { userId: 99999 });
       expect(results).toHaveLength(0);
     });
 
     it('userId と q（キーワード）を同時に指定すると両方の条件でAND検索される', async () => {
-      const results = await searchMessages('bob', { userId: userId2 });
+      const { items: results } = await searchMessages('bob', { userId: userId2 });
       expect(results).toHaveLength(1);
       expect(results[0].id).toBe(msgUser2);
 
       // userId2 の投稿でもキーワードが不一致なら返らない
-      const results2 = await searchMessages('alice-only', { userId: userId2 });
+      const { items: results2 } = await searchMessages('alice-only', { userId: userId2 });
       expect(results2).toHaveLength(0);
     });
   });
 
   describe('添付ファイルフィルタ', () => {
     it('hasAttachment=true を指定すると添付ファイル付きメッセージのみ返る', async () => {
-      const results = await searchMessages('keyword', { hasAttachment: true });
+      const { items: results } = await searchMessages('keyword', { hasAttachment: true });
       expect(results).toHaveLength(1);
       expect(results[0].id).toBe(msgWithAttach);
     });
 
     it('hasAttachment=false を指定すると添付ファイルなしのメッセージのみ返る', async () => {
-      const results = await searchMessages('keyword', { hasAttachment: false });
+      const { items: results } = await searchMessages('keyword', { hasAttachment: false });
       const ids = results.map((r) => r.id);
       expect(ids).not.toContain(msgWithAttach);
       expect(ids.length).toBeGreaterThanOrEqual(1);
     });
 
     it('hasAttachment 未指定のとき添付ファイルの有無を問わず返る', async () => {
-      const results = await searchMessages('keyword', {});
+      const { items: results } = await searchMessages('keyword', {});
       const ids = results.map((r) => r.id);
       expect(ids).toContain(msgWithAttach);
       expect(ids).toContain(msgOld);
@@ -191,7 +191,7 @@ describe('高度検索API', () => {
 
   describe('複合フィルタ', () => {
     it('キーワード・日付範囲・userId・hasAttachment をすべて指定するとすべての条件でAND絞り込みされる', async () => {
-      const results = await searchMessages('keyword', {
+      const { items: results } = await searchMessages('keyword', {
         dateFrom: '2024-03-15',
         dateTo: '2024-04-30',
         userId: userId1,
@@ -202,7 +202,7 @@ describe('高度検索API', () => {
     });
 
     it('フィルタ条件が一致するメッセージが存在しないとき空配列を返す', async () => {
-      const results = await searchMessages('keyword', {
+      const { items: results } = await searchMessages('keyword', {
         dateFrom: '2025-01-01',
         dateTo: '2025-12-31',
       });
@@ -212,7 +212,7 @@ describe('高度検索API', () => {
 
   describe('レスポンス形式', () => {
     it('結果には channelName・username・createdAt・attachments が含まれる', async () => {
-      const results = await searchMessages('keyword', { hasAttachment: true });
+      const { items: results } = await searchMessages('keyword', { hasAttachment: true });
       expect(results).toHaveLength(1);
       const r = results[0];
       expect(r.channelName).toBe('general');
@@ -223,7 +223,7 @@ describe('高度検索API', () => {
     });
 
     it('結果は createdAt 降順で返る', async () => {
-      const results = await searchMessages('keyword', {});
+      const { items: results } = await searchMessages('keyword', {});
       for (let i = 1; i < results.length; i++) {
         expect(new Date(results[i - 1].createdAt).getTime()).toBeGreaterThanOrEqual(
           new Date(results[i].createdAt).getTime(),
@@ -234,7 +234,7 @@ describe('高度検索API', () => {
     it('q パラメータが空文字のとき空配列を返す（キーワード必須）', async () => {
       // サービス層では空文字キーワードで全件ヒットするが、コントローラーが400を返す
       // ここではサービス層に空文字を渡した場合の挙動を確認（全件返ってもよい）
-      const results = await searchMessages('', {});
+      const { items: results } = await searchMessages('', {});
       // 空キーワードの場合は0件以上（実装依存）
       expect(Array.isArray(results)).toBe(true);
     });
@@ -279,7 +279,7 @@ describe('高度検索API', () => {
 
     describe('単一タグ指定', () => {
       it('tagIds=[tagA] を指定すると tagA が付与されたメッセージのみ返る', async () => {
-        const results = await searchMessages('keyword', { tagIds: [tagIdA] });
+        const { items: results } = await searchMessages('keyword', { tagIds: [tagIdA] });
         const ids = results.map((r) => r.id);
         expect(ids).toContain(msgOld);
         expect(ids).toContain(msgNew);
@@ -288,21 +288,21 @@ describe('高度検索API', () => {
       });
 
       it('指定した tagId がどのメッセージにも紐づいていないとき空配列を返す', async () => {
-        const results = await searchMessages('keyword', { tagIds: [999999] });
+        const { items: results } = await searchMessages('keyword', { tagIds: [999999] });
         expect(results).toHaveLength(0);
       });
     });
 
     describe('複数タグ指定', () => {
       it('tagIds=[tagA, tagB] を指定すると両方付与されたメッセージのみ返る (AND 条件)', async () => {
-        const results = await searchMessages('keyword', { tagIds: [tagIdA, tagIdB] });
+        const { items: results } = await searchMessages('keyword', { tagIds: [tagIdA, tagIdB] });
         const ids = results.map((r) => r.id);
         // 両方付与されているのは msgNew のみ
         expect(ids).toEqual([msgNew]);
       });
 
       it('片方のタグしか付いていないメッセージは除外される', async () => {
-        const results = await searchMessages('keyword', { tagIds: [tagIdA, tagIdB] });
+        const { items: results } = await searchMessages('keyword', { tagIds: [tagIdA, tagIdB] });
         const ids = results.map((r) => r.id);
         expect(ids).not.toContain(msgOld); // tagA のみ
         expect(ids).not.toContain(msgUser2); // tagB のみ
@@ -313,7 +313,7 @@ describe('高度検索API', () => {
       it('tagIds と dateFrom/dateTo を併用するとすべての条件で AND 絞り込みされる', async () => {
         // tagA は msgOld(2024-01-15) と msgNew(2024-06-01) に付与
         // dateFrom=2024-04-01 で msgNew のみ残る
-        const results = await searchMessages('keyword', {
+        const { items: results } = await searchMessages('keyword', {
           tagIds: [tagIdA],
           dateFrom: '2024-04-01',
         });
@@ -324,7 +324,7 @@ describe('高度検索API', () => {
 
       it('tagIds と userId を併用するとタグ付き かつ 指定ユーザー投稿のみ返る', async () => {
         // tagB は msgNew(userId1) と msgUser2(userId2) に付与
-        const results = await searchMessages('keyword', {
+        const { items: results } = await searchMessages('keyword', {
           tagIds: [tagIdB],
           userId: userId2,
         });
@@ -335,7 +335,7 @@ describe('高度検索API', () => {
       it('tagIds と q (キーワード) を併用すると両方に一致するメッセージのみ返る', async () => {
         // tagA は msgOld('keyword old message') と msgNew('keyword new message')
         // q='old' で msgOld のみ
-        const results = await searchMessages('old', { tagIds: [tagIdA] });
+        const { items: results } = await searchMessages('old', { tagIds: [tagIdA] });
         const ids = results.map((r) => r.id);
         expect(ids).toEqual([msgOld]);
       });
@@ -343,7 +343,7 @@ describe('高度検索API', () => {
 
     describe('レスポンス整合', () => {
       it('結果の各メッセージに tags: Tag[] が含まれる (bulk fetch 結果)', async () => {
-        const results = await searchMessages('keyword', { tagIds: [tagIdA] });
+        const { items: results } = await searchMessages('keyword', { tagIds: [tagIdA] });
         expect(results.length).toBeGreaterThan(0);
         for (const msg of results) {
           expect(Array.isArray(msg.tags)).toBe(true);

--- a/packages/server/src/__tests__/audit-log.test.ts
+++ b/packages/server/src/__tests__/audit-log.test.ts
@@ -22,7 +22,7 @@
  * - API: GET /api/admin/audit-logs
  *   - requireAdmin ミドルウェア配下
  *   - Queryパラメータ: action_type, actor_user_id, from, to, limit, offset
- *   - レスポンス: { logs: AuditLog[], total: number }
+ *   - レスポンス: { items: AuditLog[], total: number }
  *
  * 戦略: pg-mem のインメモリ PostgreSQL 互換 DB + supertest で検証。
  */
@@ -303,7 +303,7 @@ describe('GET /api/admin/audit-logs', () => {
       const token = await seedManyAndAdmin();
       const res = await request(app).get('/api/admin/audit-logs').set('Cookie', `token=${token}`);
       expect(res.status).toBe(200);
-      expect((res.body as { logs: unknown[] }).logs).toHaveLength(50);
+      expect((res.body as { items: unknown[] }).items).toHaveLength(50);
       expect((res.body as { total: number }).total).toBe(55);
     });
 
@@ -313,7 +313,7 @@ describe('GET /api/admin/audit-logs', () => {
         .get('/api/admin/audit-logs?limit=5')
         .set('Cookie', `token=${token}`);
       expect(res.status).toBe(200);
-      expect((res.body as { logs: unknown[] }).logs).toHaveLength(5);
+      expect((res.body as { items: unknown[] }).items).toHaveLength(5);
     });
 
     it('offset クエリでオフセットを制御できる', async () => {
@@ -322,7 +322,7 @@ describe('GET /api/admin/audit-logs', () => {
         .get('/api/admin/audit-logs?limit=10&offset=50')
         .set('Cookie', `token=${token}`);
       expect(res.status).toBe(200);
-      expect((res.body as { logs: unknown[] }).logs).toHaveLength(5); // 55-50=5
+      expect((res.body as { items: unknown[] }).items).toHaveLength(5); // 55-50=5
     });
 
     it('limit が上限（200）を超える場合は 400 を返す', async () => {
@@ -355,7 +355,7 @@ describe('GET /api/admin/audit-logs', () => {
         .set('Cookie', `token=${token}`);
       expect(res.status).toBe(200);
       expect((res.body as { total: number }).total).toBe(1);
-      expect((res.body as { logs: { actionType: string }[] }).logs[0].actionType).toBe(
+      expect((res.body as { items: { actionType: string }[] }).items[0].actionType).toBe(
         'channel.create',
       );
     });
@@ -421,10 +421,8 @@ describe('GET /api/admin/audit-logs', () => {
         "INSERT INTO audit_logs (actor_user_id, action_type, target_type, target_id, metadata) VALUES ($1, 'channel.create', 'channel', 10, '{\"name\":\"x\"}')",
         [userId],
       );
-      const res = await request(app)
-        .get('/api/admin/audit-logs')
-        .set('Cookie', `token=${token}`);
-      const log = (res.body as { logs: Record<string, unknown>[] }).logs[0];
+      const res = await request(app).get('/api/admin/audit-logs').set('Cookie', `token=${token}`);
+      const log = (res.body as { items: Record<string, unknown>[] }).items[0];
       expect(log).toHaveProperty('id');
       expect(log).toHaveProperty('actorUserId');
       expect(log).toHaveProperty('actorUsername');
@@ -454,12 +452,12 @@ describe('GET /api/admin/audit-logs', () => {
       );
       await testDb.execute('DELETE FROM users WHERE id = $1', [ghost]);
 
-      const res = await request(app)
-        .get('/api/admin/audit-logs')
-        .set('Cookie', `token=${token}`);
-      const log = (res.body as {
-        logs: { actorUserId: number | null; actorUsername: string | null }[];
-      }).logs.find((l) => l.actorUserId === null);
+      const res = await request(app).get('/api/admin/audit-logs').set('Cookie', `token=${token}`);
+      const log = (
+        res.body as {
+          items: { actorUserId: number | null; actorUsername: string | null }[];
+        }
+      ).items.find((l) => l.actorUserId === null);
       expect(log).toBeDefined();
       expect(log!.actorUsername).toBeNull();
     });
@@ -480,16 +478,20 @@ describe('既存操作からの監査ログ記録（横断的動作）', () => {
   describe('認証系（authController）', () => {
     it('POST /api/auth/login 成功時に auth.login が actor=ログインユーザー で記録される', async () => {
       const suffix = `login_${Date.now()}`;
-      await request(app).post('/api/auth/register').send({
-        username: `u_${suffix}`,
-        email: `u_${suffix}@example.com`,
-        password: 'password123',
-      });
+      await request(app)
+        .post('/api/auth/register')
+        .send({
+          username: `u_${suffix}`,
+          email: `u_${suffix}@example.com`,
+          password: 'password123',
+        });
       await clearAuditLogs(); // register 時の記録分は無視して login のみ観察
-      const res = await request(app).post('/api/auth/login').send({
-        email: `u_${suffix}@example.com`,
-        password: 'password123',
-      });
+      const res = await request(app)
+        .post('/api/auth/login')
+        .send({
+          email: `u_${suffix}@example.com`,
+          password: 'password123',
+        });
       expect(res.status).toBe(200);
       const logs = await testDb.query<{ action_type: string; actor_user_id: number }>(
         'SELECT action_type, actor_user_id FROM audit_logs',
@@ -743,5 +745,91 @@ describe('既存操作からの監査ログ記録（横断的動作）', () => {
       );
       expect(row!.target_id).toBe(chId);
     });
+  });
+});
+
+// #375 ページング仕様統一（オフセット系 { items, total, limit, offset }）
+// 注: サービス層 listAuditLogs の戻り値（{ logs, total }）は変更せず、
+//     HTTP レスポンスのみコントローラで { items, total, limit, offset } に詰め替える。
+describe('GET /api/admin/audit-logs ページング統一（#375）', () => {
+  beforeEach(async () => {
+    await clearAuditLogs();
+  });
+
+  async function seedAndAdmin(count: number): Promise<string> {
+    const { token, userId } = await registerUser(
+      app,
+      `pg375_${Date.now()}_${Math.random()}`,
+      `pg375_${Date.now()}_${Math.random()}@example.com`,
+    );
+    await makeAdmin(userId);
+    for (let i = 0; i < count; i++) {
+      await testDb.execute(
+        "INSERT INTO audit_logs (actor_user_id, action_type) VALUES ($1, 'auth.login')",
+        [userId],
+      );
+    }
+    return token;
+  }
+
+  it('レスポンスが { items, total, limit, offset } 形式で返る（旧 { logs } から変更）', async () => {
+    const token = await seedAndAdmin(3);
+    const res = await request(app).get('/api/admin/audit-logs').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body).not.toHaveProperty('logs');
+    expect(typeof res.body.total).toBe('number');
+    expect(typeof res.body.limit).toBe('number');
+    expect(typeof res.body.offset).toBe('number');
+  });
+
+  it('items が旧 logs 配列と同じ監査ログを保持する', async () => {
+    const token = await seedAndAdmin(3);
+    const res = await request(app).get('/api/admin/audit-logs').set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(3);
+    expect(res.body.items[0].actionType).toBe('auth.login');
+  });
+
+  it('total はフィルタ適用後の総件数を表す', async () => {
+    const token = await seedAndAdmin(7);
+    const res = await request(app)
+      .get('/api/admin/audit-logs?limit=2')
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.total).toBe(7);
+  });
+
+  it('レスポンスの limit / offset がリクエスト値（既定値含む）を反映する', async () => {
+    const token = await seedAndAdmin(5);
+
+    const def = await request(app).get('/api/admin/audit-logs').set('Cookie', `token=${token}`);
+    expect(def.body.limit).toBe(50);
+    expect(def.body.offset).toBe(0);
+
+    const paged = await request(app)
+      .get('/api/admin/audit-logs?limit=2&offset=2')
+      .set('Cookie', `token=${token}`);
+    expect(paged.body.limit).toBe(2);
+    expect(paged.body.offset).toBe(2);
+  });
+
+  it('offset を進めると前ページと重複しない次ページが取得できる', async () => {
+    const token = await seedAndAdmin(6);
+
+    const page1 = await request(app)
+      .get('/api/admin/audit-logs?limit=2&offset=0')
+      .set('Cookie', `token=${token}`);
+    const page2 = await request(app)
+      .get('/api/admin/audit-logs?limit=2&offset=2')
+      .set('Cookie', `token=${token}`);
+
+    const ids1 = (page1.body.items as { id: number }[]).map((l) => l.id);
+    const ids2 = (page2.body.items as { id: number }[]).map((l) => l.id);
+    expect(ids1).toHaveLength(2);
+    expect(ids2).toHaveLength(2);
+    expect(ids1.some((id) => ids2.includes(id))).toBe(false);
   });
 });

--- a/packages/server/src/__tests__/channel-archive.test.ts
+++ b/packages/server/src/__tests__/channel-archive.test.ts
@@ -104,9 +104,11 @@ describe('チャンネルアーカイブ: サービス層', () => {
       const { userId } = await registerUser(app, 'user1', 'user1@example.com');
       const channelId = await createChannelViaService('ch-unarchive-2', userId);
 
-      await expect(channelService.unarchiveChannel(channelId, userId, false)).rejects.toMatchObject({
-        statusCode: 409,
-      });
+      await expect(channelService.unarchiveChannel(channelId, userId, false)).rejects.toMatchObject(
+        {
+          statusCode: 409,
+        },
+      );
     });
 
     it('作成者以外によるアーカイブ解除はエラーになる（403相当）', async () => {
@@ -129,7 +131,9 @@ describe('チャンネルアーカイブ: サービス層', () => {
       const channelId = await createChannelViaService('ch-unarchive-4', owner);
       await channelService.archiveChannel(channelId, owner, false);
 
-      await expect(channelService.unarchiveChannel(channelId, adminId, true)).resolves.not.toThrow();
+      await expect(
+        channelService.unarchiveChannel(channelId, adminId, true),
+      ).resolves.not.toThrow();
 
       const channel = await channelService.getChannelById(channelId);
       expect(channel?.isArchived).toBe(false);
@@ -216,14 +220,13 @@ describe('チャンネルアーカイブ: サービス層', () => {
         [owner],
       );
       const privateChannelId = row!.id;
-      await testDb.execute(
-        'INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)',
-        [privateChannelId, owner],
-      );
-      await testDb.execute(
-        'UPDATE channels SET is_archived = true WHERE id = $1',
-        [privateChannelId],
-      );
+      await testDb.execute('INSERT INTO channel_members (channel_id, user_id) VALUES ($1, $2)', [
+        privateChannelId,
+        owner,
+      ]);
+      await testDb.execute('UPDATE channels SET is_archived = true WHERE id = $1', [
+        privateChannelId,
+      ]);
 
       const memberArchived = await channelService.getArchivedChannels(owner);
       const nonMemberArchived = await channelService.getArchivedChannels(nonMember);
@@ -287,9 +290,7 @@ describe('REST API: PATCH /api/channels/:id/archive（アーカイブ）', () =>
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
     const channelId = await createChannelReq(app, token, 'ch-api-archive-3');
 
-    await request(app)
-      .patch(`/api/channels/${channelId}/archive`)
-      .set('Cookie', `token=${token}`);
+    await request(app).patch(`/api/channels/${channelId}/archive`).set('Cookie', `token=${token}`);
 
     const res = await request(app)
       .patch(`/api/channels/${channelId}/archive`)
@@ -300,7 +301,11 @@ describe('REST API: PATCH /api/channels/:id/archive（アーカイブ）', () =>
 
   it('管理者（admin）は他者のチャンネルをアーカイブできる（200が返る）', async () => {
     const { token: ownerToken } = await registerUser(app, 'owner2', 'owner2@example.com');
-    const { token: adminToken, userId: adminId } = await registerUser(app, 'admin1', 'admin1@example.com');
+    const { token: adminToken, userId: adminId } = await registerUser(
+      app,
+      'admin1',
+      'admin1@example.com',
+    );
     await testDb.execute("UPDATE users SET role = 'admin' WHERE id = $1", [adminId]);
 
     const channelId = await createChannelReq(app, ownerToken, 'ch-api-archive-4');
@@ -323,9 +328,7 @@ describe('REST API: DELETE /api/channels/:id/archive（アーカイブ解除）'
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
     const channelId = await createChannelReq(app, token, 'ch-api-unarchive-1');
 
-    await request(app)
-      .patch(`/api/channels/${channelId}/archive`)
-      .set('Cookie', `token=${token}`);
+    await request(app).patch(`/api/channels/${channelId}/archive`).set('Cookie', `token=${token}`);
 
     const res = await request(app)
       .delete(`/api/channels/${channelId}/archive`)
@@ -387,9 +390,7 @@ describe('REST API: GET /api/channels/archived（アーカイブ一覧）', () =
   it('認証済みユーザーにアーカイブ済みチャンネル一覧を返す（200）', async () => {
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
 
-    const res = await request(app)
-      .get('/api/channels/archived')
-      .set('Cookie', `token=${token}`);
+    const res = await request(app).get('/api/channels/archived').set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body.channels)).toBe(true);
@@ -404,15 +405,11 @@ describe('REST API: GET /api/channels/archived（アーカイブ一覧）', () =
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
     const channelId = await createChannelReq(app, token, 'ch-archived-api-1');
 
-    await request(app)
-      .patch(`/api/channels/${channelId}/archive`)
-      .set('Cookie', `token=${token}`);
+    await request(app).patch(`/api/channels/${channelId}/archive`).set('Cookie', `token=${token}`);
 
     await createChannelReq(app, token, 'ch-active-api-1');
 
-    const res = await request(app)
-      .get('/api/channels/archived')
-      .set('Cookie', `token=${token}`);
+    const res = await request(app).get('/api/channels/archived').set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
     const channels = res.body.channels as { isArchived: boolean }[];
@@ -436,12 +433,18 @@ describe('REST API: GET /api/channels/archived（アーカイブ一覧）', () =
       .get('/api/channels/archived')
       .set('Cookie', `token=${ownerToken}`);
 
-    expect(memberRes.body.channels.some((ch: { id: number }) => ch.id === privateChannelId)).toBe(true);
+    expect(memberRes.body.channels.some((ch: { id: number }) => ch.id === privateChannelId)).toBe(
+      true,
+    );
   });
 
   it('プライベートかつアーカイブ済みのチャンネルは非メンバーには返らない', async () => {
     const { token: ownerToken } = await registerUser(app, 'owner7', 'owner7@example.com');
-    const { token: nonMemberToken } = await registerUser(app, 'nonmember2', 'nonmember2@example.com');
+    const { token: nonMemberToken } = await registerUser(
+      app,
+      'nonmember2',
+      'nonmember2@example.com',
+    );
 
     const createRes = await request(app)
       .post('/api/channels')
@@ -457,7 +460,9 @@ describe('REST API: GET /api/channels/archived（アーカイブ一覧）', () =
       .get('/api/channels/archived')
       .set('Cookie', `token=${nonMemberToken}`);
 
-    expect(nonMemberRes.body.channels.some((ch: { id: number }) => ch.id === privateChannelId)).toBe(false);
+    expect(
+      nonMemberRes.body.channels.some((ch: { id: number }) => ch.id === privateChannelId),
+    ).toBe(false);
   });
 });
 
@@ -475,25 +480,21 @@ describe('REST API: アーカイブ済みチャンネルへのメッセージ送
     const channelId = await createChannelReq(app, token, 'ch-msg-read-archived');
 
     await insertMessage(channelId, userId, 'テストメッセージ');
-    await request(app)
-      .patch(`/api/channels/${channelId}/archive`)
-      .set('Cookie', `token=${token}`);
+    await request(app).patch(`/api/channels/${channelId}/archive`).set('Cookie', `token=${token}`);
 
     const res = await request(app)
       .get(`/api/channels/${channelId}/messages`)
       .set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body.messages)).toBe(true);
+    expect(Array.isArray(res.body.items)).toBe(true);
   });
 
   it('アーカイブ済みチャンネルへのメッセージ送信（HTTP POST）は 403 を返す', async () => {
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
     const channelId = await createChannelReq(app, token, 'ch-msg-send-archived');
 
-    await request(app)
-      .patch(`/api/channels/${channelId}/archive`)
-      .set('Cookie', `token=${token}`);
+    await request(app).patch(`/api/channels/${channelId}/archive`).set('Cookie', `token=${token}`);
 
     const res = await request(app)
       .post(`/api/channels/${channelId}/messages`)
@@ -529,9 +530,7 @@ describe('Channel 型: is_archived フィールド境界条件', () => {
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
     await createChannelReq(app, token, 'ch-type-check-1');
 
-    const res = await request(app)
-      .get('/api/channels')
-      .set('Cookie', `token=${token}`);
+    const res = await request(app).get('/api/channels').set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
     const channels = res.body.channels as { isArchived?: boolean }[];
@@ -543,13 +542,9 @@ describe('Channel 型: is_archived フィールド境界条件', () => {
     const { token } = await registerUser(app, 'user1', 'user1@example.com');
     const channelId = await createChannelReq(app, token, 'ch-type-check-2');
 
-    await request(app)
-      .patch(`/api/channels/${channelId}/archive`)
-      .set('Cookie', `token=${token}`);
+    await request(app).patch(`/api/channels/${channelId}/archive`).set('Cookie', `token=${token}`);
 
-    const res = await request(app)
-      .get('/api/channels/archived')
-      .set('Cookie', `token=${token}`);
+    const res = await request(app).get('/api/channels/archived').set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
     const channels = res.body.channels as { isArchived: boolean }[];

--- a/packages/server/src/__tests__/integration/messageController.test.ts
+++ b/packages/server/src/__tests__/integration/messageController.test.ts
@@ -30,9 +30,9 @@ describe('GET /api/channels/:channelId/messages', () => {
       .set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body.messages)).toBe(true);
-    expect(res.body.messages.length).toBeGreaterThan(0);
-    expect(res.body.messages[0].content).toBe('テストメッセージ');
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body.items.length).toBeGreaterThan(0);
+    expect(res.body.items[0].content).toBe('テストメッセージ');
   });
 
   it('正常: limit パラメータで件数を絞り込める', async () => {
@@ -47,7 +47,7 @@ describe('GET /api/channels/:channelId/messages', () => {
       .set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.messages.length).toBe(3);
+    expect(res.body.items.length).toBe(3);
   });
 
   it('正常: before パラメータで指定ID以前のメッセージが返る（ページネーション）', async () => {
@@ -61,7 +61,7 @@ describe('GET /api/channels/:channelId/messages', () => {
       .set('Cookie', `token=${token}`);
 
     expect(res.status).toBe(200);
-    const ids = (res.body.messages as { id: number }[]).map((m) => m.id);
+    const ids = (res.body.items as { id: number }[]).map((m) => m.id);
     expect(ids).toContain(id1);
     expect(ids).not.toContain(id2);
   });
@@ -91,7 +91,8 @@ describe('PUT /api/messages/:id', () => {
 
   it('正常: mentionedUserIds を更新できる', async () => {
     const { token, userId } = await registerUser(app, 'msg_edit2', 'msg_edit2@example.com');
-    const { userId: mentionedId } = await registerUser(app,
+    const { userId: mentionedId } = await registerUser(
+      app,
       'msg_edit2_target',
       'msg_edit2_target@example.com',
     );
@@ -122,11 +123,13 @@ describe('PUT /api/messages/:id', () => {
   });
 
   it('異常: 他人のメッセージを編集しようとすると403が返る', async () => {
-    const { token: ownerToken, userId: ownerId } = await registerUser(app,
+    const { token: ownerToken, userId: ownerId } = await registerUser(
+      app,
       'msg_edit4_owner',
       'msg_edit4_owner@example.com',
     );
-    const { token: otherToken } = await registerUser(app,
+    const { token: otherToken } = await registerUser(
+      app,
       'msg_edit4_other',
       'msg_edit4_other@example.com',
     );
@@ -162,11 +165,13 @@ describe('DELETE /api/messages/:id', () => {
   });
 
   it('異常: 他人のメッセージを削除しようとすると403が返る', async () => {
-    const { token: ownerToken, userId: ownerId } = await registerUser(app,
+    const { token: ownerToken, userId: ownerId } = await registerUser(
+      app,
       'msg_del2_owner',
       'msg_del2_owner@example.com',
     );
-    const { token: otherToken } = await registerUser(app,
+    const { token: otherToken } = await registerUser(
+      app,
       'msg_del2_other',
       'msg_del2_other@example.com',
     );
@@ -184,5 +189,103 @@ describe('DELETE /api/messages/:id', () => {
     const res = await request(app).delete('/api/messages/1');
 
     expect(res.status).toBe(401);
+  });
+});
+
+// #375 ページング仕様統一（カーソル系 { items, nextCursor, hasMore }）
+// 対象: GET /api/channels/:channelId/messages
+// 注: サービス層 getChannelMessages（Message[] を返す）は変更せず、
+//     コントローラで limit+1 件取得して hasMore / nextCursor を導出する。
+describe('GET /api/channels/:channelId/messages カーソルページング（#375）', () => {
+  // n 件のメッセージを持つチャンネルを用意する（戻り値: token, channelId, 挿入順の id 配列）
+  async function seedChannel(prefix: string, count: number) {
+    const { token, userId } = await registerUser(app, prefix, `${prefix}@example.com`);
+    const channelId = await createChannelReq(app, token, `${prefix}-ch`);
+    const ids: number[] = [];
+    for (let i = 0; i < count; i++) {
+      ids.push(await insertMessage(channelId, userId, `${prefix}-msg-${i}`));
+    }
+    return { token, channelId, ids };
+  }
+
+  it('レスポンスが { items, nextCursor, hasMore } 形式で返る（旧 { messages } から変更）', async () => {
+    const { token, channelId } = await seedChannel('cur1', 3);
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/messages`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('messages');
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body).toHaveProperty('nextCursor');
+    expect(typeof res.body.hasMore).toBe('boolean');
+  });
+
+  it('items が時系列昇順のメッセージ配列を保持する', async () => {
+    const { token, channelId, ids } = await seedChannel('cur2', 3);
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/messages`)
+      .set('Cookie', `token=${token}`);
+
+    const returnedIds = (res.body.items as { id: number }[]).map((m) => m.id);
+    expect(returnedIds).toEqual(ids);
+  });
+
+  it('続きがある場合 hasMore=true かつ nextCursor に次の before 値が入る', async () => {
+    const { token, channelId } = await seedChannel('cur3', 5);
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/messages?limit=2`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(true);
+    // nextCursor は現在表示中の最古メッセージ ID（= items[0].id）
+    expect(res.body.nextCursor).toBe(String((res.body.items as { id: number }[])[0].id));
+  });
+
+  it('最古まで読み込むと hasMore=false かつ nextCursor=null になる', async () => {
+    const { token, channelId } = await seedChannel('cur4', 2);
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/messages?limit=50`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('nextCursor を before に渡すと重複なく続き（より古いメッセージ）を取得できる', async () => {
+    const { token, channelId } = await seedChannel('cur5', 5);
+
+    const page1 = await request(app)
+      .get(`/api/channels/${channelId}/messages?limit=2`)
+      .set('Cookie', `token=${token}`);
+    const cursor = page1.body.nextCursor as string;
+
+    const page2 = await request(app)
+      .get(`/api/channels/${channelId}/messages?limit=2&before=${cursor}`)
+      .set('Cookie', `token=${token}`);
+
+    const ids1 = (page1.body.items as { id: number }[]).map((m) => m.id);
+    const ids2 = (page2.body.items as { id: number }[]).map((m) => m.id);
+    expect(ids1.some((id) => ids2.includes(id))).toBe(false);
+    // page2 は page1 より古いメッセージ（より小さい ID）
+    expect(Math.max(...ids2)).toBeLessThan(Math.min(...ids1));
+  });
+
+  it('メッセージ件数が limit 未満のチャンネルは hasMore=false / nextCursor=null', async () => {
+    const { token, channelId } = await seedChannel('cur6', 2);
+
+    const res = await request(app)
+      .get(`/api/channels/${channelId}/messages?limit=10`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.nextCursor).toBeNull();
   });
 });

--- a/packages/server/src/__tests__/integration/search.test.ts
+++ b/packages/server/src/__tests__/integration/search.test.ts
@@ -33,9 +33,9 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.messages)).toBe(true);
-      expect(res.body.messages).toHaveLength(1);
-      expect(res.body.messages[0].content).toContain('ハローワールド');
+      expect(Array.isArray(res.body.items)).toBe(true);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].content).toContain('ハローワールド');
     });
 
     it('複数チャンネルをまたいで検索できる', async () => {
@@ -50,7 +50,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(2);
+      expect(res.body.items).toHaveLength(2);
     });
 
     it('検索結果にチャンネル名が含まれる', async () => {
@@ -63,7 +63,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages[0].channelName).toBe('search-ch3');
+      expect(res.body.items[0].channelName).toBe('search-ch3');
     });
 
     it('削除済みメッセージは検索結果に含まれない', async () => {
@@ -77,7 +77,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(0);
+      expect(res.body.items).toHaveLength(0);
     });
 
     it('一致するメッセージがない場合は空配列を返す', async () => {
@@ -88,7 +88,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(0);
+      expect(res.body.items).toHaveLength(0);
     });
   });
 
@@ -134,8 +134,8 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(1);
-      expect(res.body.messages[0].id).toBe(taggedMsg);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].id).toBe(taggedMsg);
     });
 
     it('q が空でも userId が指定されていれば 200 を返す', async () => {
@@ -150,7 +150,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      const ids = (res.body.messages as { id: number }[]).map((m) => m.id);
+      const ids = (res.body.items as { id: number }[]).map((m) => m.id);
       expect(ids).toContain(myMsg);
     });
 
@@ -162,7 +162,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.messages)).toBe(true);
+      expect(Array.isArray(res.body.items)).toBe(true);
     });
 
     it('q が空でも hasAttachment が指定されていれば 200 を返す', async () => {
@@ -173,7 +173,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.messages)).toBe(true);
+      expect(Array.isArray(res.body.items)).toBe(true);
     });
 
     // Step 7c-1: in:channel 構文サポートのため channelId フィルタを追加
@@ -185,7 +185,7 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.messages)).toBe(true);
+      expect(Array.isArray(res.body.items)).toBe(true);
     });
 
     it('channelId フィルタで指定したチャンネルのメッセージのみ返る', async () => {
@@ -200,9 +200,9 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      const ids = (res.body.messages as { id: number }[]).map((m) => m.id);
+      const ids = (res.body.items as { id: number }[]).map((m) => m.id);
       expect(ids).toContain(msg1);
-      expect(res.body.messages).toHaveLength(1);
+      expect(res.body.items).toHaveLength(1);
     });
 
     it('channelId + q の組み合わせで keyword + チャンネル絞り込みが効く', async () => {
@@ -218,8 +218,8 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(1);
-      expect(res.body.messages[0].id).toBe(target);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].id).toBe(target);
     });
   });
 
@@ -248,8 +248,8 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${aliceToken}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(1);
-      expect(res.body.messages[0].id).toBe(msgToAlice);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].id).toBe(msgToAlice);
     });
 
     it('unreadOnly=true で未読メンションのみが返される', async () => {
@@ -278,8 +278,8 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${aliceToken}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(1);
-      expect(res.body.messages[0].id).toBe(unreadMsg);
+      expect(res.body.items).toHaveLength(1);
+      expect(res.body.items[0].id).toBe(unreadMsg);
     });
 
     it('他人宛のメンションは mentionedToMe=true で返らない', async () => {
@@ -308,7 +308,133 @@ describe('GET /api/messages/search', () => {
         .set('Cookie', `token=${aliceToken}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.messages).toHaveLength(0);
+      expect(res.body.items).toHaveLength(0);
+    });
+  });
+
+  // #375 ページング仕様統一（オフセット系 { items, total, limit, offset }）
+  describe('ページング（オフセット系 #375）', () => {
+    // 同一キーワードを含むメッセージを n 件用意するヘルパ
+    async function seedMessages(prefix: string, keyword: string, count: number) {
+      const { token, userId } = await registerUser(app, prefix, `${prefix}@example.com`);
+      const channelId = await createChannelReq(app, token, `${prefix}-ch`);
+      for (let i = 0; i < count; i++) {
+        await insertMessage(channelId, userId, `${keyword}-${i}`);
+      }
+      return { token };
+    }
+
+    it('レスポンスが { items, total, limit, offset } 形式で返る', async () => {
+      const { token } = await seedMessages('pg1', 'ページング検索', 3);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('ページング検索')}`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.items)).toBe(true);
+      expect(typeof res.body.total).toBe('number');
+      expect(typeof res.body.limit).toBe('number');
+      expect(typeof res.body.offset).toBe('number');
+    });
+
+    it('items が旧 messages 配列と同じ検索結果を保持する', async () => {
+      const { token } = await seedMessages('pg2', 'アイテム保持', 2);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('アイテム保持')}`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.body.items).toHaveLength(2);
+      expect(res.body.items[0].content).toContain('アイテム保持');
+    });
+
+    it('total はフィルタ適用後の総件数を表す（limit で切られても全件数）', async () => {
+      const { token } = await seedMessages('pg3', 'トータル件数', 5);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('トータル件数')}&limit=2`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.items).toHaveLength(2);
+      expect(res.body.total).toBe(5);
+    });
+
+    it('limit / offset 未指定時は既定値（limit=既定, offset=0）が適用される', async () => {
+      const { token } = await seedMessages('pg4', '既定値検索', 3);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('既定値検索')}`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.body.limit).toBe(50);
+      expect(res.body.offset).toBe(0);
+    });
+
+    it('limit でページサイズを制限でき items が limit 件以内になる', async () => {
+      const { token } = await seedMessages('pg5', '上限制限', 4);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('上限制限')}&limit=2`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.body.items.length).toBeLessThanOrEqual(2);
+      expect(res.body.limit).toBe(2);
+    });
+
+    it('offset を進めると前ページと重複しない次ページが取得できる', async () => {
+      const { token } = await seedMessages('pg6', '重複なしページ', 5);
+      const kw = encodeURIComponent('重複なしページ');
+
+      const page1 = await request(app)
+        .get(`/api/messages/search?q=${kw}&limit=2&offset=0`)
+        .set('Cookie', `token=${token}`);
+      const page2 = await request(app)
+        .get(`/api/messages/search?q=${kw}&limit=2&offset=2`)
+        .set('Cookie', `token=${token}`);
+
+      const ids1 = (page1.body.items as { id: number }[]).map((m) => m.id);
+      const ids2 = (page2.body.items as { id: number }[]).map((m) => m.id);
+      expect(ids1).toHaveLength(2);
+      expect(ids2).toHaveLength(2);
+      expect(ids1.some((id) => ids2.includes(id))).toBe(false);
+    });
+
+    it('offset が total を超える場合は items が空配列で total は維持される', async () => {
+      const { token } = await seedMessages('pg7', '範囲外オフセット', 3);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('範囲外オフセット')}&offset=100`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.body.items).toHaveLength(0);
+      expect(res.body.total).toBe(3);
+    });
+
+    it('limit は上限値を超えるとサーバ側でクランプされる', async () => {
+      const { token } = await seedMessages('pg8', 'クランプ検索', 1);
+
+      const res = await request(app)
+        .get(`/api/messages/search?q=${encodeURIComponent('クランプ検索')}&limit=9999`)
+        .set('Cookie', `token=${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.limit).toBe(100);
+    });
+
+    it('limit / offset が数値以外・負数の場合は 400 を返す', async () => {
+      const { token } = await registerUser(app, 'pg9', 'pg9@example.com');
+
+      const badLimit = await request(app)
+        .get('/api/messages/search?q=test&limit=abc')
+        .set('Cookie', `token=${token}`);
+      expect(badLimit.status).toBe(400);
+
+      const negativeOffset = await request(app)
+        .get('/api/messages/search?q=test&offset=-1')
+        .set('Cookie', `token=${token}`);
+      expect(negativeOffset.status).toBe(400);
     });
   });
 });

--- a/packages/server/src/__tests__/threadReply.test.ts
+++ b/packages/server/src/__tests__/threadReply.test.ts
@@ -146,20 +146,20 @@ describe('searchMessages（スレッド対応）', () => {
   });
 
   it('スレッド返信も検索対象に含まれる', async () => {
-    const results = await searchMessages('検索対象');
+    const { items: results } = await searchMessages('検索対象');
     expect(results.length).toBeGreaterThan(0);
     expect(results.some((r: Message) => r.rootMessageId === rootId)).toBe(true);
   });
 
   it('スレッド返信の結果に rootMessageContent が付与される', async () => {
-    const results = await searchMessages('検索対象');
+    const { items: results } = await searchMessages('検索対象');
     const reply = results.find((r: Message) => r.rootMessageId === rootId);
     expect(reply).toBeDefined();
     expect(reply!.rootMessageContent).not.toBeNull();
   });
 
   it('ルートメッセージの検索結果には rootMessageContent が null になる', async () => {
-    const results = await searchMessages('ルートメッセージ');
+    const { items: results } = await searchMessages('ルートメッセージ');
     const root = results.find((r: Message) => r.id === rootId);
     expect(root).toBeDefined();
     expect(root!.rootMessageContent).toBeNull();

--- a/packages/server/src/controllers/adminController.ts
+++ b/packages/server/src/controllers/adminController.ts
@@ -369,7 +369,8 @@ export async function getAuditLogs(
       limit: rawLimit,
       offset: rawOffset,
     });
-    res.json(result);
+    // #375 ページング標準仕様（オフセット系）: { items, total, limit, offset }
+    res.json({ items: result.logs, total: result.total, limit: rawLimit, offset: rawOffset });
   } catch (err) {
     next(err);
   }

--- a/packages/server/src/controllers/messageController.ts
+++ b/packages/server/src/controllers/messageController.ts
@@ -24,7 +24,27 @@ export async function searchMessages(
       mentionedToMe,
       unreadOnly,
       channelId,
+      limit: limitRaw,
+      offset: offsetRaw,
     } = req.query;
+
+    // #375 オフセットページング: limit / offset を検証（数値以外・負数は 400）
+    let limit: number | undefined;
+    if (typeof limitRaw === 'string' && limitRaw !== '') {
+      limit = Number(limitRaw);
+      if (!Number.isInteger(limit) || limit < 1) {
+        next(createError('limit must be a positive integer', 400));
+        return;
+      }
+    }
+    let offset: number | undefined;
+    if (typeof offsetRaw === 'string' && offsetRaw !== '') {
+      offset = Number(offsetRaw);
+      if (!Number.isInteger(offset) || offset < 0) {
+        next(createError('offset must be a non-negative integer', 400));
+        return;
+      }
+    }
 
     const filters = {
       dateFrom: typeof dateFrom === 'string' && dateFrom ? dateFrom : undefined,
@@ -50,6 +70,8 @@ export async function searchMessages(
         typeof channelId === 'string' && channelId !== '' && !isNaN(Number(channelId))
           ? Number(channelId)
           : undefined,
+      limit,
+      offset,
     };
 
     const hasAnyFilter =
@@ -68,7 +90,8 @@ export async function searchMessages(
     }
 
     const currentUserId = (req as AuthenticatedRequest).userId;
-    res.json({ messages: await messageService.searchMessages(q, filters, currentUserId) });
+    // #375 ページング標準仕様（オフセット系）: { items, total, limit, offset }
+    res.json(await messageService.searchMessages(q, filters, currentUserId));
   } catch (err) {
     next(err);
   }
@@ -80,9 +103,22 @@ export async function getMessages(req: Request, res: Response, next: NextFunctio
     const limit = req.query.limit ? Number(req.query.limit) : 50;
     const before = req.query.before ? Number(req.query.before) : undefined;
     const viewerUserId = (req as { userId?: number }).userId;
-    res.json({
-      messages: await messageService.getChannelMessages(channelId, limit, before, viewerUserId),
-    });
+
+    // #375 ページング標準仕様（カーソル系）: { items, nextCursor, hasMore }
+    // hasMore 判定のため limit+1 件取得し、超過分（最古の余剰 1 件）を切り落とす。
+    // getChannelMessages は時系列昇順で返すため、余剰は先頭側に現れる。
+    const fetched = await messageService.getChannelMessages(
+      channelId,
+      limit + 1,
+      before,
+      viewerUserId,
+    );
+    const hasMore = fetched.length > limit;
+    const items = hasMore ? fetched.slice(fetched.length - limit) : fetched;
+    // 次に遡る際の before に渡すカーソル = 現在表示中の最古メッセージ ID
+    const nextCursor = hasMore && items.length > 0 ? String(items[0].id) : null;
+
+    res.json({ items, nextCursor, hasMore });
   } catch (err) {
     next(err);
   }

--- a/packages/server/src/routes/channels.ts
+++ b/packages/server/src/routes/channels.ts
@@ -177,16 +177,22 @@ router.delete('/:id/members/:userId', authenticateToken, controller.removeMember
  *         schema: { type: integer }
  *     responses:
  *       200:
- *         description: Array of messages
+ *         description: カーソル系ページング { items, nextCursor, hasMore }（#375）
  *         content:
  *           application/json:
  *             schema:
  *               type: object
  *               properties:
- *                 messages:
+ *                 items:
  *                   type: array
  *                   items:
  *                     $ref: '#/components/schemas/Message'
+ *                 nextCursor:
+ *                   type: string
+ *                   nullable: true
+ *                   description: 次に古いメッセージを取得する際 before に渡すカーソル。続きが無ければ null
+ *                 hasMore:
+ *                   type: boolean
  */
 router.get('/:channelId/messages', authenticateToken, messageController.getMessages);
 router.post(

--- a/packages/server/src/routes/messages.ts
+++ b/packages/server/src/routes/messages.ts
@@ -18,9 +18,29 @@ const router = Router();
  *         name: q
  *         required: true
  *         schema: { type: string }
+ *       - in: query
+ *         name: limit
+ *         description: 1ページあたりの件数（既定 50・上限 100、#375 オフセット系ページング）
+ *         schema: { type: integer, default: 50 }
+ *       - in: query
+ *         name: offset
+ *         description: 先頭からのスキップ件数（既定 0）
+ *         schema: { type: integer, default: 0 }
  *     responses:
  *       200:
- *         description: 検索結果メッセージ一覧
+ *         description: 検索結果（オフセット系ページング { items, total, limit, offset }）
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Message'
+ *                 total: { type: integer }
+ *                 limit: { type: integer }
+ *                 offset: { type: integer }
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  */

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -4,6 +4,7 @@ import {
   Message,
   MessageSearchFilters,
   MessageSearchResult,
+  OffsetPaged,
   QuotedMessage,
   Reaction,
   Tag,
@@ -366,13 +367,21 @@ export async function restoreMessage(messageId: number, userId: number): Promise
   return toMessage(row!);
 }
 
+/** 検索のページング既定値・上限（#375 オフセット系へ統一） */
+export const SEARCH_DEFAULT_LIMIT = 50;
+export const SEARCH_MAX_LIMIT = 100;
+
 export async function searchMessages(
   q: string,
   filters: MessageSearchFilters = {},
   currentUserId?: number,
-): Promise<MessageSearchResult[]> {
+): Promise<OffsetPaged<MessageSearchResult>> {
   const { dateFrom, dateTo, userId, hasAttachment, tagIds, mentionedToMe, unreadOnly, channelId } =
     filters;
+
+  // ページングパラメータの実効値（サービス側でクランプ）
+  const limit = Math.min(Math.max(filters.limit ?? SEARCH_DEFAULT_LIMIT, 1), SEARCH_MAX_LIMIT);
+  const offset = Math.max(filters.offset ?? 0, 0);
 
   // dateFrom > dateTo の場合は空を返す（早期リターン）
   if (
@@ -382,7 +391,7 @@ export async function searchMessages(
     isValidDate(dateTo) &&
     new Date(dateFrom) > new Date(dateTo)
   ) {
-    return [];
+    return { items: [], total: 0, limit, offset };
   }
 
   const params: unknown[] = [];
@@ -428,11 +437,8 @@ export async function searchMessages(
     }
   }
 
-  let sql = `SELECT DISTINCT m.id, m.channel_id, m.user_id, u.username, u.avatar_url,
-            m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at,
-            m.parent_message_id, m.root_message_id, m.quoted_message_id, m.forwarded_from_message_id,
-            c.name AS channel_name,
-            rm.content AS root_message_content
+  // FROM〜WHERE 句（フィルタ条件）を count / data の両クエリで共有する
+  let body = `
      FROM messages m
      LEFT JOIN users u ON m.user_id = u.id
      JOIN channels c ON m.channel_id = c.id
@@ -445,31 +451,49 @@ export async function searchMessages(
      ${mentionsWhere}`;
 
   if (dateFrom && isValidDate(dateFrom)) {
-    sql += ` AND m.created_at >= $${idx++}`;
+    body += ` AND m.created_at >= $${idx++}`;
     params.push(dateFrom);
   }
 
   if (dateTo && isValidDate(dateTo)) {
-    sql += ` AND m.created_at <= $${idx++}`;
+    body += ` AND m.created_at <= $${idx++}`;
     params.push(`${dateTo}T23:59:59.999Z`);
   }
 
   if (userId !== undefined) {
-    sql += ` AND m.user_id = $${idx++}`;
+    body += ` AND m.user_id = $${idx++}`;
     params.push(userId);
   }
 
   // in:channel チップ構文用のチャンネル絞り込み
   if (channelId !== undefined) {
-    sql += ` AND m.channel_id = $${idx++}`;
+    body += ` AND m.channel_id = $${idx++}`;
     params.push(channelId);
   }
 
-  sql += ` ORDER BY m.created_at DESC LIMIT 100`;
+  // total: フィルタ適用後の総件数（limit/offset を適用する前に算出）
+  // COUNT(DISTINCT) は pg-mem 互換性が低いため、DISTINCT id を取得して件数を数える
+  const idRows = await query<{ id: number }>(`SELECT DISTINCT m.id ${body}`, params);
+  const total = idRows.length;
+
+  // ページング用パラメータを末尾に追加
+  params.push(limit);
+  const limitIndex = params.length;
+  params.push(offset);
+  const offsetIndex = params.length;
+
+  const dataSql =
+    `SELECT DISTINCT m.id, m.channel_id, m.user_id, u.username, u.avatar_url,
+            m.content, m.is_edited, m.is_deleted, m.created_at, m.updated_at,
+            m.parent_message_id, m.root_message_id, m.quoted_message_id, m.forwarded_from_message_id,
+            c.name AS channel_name,
+            rm.content AS root_message_content` +
+    body +
+    ` ORDER BY m.created_at DESC LIMIT $${limitIndex} OFFSET $${offsetIndex}`;
 
   const rows = await query<
     MessageRow & { channel_name: string; root_message_content: string | null }
-  >(sql, params);
+  >(dataSql, params);
 
   const baseResults = await Promise.all(
     rows.map(async (row) => ({
@@ -481,10 +505,11 @@ export async function searchMessages(
 
   // タグを bulk fetch して各メッセージに付与（N+1 回避）
   const messageIds = baseResults.map((r) => r.id);
-  if (messageIds.length === 0) return baseResults;
+  if (messageIds.length === 0) return { items: baseResults, total, limit, offset };
 
   const tagsMap = await getForMessages(messageIds);
-  return baseResults.map((msg) => ({ ...msg, tags: tagsMap.get(msg.id) ?? [] }));
+  const items = baseResults.map((msg) => ({ ...msg, tags: tagsMap.get(msg.id) ?? [] }));
+  return { items, total, limit, offset };
 }
 
 function isValidDate(dateStr: string): boolean {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,3 +26,4 @@ export * from './types/calendar';
 export * from './types/thread';
 export * from './types/wikiPage';
 export * from './types/apiResponse';
+export * from './types/pagination';

--- a/packages/shared/src/types/auditLog.ts
+++ b/packages/shared/src/types/auditLog.ts
@@ -2,6 +2,8 @@
  * 監査ログの型定義
  */
 
+import type { OffsetPaged } from './pagination';
+
 export type AuditActionType =
   | 'auth.login'
   | 'auth.logout'
@@ -54,7 +56,8 @@ export interface AuditLog {
   createdAt: string;
 }
 
-export interface AuditLogListResponse {
-  logs: AuditLog[];
-  total: number;
-}
+/**
+ * 監査ログ一覧 API のレスポンス（#375 オフセット系ページングに統一）
+ * 旧形式 { logs, total } から { items, total, limit, offset } へ変更。
+ */
+export type AuditLogListResponse = OffsetPaged<AuditLog>;

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -73,6 +73,10 @@ export interface MessageSearchFilters {
   unreadOnly?: boolean;
   /** in:channel チップ構文で指定するチャンネル ID */
   channelId?: number;
+  /** ページング: 1 ページあたりの件数（#375。未指定時はサービス側既定値） */
+  limit?: number;
+  /** ページング: 先頭からのスキップ件数（#375。未指定時は 0） */
+  offset?: number;
 }
 
 export interface SendMessageInput {

--- a/packages/shared/src/types/pagination.ts
+++ b/packages/shared/src/types/pagination.ts
@@ -1,0 +1,35 @@
+/**
+ * ページング共通レスポンス形式（#375 検索・一覧 API のページング仕様統一）
+ *
+ * 一覧・検索系 API のページング方式を 2 種類に標準化する。
+ * 返却キーはドメイン名ではなく汎用の `items` に統一し、フロントの一覧取得ロジックを共通化する。
+ *
+ *   - オフセット系: ページャ・総件数表示が必要な一覧（管理画面の監査ログ、検索結果など）
+ *   - カーソル系  : 時系列で前方へ遡る無限スクロール（チャンネル/DM のメッセージタイムライン）
+ *
+ * 用途別の使い分けは doc/api-pagination-guide.md を正本とする。
+ */
+
+/**
+ * オフセットベースのページングレスポンス。
+ * - total : フィルタ適用後の総件数（limit で切られても全件数を表す）
+ * - limit : 1 ページあたりの件数（サーバ側でクランプ済みの実効値）
+ * - offset: 先頭からのスキップ件数
+ */
+export interface OffsetPaged<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * カーソルベースのページングレスポンス。
+ * - nextCursor: 次ページ取得に渡す不透明なカーソル文字列。続きが無い場合は null
+ * - hasMore   : 続きが存在するか
+ */
+export interface CursorPaged<T> {
+  items: T[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}


### PR DESCRIPTION
## 概要
一覧・検索系 API のページング方式が混在（カーソル / オフセット / limit のみ / 独自）していた問題を解消し、標準仕様に統一する。返却キーはドメイン名（`messages` / `logs`）ではなく汎用 `items` に統一し、フロントの一覧取得ロジックを共通化する。

方針は事前にユーザーと合意：**用途別の二本立て**（カーソル系 `{ items, nextCursor, hasMore }` / オフセット系 `{ items, total, limit, offset }`）、**返却キーは汎用 `items`**、**代表 3 エンドポイント + フロント共通化**（残りは追従 Issue 化）。

## 変更内容
### 共通型（shared）
- `packages/shared/src/types/pagination.ts` を追加：`OffsetPaged<T>` / `CursorPaged<T>`
- `AuditLogListResponse` を `OffsetPaged<AuditLog>` へ再定義、`MessageSearchFilters` に `limit` / `offset` を追加

### サーバー
- `GET /api/messages/search`：オフセット系へ。`limit`（既定50・上限100クランプ）/ `offset` 対応、数値以外・負数は `400`。`total` 算出（フィルタ適用後の全件数）
- `GET /api/admin/audit-logs`：`{ logs, total }` → `{ items, total, limit, offset }`
- `GET /api/channels/:channelId/messages`：`{ messages }` → `{ items, nextCursor, hasMore }`（`limit+1` 取得で `hasMore` 判定）
- Swagger 定義を更新
- **設計**: サービス層（`getChannelMessages` / `listAuditLogs`）の戻り値は変更せず**コントローラ層で封筒化**し影響を最小化。`searchMessages` のみコントローラ専用のため `OffsetPaged` を返すよう変更

### フロント
- 共通フック `useOffsetPagination` を追加（offset 管理・`nextPage`/`prevPage`・`hasNext`/`hasPrev`・`total`・filters 変更で offset リセット。React 19 `use()`+Suspense 構成に整合）
- `AuditLogView` を同フックへ移行（総件数・ページ位置表示を追加）
- `SearchPage` はヒット件数表示に `total` を使用
- `useMessages` をカーソル系（`nextCursor`/`hasMore`）に対応
- `useMentionUnreadCount` は未読メンション件数に `total` を使用（従来は表示件数上限でキャップされていた潜在バグの修正）

### ドキュメント
- `doc/api-pagination-guide.md` を正本として追加

## 影響範囲
- レスポンス形状の変更（意図的な仕様変更）に伴い既存テストのアサーションを `items` 系へ更新
  - サーバー: `search.test.ts`（22箇所）/ `audit-log.test.ts`（HTTPレベル）/ `messageController.test.ts`（5箇所）/ `advanced-search.test.ts`・`threadReply.test.ts`（サービス直呼びの `searchMessages` を `items` 分割代入）/ `channel-archive.test.ts`
  - フロント: `useMessages.test.tsx` / `AuditLogView.test.tsx` / `SearchPage.test.tsx` / `client.test.ts` / `useMentionUnreadCount.test.tsx` / `ChatPagePermalink.test.tsx` のモック・期待値を新形状へ
- **スコープ外（追従 Issue 化）**: DM メッセージ / ゲストリンク / スレッド返信 / tags サジェスト / その他 `{ pages }`・`{ events }` 系一覧

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（2555 件）
- [x] バックエンドユニットテストがすべてパスする（1791 件）
- [x] ビルドが正常に完了すること（`npm run build` 成功、lint エラー 0）
- [ ] (手動確認) 未実施（要レビュー時に動作確認推奨）

## 関連Issue
Fixes #375
関連: レスポンス形式統一 #372

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（doc/api-pagination-guide.md 追加・Swagger 更新）を修正した
- [x] `it.todo` / 空ボディの `it` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)