### PR TITLE
refactor: DM/ゲスト/スレッド返信のページングをカーソル系へ統一 (#386)

### DIFF
--- a/doc/api-pagination-guide.md
+++ b/doc/api-pagination-guide.md
@@ -54,20 +54,27 @@ interface CursorPaged<T> {
 - クエリパラメータ: `limit` / `before`（= 前ページで受け取った `nextCursor`）。
 - サーバは `limit + 1` 件取得して `hasMore` を判定し、超過分を切り落とす。
 - `nextCursor` は現在表示中の最古メッセージ ID（文字列）。クライアントは値を解釈せず `before` にそのまま渡す。
+- 導出は共通ヘルパー `packages/server/src/utils/pagination.ts` の `parseCursorParams` / `buildCursorPage` に集約する。サービス層は「時系列昇順で `limit + 1` 件」を返し、コントローラ/ルートで封筒化する。
 
 ### 適用済みエンドポイント
-- `GET /api/channels/:channelId/messages`
+- `GET /api/channels/:channelId/messages`（#375）
+- `GET /api/dm/conversations/:id/messages`（#386）
+- `GET /api/guest-links/:token/messages`（#386）
+- `GET /api/messages/:id/replies`（#386・スレッド返信）
 
 ### フロント
 - `useMessages` が `items` を取り込み、`nextCursor` / `hasMore` を保持して `loadMore()` で前方（より古いメッセージ）を読み込む。
+- `DMPage` / `GuestChannelPage` / `ChatPage`（スレッドパネル）は `items` を読む（現状は初回ページのみ消費。無限スクロールは `nextCursor` で拡張可能）。
 
-## 段階移行（追従 Issue）
+## 標準化対象外（exempt）
 
-#375 では代表的な 3 エンドポイント（メッセージ検索 / 監査ログ / チャンネルメッセージ）と共通フックを整備した。
-以下は本仕様への追従が未対応のため、別 Issue で段階移行する。
+以下は「有界リスト」または「オートコンプリート」であり、ページング標準仕様の適用対象外とする（#386 で判断）。
+返却キーは従来のドメイン名のまま維持する。
 
-- DM メッセージ（`GET /api/dm/conversations/:id/messages`、カーソル系候補）
-- ゲストリンクメッセージ
-- スレッド返信一覧
-- tags サジェスト（`limit` のみ）
-- その他 `{ pages }` / `{ events }` 等のドメイン名一覧
+| エンドポイント | 返却キー | 対象外の理由 |
+|---|---|---|
+| `GET /api/tags/suggestions` | `{ suggestions }` | 入力補完用（最大10件）。オフセット/カーソルいずれの UI も持たない |
+| `GET /api/channels/:id/wiki-pages` 等 | `{ pages }` | チャンネル内 Wiki の有界リスト。件数が小さくページングが不要 |
+| `GET /api/channels/:id/calendar` 等 | `{ events }` | 期間指定で取得する有界リスト。ページングではなく期間で絞る |
+
+将来これらがページングを要する規模になった場合は、本ガイドの標準仕様に従って移行する。

--- a/packages/client/src/__tests__/DMPage.test.tsx
+++ b/packages/client/src/__tests__/DMPage.test.tsx
@@ -132,7 +132,7 @@ beforeEach(() => {
     delete socketHandlers[k];
   });
   mockApi.dm.markAsRead.mockResolvedValue(undefined);
-  mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+  mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
 });
 
 describe('DMページ（DMPage）', () => {
@@ -181,7 +181,11 @@ describe('DMページ（DMPage）', () => {
       mockApi.dm.listConversations.mockResolvedValue({
         conversations: [makeConversation()],
       });
-      mockApi.dm.getMessages.mockResolvedValue({ messages: [makeMessage()] });
+      mockApi.dm.getMessages.mockResolvedValue({
+        items: [makeMessage()],
+        nextCursor: null,
+        hasMore: false,
+      });
       await renderDMPage();
 
       await userEvent.click(screen.getByText('bob'));
@@ -258,7 +262,7 @@ describe('DMページ（DMPage）', () => {
       mockApi.dm.listConversations.mockResolvedValue({
         conversations: [makeConversation()],
       });
-      mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+      mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderDMPage();
 
       await userEvent.click(screen.getByText('bob'));
@@ -340,7 +344,7 @@ describe('DMページ（DMPage）', () => {
       mockApi.dm.createConversation.mockResolvedValue({
         conversation: existingConv,
       });
-      mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+      mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderDMPage();
 
       await userEvent.click(screen.getByRole('button', { name: '新規DM' }));
@@ -363,7 +367,7 @@ describe('DMページ（DMPage）', () => {
       mockApi.dm.listConversations.mockResolvedValue({
         conversations: [makeConversation({ id: 7 })],
       });
-      mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+      mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await act(async () => {
         render(
           <MemoryRouter initialEntries={['/dm?conv=7']}>
@@ -394,7 +398,7 @@ describe('サイドバーのDM一覧', () => {
           }),
         ],
       });
-      mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+      mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderDMPage();
 
       // id=1の会話を選択
@@ -423,7 +427,7 @@ describe('サイドバーのDM一覧', () => {
       mockApi.dm.listConversations.mockResolvedValue({
         conversations: [makeConversation({ id: 1, unreadCount: 0 })],
       });
-      mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+      mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderDMPage();
 
       // 会話を選択して開く
@@ -456,7 +460,7 @@ describe('DMPage: Step 8a: AppLayout 化', () => {
       delete socketHandlers[k];
     });
     mockApi.dm.markAsRead.mockResolvedValue(undefined);
-    mockApi.dm.getMessages.mockResolvedValue({ messages: [] });
+    mockApi.dm.getMessages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
     mockApi.dm.listConversations.mockResolvedValue({ conversations: [] });
     resetDmConversationsCache();
   });
@@ -486,5 +490,25 @@ describe('DMPage: Step 8a: AppLayout 化', () => {
     });
     await renderDMPage();
     expect(screen.getByText('bob')).toBeInTheDocument();
+  });
+
+  // #386 DM メッセージがカーソル系 CursorPaged を返すようになったため items を消費する
+  describe('カーソルページング移行（#386）', () => {
+    it('会話選択時に CursorPaged.items を DM メッセージとして表示する', async () => {
+      mockApi.dm.listConversations.mockResolvedValue({
+        conversations: [makeConversation()],
+      });
+      mockApi.dm.getMessages.mockResolvedValue({
+        items: [makeMessage({ id: 10, content: 'カーソル封筒の本文' })],
+        nextCursor: '10',
+        hasMore: true,
+      });
+      await renderDMPage();
+
+      await userEvent.click(screen.getByText('bob'));
+      await waitFor(() => {
+        expect(screen.getByText('カーソル封筒の本文')).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/client/src/__tests__/GuestChannelPage.test.tsx
+++ b/packages/client/src/__tests__/GuestChannelPage.test.tsx
@@ -85,7 +85,7 @@ describe('GuestChannelPage', () => {
         channelId: 10,
         channelName: 'general',
       });
-      mockApi.messages.mockResolvedValue({ messages: [] });
+      mockApi.messages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderAt('tok-abc');
       await waitFor(() => expect(screen.getByText(/general/)).toBeInTheDocument());
     });
@@ -143,7 +143,7 @@ describe('GuestChannelPage', () => {
         channelId: 10,
         channelName: 'general',
       });
-      mockApi.messages.mockResolvedValue({ messages: [] });
+      mockApi.messages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderAt('tok-abc');
       await waitFor(() => expect(mockApi.verify).toHaveBeenCalledWith('tok-abc', ''));
     });
@@ -158,7 +158,9 @@ describe('GuestChannelPage', () => {
         channelName: 'general',
       });
       mockApi.messages.mockResolvedValue({
-        messages: [
+        nextCursor: null,
+        hasMore: false,
+        items: [
           {
             id: 1,
             channelId: 10,
@@ -218,7 +220,9 @@ describe('GuestChannelPage', () => {
         channelName: 'general',
       });
       mockApi.messages.mockResolvedValue({
-        messages: [
+        nextCursor: null,
+        hasMore: false,
+        items: [
           {
             id: 1,
             channelId: 10,
@@ -304,7 +308,7 @@ describe('GuestChannelPage', () => {
         channelId: 10,
         channelName: 'general',
       });
-      mockApi.messages.mockResolvedValue({ messages: [] });
+      mockApi.messages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderAt('tok-abc');
       // ログイン済みでも guestLinks API が呼ばれる（通常チャットページに遷移しない）
       await waitFor(() => expect(mockApi.lookup).toHaveBeenCalled());
@@ -320,7 +324,9 @@ describe('GuestChannelPage', () => {
         channelName: 'general',
       });
       mockApi.messages.mockResolvedValue({
-        messages: [
+        nextCursor: null,
+        hasMore: false,
+        items: [
           {
             id: 1,
             channelId: 10,
@@ -348,7 +354,7 @@ describe('GuestChannelPage', () => {
         channelId: 10,
         channelName: 'general',
       });
-      mockApi.messages.mockResolvedValue({ messages: [] });
+      mockApi.messages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderAt('tok-abc');
       await waitFor(() => expect(screen.getByText(/general（ゲスト閲覧）/)).toBeInTheDocument());
     });
@@ -362,7 +368,7 @@ describe('GuestChannelPage', () => {
         channelId: 10,
         channelName: 'general',
       });
-      mockApi.messages.mockResolvedValue({ messages: [] });
+      mockApi.messages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       await renderAt('tok-abc');
       await waitFor(() => expect(mockApi.messages).toHaveBeenCalledWith('tok-abc', 'gt-issued'));
     });
@@ -387,7 +393,7 @@ describe('GuestChannelPage', () => {
         channelId: 10,
         channelName: 'general',
       });
-      mockApi.messages.mockResolvedValue({ messages: [] });
+      mockApi.messages.mockResolvedValue({ items: [], nextCursor: null, hasMore: false });
       const { rerender } = await renderAt('tok-abc');
       await waitFor(() => expect(mockApi.lookup).toHaveBeenCalledTimes(1));
       rerender(
@@ -399,6 +405,37 @@ describe('GuestChannelPage', () => {
       );
       // 再レンダリング後も lookup が再呼び出しされない
       expect(mockApi.lookup).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #386 ゲストメッセージがカーソル系 CursorPaged を返すようになったため items を消費する
+  describe('カーソルページング移行（#386）', () => {
+    it('CursorPaged.items をゲストメッセージとして表示する', async () => {
+      mockApi.lookup.mockResolvedValue({ guestLink: baseLookup });
+      mockApi.verify.mockResolvedValue({
+        guestToken: 'gt-1',
+        channelId: 10,
+        channelName: 'general',
+      });
+      mockApi.messages.mockResolvedValue({
+        nextCursor: '1',
+        hasMore: true,
+        items: [
+          {
+            id: 1,
+            channelId: 10,
+            userId: 1,
+            username: 'alice',
+            content: 'カーソル封筒のゲスト本文',
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+            isEdited: false,
+            attachments: [],
+          },
+        ],
+      });
+      await renderAt('tok-abc');
+      await waitFor(() => expect(screen.getByText('カーソル封筒のゲスト本文')).toBeInTheDocument());
     });
   });
 });

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -1025,48 +1025,60 @@ describe('TaskBoardPage', () => {
   describe('Issue #328: カラム別 WIP／期限サマリー', () => {
     describe('カラム見出しのサマリーバッジ', () => {
       it('各カラム見出しに期限切れ・今日・担当自分の件数バッジが表示される', async () => {
-        mockTasksList.mockResolvedValue({
-          tasks: [
-            makeTask({
-              id: 101,
-              title: '期限切れの未着手',
-              status: 'todo',
-              dueAt: daysFromNow(-1),
-            }),
-            makeTask({
-              id: 102,
-              title: '今日期限の未着手',
-              status: 'todo',
-              dueAt: todayAt(23),
-            }),
-            makeTask({
-              id: 103,
-              title: '自分担当の未着手',
-              status: 'todo',
-              assigneeId: 1,
-              assigneeUsername: 'alice',
-            }),
-          ],
-        });
-        const TaskBoardPage = await importTaskBoardPage();
-        await act(async () => {
-          render(
-            <MemoryRouter>
-              <TaskBoardPage />
-            </MemoryRouter>,
-          );
-        });
+        // isOverdue(datetime 過去) と isDueToday(同日) は重複しうるため、
+        // 「今日23時」期限が実行時刻次第で期限切れに二重計上されるのを防ぐ目的で
+        // システム時刻を当日午前9時に固定する（時刻依存のフレーク回避）。
+        // shouldAdvanceTime: true で findBy/waitFor の非同期ポーリングは従来どおり動く。
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        const fixedNow = new Date();
+        fixedNow.setHours(9, 0, 0, 0);
+        vi.setSystemTime(fixedNow);
+        try {
+          mockTasksList.mockResolvedValue({
+            tasks: [
+              makeTask({
+                id: 101,
+                title: '期限切れの未着手',
+                status: 'todo',
+                dueAt: daysFromNow(-1),
+              }),
+              makeTask({
+                id: 102,
+                title: '今日期限の未着手',
+                status: 'todo',
+                dueAt: todayAt(23),
+              }),
+              makeTask({
+                id: 103,
+                title: '自分担当の未着手',
+                status: 'todo',
+                assigneeId: 1,
+                assigneeUsername: 'alice',
+              }),
+            ],
+          });
+          const TaskBoardPage = await importTaskBoardPage();
+          await act(async () => {
+            render(
+              <MemoryRouter>
+                <TaskBoardPage />
+              </MemoryRouter>,
+            );
+          });
 
-        const todoColumn = await screen.findByTestId('column-todo');
-        expect(within(todoColumn).getByTestId('summary-badge-todo-overdue')).toHaveTextContent(
-          '期限切れ 1',
-        );
-        expect(within(todoColumn).getByTestId('summary-badge-todo-today')).toHaveTextContent(
-          '今日 1',
-        );
-        expect(within(todoColumn).getByTestId('summary-badge-todo-mine')).toHaveTextContent(
-          '担当自分 1',
-        );
+          const todoColumn = await screen.findByTestId('column-todo');
+          expect(within(todoColumn).getByTestId('summary-badge-todo-overdue')).toHaveTextContent(
+            '期限切れ 1',
+          );
+          expect(within(todoColumn).getByTestId('summary-badge-todo-today')).toHaveTextContent(
+            '今日 1',
+          );
+          expect(within(todoColumn).getByTestId('summary-badge-todo-mine')).toHaveTextContent(
+            '担当自分 1',
+          );
+        } finally {
+          vi.useRealTimers();
+        }
       });
 
       it('件数が 0 件のサマリーバッジは表示されない', async () => {

--- a/packages/client/src/__tests__/client.test.ts
+++ b/packages/client/src/__tests__/client.test.ts
@@ -253,3 +253,46 @@ describe('api ページング封筒（#375）', () => {
     expect(res.offset).toBe(0);
   });
 });
+
+// #386 カーソル系へ移行した残りの API クライアント封筒
+describe('api カーソル封筒の追従移行（#386）', () => {
+  it('api.dm.getMessages が CursorPaged（items / nextCursor / hasMore）を返す', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [{ id: 1 }], nextCursor: '1', hasMore: true }));
+
+    const res = await api.dm.getMessages(7, { limit: 50 });
+
+    expect(res.items).toEqual([{ id: 1 }]);
+    expect(res.nextCursor).toBe('1');
+    expect(res.hasMore).toBe(true);
+  });
+
+  it('api.dm.getMessages が limit / before をクエリに付与する', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [], nextCursor: null, hasMore: false }));
+
+    await api.dm.getMessages(7, { limit: 30, before: '99' });
+
+    const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('limit=30');
+    expect(calledUrl).toContain('before=99');
+  });
+
+  it('api.messages.getReplies が CursorPaged（items / nextCursor / hasMore）を返す', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [{ id: 5 }], nextCursor: null, hasMore: false }));
+
+    const res = await api.messages.getReplies(42);
+
+    expect(res.items).toEqual([{ id: 5 }]);
+    expect(res.nextCursor).toBeNull();
+    expect(res.hasMore).toBe(false);
+  });
+
+  it('api.guestLinks.messages が CursorPaged（items / nextCursor / hasMore）を返す', async () => {
+    vi.stubGlobal('fetch', mockFetch({ items: [{ id: 3 }], nextCursor: '3', hasMore: true }));
+
+    const res = await api.guestLinks.messages('tok', 'guest-tok');
+
+    expect(res.items).toEqual([{ id: 3 }]);
+    expect(res.nextCursor).toBe('3');
+    expect(res.hasMore).toBe(true);
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -270,8 +270,14 @@ export const api = {
       // #375 オフセット系ページング: { items, total, limit, offset }
       return request<OffsetPaged<MessageSearchResult>>(`/messages/search?${params.toString()}`);
     },
-    getReplies: (messageId: number) =>
-      request<{ replies: Message[] }>(`/messages/${messageId}/replies`),
+    getReplies: (messageId: number, params?: { limit?: number; before?: number | string }) => {
+      const q = new URLSearchParams();
+      if (params?.limit) q.set('limit', String(params.limit));
+      if (params?.before) q.set('before', String(params.before));
+      const qs = q.toString();
+      // #386 カーソル系ページング: { items, nextCursor, hasMore }
+      return request<CursorPaged<Message>>(`/messages/${messageId}/replies${qs ? `?${qs}` : ''}`);
+    },
     forward: (messageId: number, input: ForwardMessageInput) =>
       request<{ message: Message }>(`/messages/${messageId}/forward`, {
         method: 'POST',
@@ -369,13 +375,15 @@ export const api = {
         method: 'POST',
         body: JSON.stringify({ targetUserId }),
       }),
-    getMessages: (conversationId: number, params?: { limit?: number; before?: number }) => {
+    getMessages: (
+      conversationId: number,
+      params?: { limit?: number; before?: number | string },
+    ) => {
       const q = new URLSearchParams();
       if (params?.limit) q.set('limit', String(params.limit));
       if (params?.before) q.set('before', String(params.before));
-      return request<{ messages: DmMessage[] }>(
-        `/dm/conversations/${conversationId}/messages?${q}`,
-      );
+      // #386 カーソル系ページング: { items, nextCursor, hasMore }
+      return request<CursorPaged<DmMessage>>(`/dm/conversations/${conversationId}/messages?${q}`);
     },
     sendMessage: (conversationId: number, content: string) =>
       request<{ message: DmMessage }>(`/dm/conversations/${conversationId}/messages`, {
@@ -491,8 +499,9 @@ export const api = {
         body: JSON.stringify({ password }),
       }),
     messages: (token: string, guestToken: string) =>
-      request<{
-        messages: Array<{
+      // #386 カーソル系ページング: { items, nextCursor, hasMore }
+      request<
+        CursorPaged<{
           id: number;
           channelId: number;
           userId: number | null;
@@ -508,8 +517,8 @@ export const api = {
             size: number;
             mimeType: string;
           }>;
-        }>;
-      }>(`/guest-links/${token}/messages`, {
+        }>
+      >(`/guest-links/${token}/messages`, {
         headers: { Authorization: `Bearer ${guestToken}` },
       }),
   },

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -343,9 +343,10 @@ export default function ChatPage({ users }: Props) {
   const handleOpenThread = useCallback((messageId: number) => {
     setThreadRootId(messageId);
     setThreadReplies([]);
+    // #386 スレッド返信はカーソル系 { items, nextCursor, hasMore } を返す
     api.messages
       .getReplies(messageId)
-      .then(({ replies }) => setThreadReplies(replies))
+      .then(({ items }) => setThreadReplies(items))
       .catch(console.error);
   }, []);
 

--- a/packages/client/src/pages/DMPage.tsx
+++ b/packages/client/src/pages/DMPage.tsx
@@ -71,7 +71,8 @@ function DMPageContent({ conversationsPromise, users, currentUserId }: DMPageCon
     setActiveConvId(convId);
     setLoadingMessages(true);
     try {
-      const { messages: msgs } = await api.dm.getMessages(convId);
+      // #386 DM メッセージはカーソル系 { items, nextCursor, hasMore } を返す
+      const { items: msgs } = await api.dm.getMessages(convId);
       setMessages(msgs);
       await api.dm.markAsRead(convId);
       // 既読後に未読数をリセット

--- a/packages/client/src/pages/GuestChannelPage.tsx
+++ b/packages/client/src/pages/GuestChannelPage.tsx
@@ -249,8 +249,9 @@ function GuestChannelContent({
     try {
       const v = await api.guestLinks.verify(token, pw);
       setGuestToken(v.guestToken);
+      // #386 ゲストメッセージはカーソル系 { items, nextCursor, hasMore } を返す
       const m = await api.guestLinks.messages(token, v.guestToken);
-      setMessages(m.messages);
+      setMessages(m.items);
     } catch (err) {
       const msg = err instanceof Error ? err.message : '取得に失敗しました';
       // 429 想定: しばらく待つ

--- a/packages/server/src/__tests__/direct-message.test.ts
+++ b/packages/server/src/__tests__/direct-message.test.ts
@@ -176,8 +176,8 @@ describe('DM API', () => {
         .set('Cookie', `token=${tokenA}`);
 
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.messages)).toBe(true);
-      expect(res.body.messages.length).toBeGreaterThan(0);
+      expect(Array.isArray(res.body.items)).toBe(true);
+      expect(res.body.items.length).toBeGreaterThan(0);
     });
 
     it('自分が参加していない会話のメッセージは取得できない（404）', async () => {
@@ -201,7 +201,7 @@ describe('DM API', () => {
       const allRes = await request(app)
         .get(`/api/dm/conversations/${convId}/messages`)
         .set('Cookie', `token=${tokenA}`);
-      const allMessages = allRes.body.messages as Array<{ id: number; content: string }>;
+      const allMessages = allRes.body.items as Array<{ id: number; content: string }>;
       expect(allMessages.length).toBeGreaterThanOrEqual(2);
 
       const secondId = allMessages[1].id;
@@ -210,7 +210,7 @@ describe('DM API', () => {
         .set('Cookie', `token=${tokenA}`);
 
       expect(res.status).toBe(200);
-      const messages = res.body.messages as Array<{ id: number }>;
+      const messages = res.body.items as Array<{ id: number }>;
       expect(messages.every((m) => m.id < secondId)).toBe(true);
     });
 
@@ -389,5 +389,88 @@ describe('Socket.IO DM イベント', () => {
       expect(target).toBeDefined();
       expect(target!.unreadCount).toBeGreaterThan(0);
     });
+  });
+});
+
+// #386 ページング標準仕様（カーソル系 { items, nextCursor, hasMore }）への移行
+// 対象: GET /api/dm/conversations/:conversationId/messages（旧 { messages }）
+describe('GET /api/dm/conversations/:id/messages カーソルページング（#386）', () => {
+  // n 件のメッセージを持つ会話を用意する
+  async function seedConversation(prefix: string, count: number) {
+    const a = await registerUser(app, `${prefix}_a`, `${prefix}_a@example.com`);
+    const b = await registerUser(app, `${prefix}_b`, `${prefix}_b@example.com`);
+    const convRes = await request(app)
+      .post('/api/dm/conversations')
+      .set('Cookie', `token=${a.token}`)
+      .send({ targetUserId: b.userId });
+    const convId = convRes.body.conversation.id as number;
+    for (let i = 0; i < count; i++) {
+      await request(app)
+        .post(`/api/dm/conversations/${convId}/messages`)
+        .set('Cookie', `token=${a.token}`)
+        .send({ content: `${prefix} msg ${i}` });
+    }
+    return { token: a.token, convId };
+  }
+
+  it('レスポンスが { items, nextCursor, hasMore } 形式で返る（旧 { messages } から変更）', async () => {
+    const { token, convId } = await seedConversation('dmcur1', 3);
+    const res = await request(app)
+      .get(`/api/dm/conversations/${convId}/messages`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('messages');
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body).toHaveProperty('nextCursor');
+    expect(typeof res.body.hasMore).toBe('boolean');
+  });
+
+  it('items が時系列昇順の DM メッセージ配列を保持する', async () => {
+    const { token, convId } = await seedConversation('dmcur2', 3);
+    const res = await request(app)
+      .get(`/api/dm/conversations/${convId}/messages`)
+      .set('Cookie', `token=${token}`);
+
+    const ids = (res.body.items as { id: number }[]).map((m) => m.id);
+    expect(ids).toEqual([...ids].sort((x, y) => x - y));
+  });
+
+  it('続きがある場合 hasMore=true かつ nextCursor に次の before 値が入る', async () => {
+    const { token, convId } = await seedConversation('dmcur3', 5);
+    const res = await request(app)
+      .get(`/api/dm/conversations/${convId}/messages?limit=2`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(true);
+    expect(res.body.nextCursor).toBe(String((res.body.items as { id: number }[])[0].id));
+  });
+
+  it('最古まで読み込むと hasMore=false かつ nextCursor=null になる', async () => {
+    const { token, convId } = await seedConversation('dmcur4', 2);
+    const res = await request(app)
+      .get(`/api/dm/conversations/${convId}/messages?limit=50`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('nextCursor を before に渡すと重複なく続き（より古いメッセージ）を取得できる', async () => {
+    const { token, convId } = await seedConversation('dmcur5', 5);
+    const page1 = await request(app)
+      .get(`/api/dm/conversations/${convId}/messages?limit=2`)
+      .set('Cookie', `token=${token}`);
+    const cursor = page1.body.nextCursor as string;
+    const page2 = await request(app)
+      .get(`/api/dm/conversations/${convId}/messages?limit=2&before=${cursor}`)
+      .set('Cookie', `token=${token}`);
+
+    const ids1 = (page1.body.items as { id: number }[]).map((m) => m.id);
+    const ids2 = (page2.body.items as { id: number }[]).map((m) => m.id);
+    expect(ids1.some((id) => ids2.includes(id))).toBe(false);
+    expect(Math.max(...ids2)).toBeLessThan(Math.min(...ids1));
   });
 });

--- a/packages/server/src/__tests__/integration/messageController.test.ts
+++ b/packages/server/src/__tests__/integration/messageController.test.ts
@@ -289,3 +289,84 @@ describe('GET /api/channels/:channelId/messages カーソルページング（#3
     expect(res.body.nextCursor).toBeNull();
   });
 });
+
+// #386 ページング標準仕様（カーソル系 { items, nextCursor, hasMore }）への移行
+// 対象: GET /api/messages/:id/replies（旧 { replies }）
+describe('GET /api/messages/:id/replies カーソルページング（#386）', () => {
+  // ルートメッセージ + n 件の返信を持つスレッドを用意する
+  async function seedThread(prefix: string, replyCount: number) {
+    const { token, userId } = await registerUser(app, prefix, `${prefix}@example.com`);
+    const channelId = await createChannelReq(app, token, `${prefix}-ch`);
+    const rootId = await insertMessage(channelId, userId, `${prefix}-root`);
+    for (let i = 0; i < replyCount; i++) {
+      await testDb.execute(
+        `INSERT INTO messages (channel_id, user_id, content, parent_message_id, root_message_id)
+         VALUES ($1, $2, $3, $4, $4)`,
+        [channelId, userId, `${prefix}-reply-${i}`, rootId],
+      );
+    }
+    return { token, rootId };
+  }
+
+  it('レスポンスが { items, nextCursor, hasMore } 形式で返る（旧 { replies } から変更）', async () => {
+    const { token, rootId } = await seedThread('rep1', 3);
+    const res = await request(app)
+      .get(`/api/messages/${rootId}/replies`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty('replies');
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body).toHaveProperty('nextCursor');
+    expect(typeof res.body.hasMore).toBe('boolean');
+  });
+
+  it('items が時系列昇順のスレッド返信配列を保持する', async () => {
+    const { token, rootId } = await seedThread('rep2', 3);
+    const res = await request(app)
+      .get(`/api/messages/${rootId}/replies`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(3);
+    const ids = (res.body.items as { id: number }[]).map((m) => m.id);
+    expect(ids).toEqual([...ids].sort((x, y) => x - y));
+  });
+
+  it('返信件数が limit 未満なら hasMore=false / nextCursor=null', async () => {
+    const { token, rootId } = await seedThread('rep3', 2);
+    const res = await request(app)
+      .get(`/api/messages/${rootId}/replies?limit=10`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(false);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it('limit を超える場合 hasMore=true かつ nextCursor が設定される', async () => {
+    const { token, rootId } = await seedThread('rep4', 5);
+    const res = await request(app)
+      .get(`/api/messages/${rootId}/replies?limit=2`)
+      .set('Cookie', `token=${token}`);
+
+    expect(res.body.items).toHaveLength(2);
+    expect(res.body.hasMore).toBe(true);
+    expect(res.body.nextCursor).toBe(String((res.body.items as { id: number }[])[0].id));
+  });
+
+  it('nextCursor を before に渡すと重複なく続きを取得できる', async () => {
+    const { token, rootId } = await seedThread('rep5', 5);
+    const page1 = await request(app)
+      .get(`/api/messages/${rootId}/replies?limit=2`)
+      .set('Cookie', `token=${token}`);
+    const cursor = page1.body.nextCursor as string;
+    const page2 = await request(app)
+      .get(`/api/messages/${rootId}/replies?limit=2&before=${cursor}`)
+      .set('Cookie', `token=${token}`);
+
+    const ids1 = (page1.body.items as { id: number }[]).map((m) => m.id);
+    const ids2 = (page2.body.items as { id: number }[]).map((m) => m.id);
+    expect(ids1.some((id) => ids2.includes(id))).toBe(false);
+    expect(Math.max(...ids2)).toBeLessThan(Math.min(...ids1));
+  });
+});

--- a/packages/server/src/__tests__/routes/guestLinks.test.ts
+++ b/packages/server/src/__tests__/routes/guestLinks.test.ts
@@ -232,8 +232,8 @@ describe('ゲスト閲覧リンクルート', () => {
         .get(`/api/guest-links/${link.token}/messages`)
         .set('Authorization', `Bearer ${guestToken}`);
       expect(res.status).toBe(200);
-      expect(Array.isArray(res.body.messages)).toBe(true);
-      expect(res.body.messages.length).toBe(1);
+      expect(Array.isArray(res.body.items)).toBe(true);
+      expect(res.body.items.length).toBe(1);
     });
 
     it('guestToken なしでは 401 になる', async () => {
@@ -251,6 +251,72 @@ describe('ゲスト閲覧リンクルート', () => {
         .get(`/api/guest-links/${link.token}/messages`)
         .set('Authorization', `Bearer ${guestToken}`);
       expect(res.status).toBe(410);
+    });
+
+    // #386 ページング標準仕様（カーソル系 { items, nextCursor, hasMore }）への移行
+    describe('カーソルページング（#386）', () => {
+      // ゲストリンク + n 件のメッセージを用意し guestToken を返す
+      async function seedGuest(count: number): Promise<{ token: string; guestToken: string }> {
+        const link = await guestLinkService.create(creatorId, { channelId });
+        for (let i = 0; i < count; i++) {
+          await testDb.execute(
+            'INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, $3)',
+            [channelId, creatorId, `guest msg ${i}`],
+          );
+        }
+        const verifyRes = await request(app).post(`/api/guest-links/${link.token}/verify`).send({});
+        return { token: link.token, guestToken: verifyRes.body.guestToken };
+      }
+
+      it('レスポンスが { items, nextCursor, hasMore } 形式で返る（旧 { messages } から変更）', async () => {
+        const { token, guestToken } = await seedGuest(3);
+        const res = await request(app)
+          .get(`/api/guest-links/${token}/messages`)
+          .set('Authorization', `Bearer ${guestToken}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body).not.toHaveProperty('messages');
+        expect(Array.isArray(res.body.items)).toBe(true);
+        expect(res.body).toHaveProperty('nextCursor');
+        expect(typeof res.body.hasMore).toBe('boolean');
+      });
+
+      it('items が時系列昇順のメッセージ配列を保持する', async () => {
+        const { token, guestToken } = await seedGuest(3);
+        const res = await request(app)
+          .get(`/api/guest-links/${token}/messages`)
+          .set('Authorization', `Bearer ${guestToken}`);
+
+        const ids = (res.body.items as { id: number }[]).map((m) => m.id);
+        expect(ids).toEqual([...ids].sort((x, y) => x - y));
+      });
+
+      it('limit を超える場合 hasMore=true かつ nextCursor に次の before 値が入る', async () => {
+        const { token, guestToken } = await seedGuest(5);
+        const res = await request(app)
+          .get(`/api/guest-links/${token}/messages?limit=2`)
+          .set('Authorization', `Bearer ${guestToken}`);
+
+        expect(res.body.items).toHaveLength(2);
+        expect(res.body.hasMore).toBe(true);
+        expect(res.body.nextCursor).toBe(String((res.body.items as { id: number }[])[0].id));
+      });
+
+      it('nextCursor を before に渡すと重複なく続き（より古いメッセージ）を取得できる', async () => {
+        const { token, guestToken } = await seedGuest(5);
+        const page1 = await request(app)
+          .get(`/api/guest-links/${token}/messages?limit=2`)
+          .set('Authorization', `Bearer ${guestToken}`);
+        const cursor = page1.body.nextCursor as string;
+        const page2 = await request(app)
+          .get(`/api/guest-links/${token}/messages?limit=2&before=${cursor}`)
+          .set('Authorization', `Bearer ${guestToken}`);
+
+        const ids1 = (page1.body.items as { id: number }[]).map((m) => m.id);
+        const ids2 = (page2.body.items as { id: number }[]).map((m) => m.id);
+        expect(ids1.some((id) => ids2.includes(id))).toBe(false);
+        expect(Math.max(...ids2)).toBeLessThan(Math.min(...ids1));
+      });
     });
   });
 

--- a/packages/server/src/__tests__/unit/pagination.test.ts
+++ b/packages/server/src/__tests__/unit/pagination.test.ts
@@ -1,0 +1,42 @@
+/**
+ * カーソルページング共通ヘルパー buildCursorPage のユニットテスト
+ *
+ * テスト対象: src/utils/pagination.ts
+ * 戦略:
+ *   - DM / ゲスト / スレッド返信 / チャンネルメッセージのカーソル封筒化（#375 / #386）で共用するヘルパー。
+ *   - 時系列昇順かつ limit+1 件取得済みの配列を入力に、hasMore / nextCursor / items を導出する純粋関数を検証する。
+ *   - DB 不要のためサービス・HTTP を介さず直接呼び出す。
+ */
+
+import { buildCursorPage } from '../../utils/pagination';
+
+// id 昇順の行を作るヘルパー（時系列昇順＝oldest first を模す）
+const rows = (ids: number[]) => ids.map((id) => ({ id }));
+
+describe('buildCursorPage（#386 カーソル封筒の共通導出）', () => {
+  it('limit+1 件のとき hasMore=true・余剰（最古1件）を除いた最新 limit 件を items にする', () => {
+    // 昇順 [10,11,12]、limit=2 → 余剰は先頭(最古)10、items=[11,12]
+    const page = buildCursorPage(rows([10, 11, 12]), 2);
+    expect(page.hasMore).toBe(true);
+    expect(page.items.map((r) => r.id)).toEqual([11, 12]);
+  });
+
+  it('hasMore=true のとき nextCursor は items 先頭（最古）の id 文字列になる', () => {
+    const page = buildCursorPage(rows([10, 11, 12]), 2);
+    expect(page.nextCursor).toBe('11');
+  });
+
+  it('limit 以下のとき hasMore=false・nextCursor=null で全件を items にする', () => {
+    const page = buildCursorPage(rows([10, 11]), 2);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+    expect(page.items.map((r) => r.id)).toEqual([10, 11]);
+  });
+
+  it('空配列のとき items=[]・hasMore=false・nextCursor=null を返す', () => {
+    const page = buildCursorPage(rows([]), 2);
+    expect(page.items).toEqual([]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+  });
+});

--- a/packages/server/src/controllers/messageController.ts
+++ b/packages/server/src/controllers/messageController.ts
@@ -5,6 +5,7 @@ import * as channelService from '../services/channelService';
 import * as auditLogService from '../services/auditLogService';
 import { AuthenticatedRequest } from '../middleware/auth';
 import { queryOne } from '../db/database';
+import { parseCursorParams, buildCursorPage } from '../utils/pagination';
 
 export async function searchMessages(
   req: Request,
@@ -100,25 +101,18 @@ export async function searchMessages(
 export async function getMessages(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
     const channelId = Number(req.params.channelId);
-    const limit = req.query.limit ? Number(req.query.limit) : 50;
-    const before = req.query.before ? Number(req.query.before) : undefined;
+    const { limit, before } = parseCursorParams(req);
     const viewerUserId = (req as { userId?: number }).userId;
 
     // #375 ページング標準仕様（カーソル系）: { items, nextCursor, hasMore }
-    // hasMore 判定のため limit+1 件取得し、超過分（最古の余剰 1 件）を切り落とす。
-    // getChannelMessages は時系列昇順で返すため、余剰は先頭側に現れる。
+    // hasMore 判定のため limit+1 件取得し、共通ヘルパーで封筒化する。
     const fetched = await messageService.getChannelMessages(
       channelId,
       limit + 1,
       before,
       viewerUserId,
     );
-    const hasMore = fetched.length > limit;
-    const items = hasMore ? fetched.slice(fetched.length - limit) : fetched;
-    // 次に遡る際の before に渡すカーソル = 現在表示中の最古メッセージ ID
-    const nextCursor = hasMore && items.length > 0 ? String(items[0].id) : null;
-
-    res.json({ items, nextCursor, hasMore });
+    res.json(buildCursorPage(fetched, limit));
   } catch (err) {
     next(err);
   }
@@ -175,8 +169,10 @@ export async function deleteMessage(
 
 export async function getReplies(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    const replies = await messageService.getThreadReplies(Number(req.params.id));
-    res.json({ replies });
+    // #386 ページング標準仕様（カーソル系）: { items, nextCursor, hasMore }
+    const { limit, before } = parseCursorParams(req);
+    const fetched = await messageService.getThreadReplies(Number(req.params.id), limit + 1, before);
+    res.json(buildCursorPage(fetched, limit));
   } catch (err) {
     next(err);
   }

--- a/packages/server/src/routes/dm.ts
+++ b/packages/server/src/routes/dm.ts
@@ -3,6 +3,7 @@ import { createError } from '../middleware/errorHandler';
 import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { createRateLimitMiddleware } from '../middleware/rateLimit';
 import * as dmService from '../services/dmService';
+import { parseCursorParams, buildCursorPage } from '../utils/pagination';
 
 const router = Router();
 
@@ -48,12 +49,16 @@ router.get('/conversations/:conversationId/messages', authenticateToken, async (
     return next(createError('Conversation not found', 404));
   }
 
-  const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
-  const before = req.query.before ? parseInt(req.query.before as string, 10) : undefined;
+  // #386 ページング標準仕様（カーソル系）: { items, nextCursor, hasMore }
+  const { limit, before } = parseCursorParams(req);
 
   try {
-    const messages = await dmService.getMessages(conversationId, userId, { limit, before });
-    return res.json({ messages });
+    // hasMore 判定のため limit+1 件取得して共通ヘルパーで封筒化する
+    const fetched = await dmService.getMessages(conversationId, userId, {
+      limit: limit + 1,
+      before,
+    });
+    return res.json(buildCursorPage(fetched, limit));
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Conversation not found or access denied') {

--- a/packages/server/src/routes/guestLinks.ts
+++ b/packages/server/src/routes/guestLinks.ts
@@ -20,6 +20,7 @@ import { queryOne } from '../db/database';
 import * as guestLinkService from '../services/guestLinkService';
 import * as permissionService from '../services/permissionService';
 import * as auditLogService from '../services/auditLogService';
+import { parseCursorParams, buildCursorPage } from '../utils/pagination';
 
 // 管理者・チャンネル別の発行/一覧用ルーター（/api/channels/:id/guest-links 配下）
 export const channelGuestLinksRouter = Router({ mergeParams: true });
@@ -196,8 +197,10 @@ router.get(
         next(createError('トークンが一致しません', 403));
         return;
       }
-      const messages = await guestLinkService.listGuestMessages(guest.channelId);
-      res.json({ messages });
+      // #386 ページング標準仕様（カーソル系）: { items, nextCursor, hasMore }
+      const { limit, before } = parseCursorParams(req);
+      const fetched = await guestLinkService.listGuestMessages(guest.channelId, limit + 1, before);
+      res.json(buildCursorPage(fetched, limit));
     } catch (err) {
       next(err);
     }

--- a/packages/server/src/routes/messages.ts
+++ b/packages/server/src/routes/messages.ts
@@ -60,9 +60,28 @@ router.get('/search', authenticateToken, controller.searchMessages);
  *         required: true
  *         schema: { type: integer }
  *         description: ルートメッセージID
+ *       - in: query
+ *         name: limit
+ *         description: 1ページあたりの件数（既定 50・上限 100、#386 カーソル系ページング）
+ *         schema: { type: integer, default: 50 }
+ *       - in: query
+ *         name: before
+ *         description: 前ページで受け取った nextCursor（より古い返信を読み込む）
+ *         schema: { type: integer }
  *     responses:
  *       200:
- *         description: 返信メッセージ一覧
+ *         description: カーソル系ページング { items, nextCursor, hasMore }（#386）
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 items:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Message'
+ *                 nextCursor: { type: string, nullable: true }
+ *                 hasMore: { type: boolean }
  */
 router.get('/:id/replies', authenticateToken, controller.getReplies);
 

--- a/packages/server/src/services/guestLinkService.ts
+++ b/packages/server/src/services/guestLinkService.ts
@@ -238,7 +238,11 @@ export async function verifyAndIssueSession(
  * - parent_message_id IS NULL（トップレベルのみ。スレッド返信は除外）
  * - 添付メタデータは含む（リアクションは含まない）
  */
-export async function listGuestMessages(channelId: number): Promise<
+export async function listGuestMessages(
+  channelId: number,
+  limit?: number,
+  before?: number,
+): Promise<
   Array<{
     id: number;
     channelId: number;
@@ -258,7 +262,31 @@ export async function listGuestMessages(channelId: number): Promise<
     }>;
   }>
 > {
-  const rows = await query<{
+  // limit 未指定は従来どおり全件を時系列昇順で返す。
+  // #386 limit 指定時はカーソル系: 最新 limit 件を id 降順で取得し昇順に戻す（チャンネル/DM と同方式）。
+  const params: unknown[] = [channelId];
+  let sql = `SELECT m.id, m.channel_id, m.user_id, u.username, u.avatar_url, m.content,
+            m.created_at, m.updated_at, m.is_edited
+     FROM messages m
+     LEFT JOIN users u ON u.id = m.user_id
+     WHERE m.channel_id = $1
+       AND m.is_deleted = false
+       AND m.parent_message_id IS NULL`;
+  let descending = false;
+  if (limit === undefined) {
+    sql += ' ORDER BY m.created_at ASC, m.id ASC';
+  } else {
+    let idx = 2;
+    if (before !== undefined) {
+      sql += ` AND m.id < $${idx++}`;
+      params.push(before);
+    }
+    sql += ` ORDER BY m.created_at DESC, m.id DESC LIMIT $${idx}`;
+    params.push(limit);
+    descending = true;
+  }
+
+  const baseRows = await query<{
     id: number;
     channel_id: number;
     user_id: number | null;
@@ -268,17 +296,8 @@ export async function listGuestMessages(channelId: number): Promise<
     created_at: string;
     updated_at: string;
     is_edited: boolean;
-  }>(
-    `SELECT m.id, m.channel_id, m.user_id, u.username, u.avatar_url, m.content,
-            m.created_at, m.updated_at, m.is_edited
-     FROM messages m
-     LEFT JOIN users u ON u.id = m.user_id
-     WHERE m.channel_id = $1
-       AND m.is_deleted = false
-       AND m.parent_message_id IS NULL
-     ORDER BY m.created_at ASC, m.id ASC`,
-    [channelId],
-  );
+  }>(sql, params);
+  const rows = descending ? baseRows.reverse() : baseRows;
 
   // 添付をまとめて取得
   const ids = rows.map((r) => r.id);

--- a/packages/server/src/services/messageService.ts
+++ b/packages/server/src/services/messageService.ts
@@ -236,11 +236,32 @@ export async function createThreadReply(
   return toMessage(row!);
 }
 
-export async function getThreadReplies(rootMessageId: number): Promise<Message[]> {
-  const rows = await query<MessageRow>(
-    MESSAGE_SELECT + ' WHERE m.root_message_id = $1 ORDER BY m.created_at ASC, m.id ASC',
-    [rootMessageId],
-  );
+export async function getThreadReplies(
+  rootMessageId: number,
+  limit?: number,
+  before?: number,
+): Promise<Message[]> {
+  // limit 未指定（socket 等）は従来どおり全件を時系列昇順で返す。
+  if (limit === undefined) {
+    const rows = await query<MessageRow>(
+      MESSAGE_SELECT + ' WHERE m.root_message_id = $1 ORDER BY m.created_at ASC, m.id ASC',
+      [rootMessageId],
+    );
+    return Promise.all(rows.map(toMessage));
+  }
+
+  // #386 カーソル系: 最新 limit 件を id 降順で取得して昇順に戻す（チャンネル/DM と同方式）
+  let sql = MESSAGE_SELECT + ' WHERE m.root_message_id = $1';
+  const params: unknown[] = [rootMessageId];
+  let idx = 2;
+  if (before !== undefined) {
+    sql += ` AND m.id < $${idx++}`;
+    params.push(before);
+  }
+  sql += ` ORDER BY m.created_at DESC, m.id DESC LIMIT $${idx}`;
+  params.push(limit);
+
+  const rows = (await query<MessageRow>(sql, params)).reverse();
   return Promise.all(rows.map(toMessage));
 }
 

--- a/packages/server/src/utils/pagination.ts
+++ b/packages/server/src/utils/pagination.ts
@@ -1,0 +1,44 @@
+import type { Request } from 'express';
+import type { CursorPaged } from '@chat-app/shared';
+
+/**
+ * カーソル系ページング（#375 / #386）の共通ユーティリティ。
+ *
+ * 一覧系エンドポイント（チャンネル / DM / ゲスト / スレッド返信のメッセージ）で共用する。
+ * サービス層は「時系列昇順で limit+1 件」取得し、本ヘルパーで封筒 { items, nextCursor, hasMore } を導出する。
+ */
+
+/** カーソル系のデフォルト・上限 limit */
+export const CURSOR_DEFAULT_LIMIT = 50;
+export const CURSOR_MAX_LIMIT = 100;
+
+/**
+ * クエリから limit / before を取り出す。
+ * - limit: 1〜CURSOR_MAX_LIMIT にクランプ（未指定は CURSOR_DEFAULT_LIMIT）
+ * - before: 直前ページの nextCursor（数値 ID 文字列）。未指定は undefined
+ */
+export function parseCursorParams(req: Request): { limit: number; before?: number } {
+  const rawLimit = req.query.limit ? Number(req.query.limit) : CURSOR_DEFAULT_LIMIT;
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(Math.max(Math.trunc(rawLimit), 1), CURSOR_MAX_LIMIT)
+    : CURSOR_DEFAULT_LIMIT;
+  const before = req.query.before ? Number(req.query.before) : undefined;
+  return { limit, before: before !== undefined && Number.isFinite(before) ? before : undefined };
+}
+
+/**
+ * 時系列昇順で limit+1 件取得済みの配列から、カーソル封筒を導出する。
+ *
+ * - hasMore: 取得件数が limit を超えたか（= さらに古いメッセージが存在する）
+ * - items  : 超過時は最古の余剰 1 件を切り落とした最新 limit 件（昇順を維持）
+ * - nextCursor: 次に遡る際の before に渡す「現在表示中の最古メッセージ ID」の文字列。続きが無ければ null
+ */
+export function buildCursorPage<T extends { id: number }>(
+  fetched: T[],
+  limit: number,
+): CursorPaged<T> {
+  const hasMore = fetched.length > limit;
+  const items = hasMore ? fetched.slice(fetched.length - limit) : fetched;
+  const nextCursor = hasMore && items.length > 0 ? String(items[0].id) : null;
+  return { items, nextCursor, hasMore };
+}


### PR DESCRIPTION
## 概要
#375 で定義したページング標準仕様（カーソル系 `{ items, nextCursor, hasMore }`）へ、残りのメッセージ系 API を移行する。実ページングが意味を持つメッセージ系 3 エンドポイント（DM / ゲスト / スレッド返信）を対象とし、オートコンプリート・有界リスト（tags / wiki / calendar）は標準化対象外として doc に明記する。

スコープは事前合意（オプションC: DM + ゲスト + スレッド返信を移行）。

## 変更内容
### サーバー
- **共通ヘルパー** `packages/server/src/utils/pagination.ts` を新設
  - `parseCursorParams(req)`: `limit`（既定50・上限100クランプ）/ `before` を抽出
  - `buildCursorPage(fetched, limit)`: `limit+1` 件の昇順配列から `{ items, nextCursor, hasMore }` を導出
  - 既存のチャンネルメッセージ（#375）も本ヘルパーへ置換し DRY 化
- `GET /api/dm/conversations/:id/messages`：`{ messages }` → カーソル系（`dmService` は既存の limit/before 対応のまま、ルートで封筒化）
- `GET /api/guest-links/:token/messages`：`{ messages }` → カーソル系（`listGuestMessages` に任意 limit/before 追加）
- `GET /api/messages/:id/replies`：`{ replies }` → カーソル系（`getThreadReplies` に任意 limit/before 追加。**socket 用の全件取得（limit 未指定）は従来動作を維持**）
- Swagger 更新

### フロント
- `api` クライアント（`dm.getMessages` / `messages.getReplies` / `guestLinks.messages`）を `CursorPaged` へ
- 消費側 `DMPage` / `GuestChannelPage` / `ChatPage`（スレッドパネル）を `items` 読み取りへ

### ドキュメント
- `doc/api-pagination-guide.md`：適用済みエンドポイントに DM/ゲスト/返信を追加。**tags サジェスト / wiki `{pages}` / calendar `{events}` を「標準化対象外（理由付き）」として明記**

### 付随修正（テスト安定化）
- `TaskBoardPage.test.tsx` の期限サマリーバッジテストが**実行時刻が23時以降だと失敗する時刻依存フレーク**だったため修正（`isOverdue`(datetime過去) と `isDueToday`(同日) が重複し、「今日23時」期限が期限切れに二重計上されていた）。システム時刻を当日午前9時に固定して排除。

## 影響範囲
- レスポンス形状変更（意図的）に伴い既存テストのアサーション/モックを `items` 系へ更新
  - サーバー: `direct-message.test.ts` / `routes/guestLinks.test.ts`（`res.body.messages` → `items`）
  - クライアント: `DMPage.test.tsx` / `GuestChannelPage.test.tsx`（`{ messages }` モック → カーソル封筒）
- サービス層の戻り値は壊さず**任意の limit/before を追加**したため、socket 等の既存呼び出しに影響なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテスト：**2561 passed**（全パス）
- [x] バックエンドユニットテスト：**1809 passed**（全パス）
- [x] ビルド正常完了（`npm run build` 成功、lint エラー 0）
- [ ] 手動確認：未実施（必要なら Playwright で実施可能）

## 関連Issue
Fixes #386
関連: #375 / PR #385

## チェックリスト
- [x] 自己レビュー実施
- [x] 命名規則に準拠
- [x] ドキュメント（guide / Swagger）更新
- [x] `it.todo` / 空ボディ `it` の残存なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)