### PR TITLE
test: 統合テストの並列実行フレークを堅牢化で解消する (#381)

### DIFF
--- a/packages/server/src/__tests__/presence-socket.test.ts
+++ b/packages/server/src/__tests__/presence-socket.test.ts
@@ -106,7 +106,7 @@ describe('Socket.IO プレゼンス連携', () => {
       const b = makeClient(port, 200, 'bob');
       const bulkPromise = new Promise<{ states: Array<{ userId: number; state: string }> }>(
         (resolve, reject) => {
-          const timer = setTimeout(() => reject(new Error('bulk not received')), 2000);
+          const timer = setTimeout(() => reject(new Error('bulk not received')), 5000);
           b.on('presence:bulk', (data) => {
             clearTimeout(timer);
             resolve(data);
@@ -127,7 +127,7 @@ describe('Socket.IO プレゼンス連携', () => {
     it('クライアント A が接続すると、既に接続済みのクライアント B が presence:state ({state:"online"}) を受信する', async () => {
       const b = await connectClient(port, 200, 'bob');
       const statePromise = new Promise<{ userId: number; state: string }>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error('state not received')), 2000);
+        const timer = setTimeout(() => reject(new Error('state not received')), 5000);
         b.on('presence:state', (p) => {
           if (p.userId === 100 && p.state === 'online') {
             clearTimeout(timer);
@@ -167,14 +167,28 @@ describe('Socket.IO プレゼンス連携', () => {
 
     it('A と B が同一ユーザーの複数タブの場合、片方の disconnect では state 変化が broadcast されない', async () => {
       const observer = await connectClient(port, 999, 'observer');
+
+      // #381 フレーク対策: tab1/tab2 接続時の alice online broadcast は並列負荷下で遅延しうる。
+      // 記録を「接続時 online の到達後」に開始しないと、その遅延イベントが received に混入する。
+      let recording = false;
+      const received: Array<{ userId: number; state: string }> = [];
+      const initialOnline = new Promise<void>((resolve) => {
+        observer.on('presence:state', (p) => {
+          if (p.userId !== 100) return;
+          if (recording) {
+            received.push(p);
+          } else if (p.state === 'online') {
+            resolve();
+          }
+        });
+      });
+
       const tab1 = await connectClient(port, 100, 'alice');
       const tab2 = await connectClient(port, 100, 'alice');
 
-      // observer に届いた presence:state を全て記録
-      const received: Array<{ userId: number; state: string }> = [];
-      observer.on('presence:state', (p) => {
-        received.push(p);
-      });
+      // alice の接続時 online が observer に伝播し切るのを待ってから記録開始
+      await initialOnline;
+      recording = true;
 
       // tab1 だけ閉じる → tab2 が残るので state 変化なし
       tab1.close();
@@ -183,8 +197,7 @@ describe('Socket.IO プレゼンス連携', () => {
       await new Promise((r) => setTimeout(r, OFFLINE_GRACE_MS + 500));
 
       // alice に関する state 変化通知が出ていないこと
-      const aliceEvents = received.filter((p) => p.userId === 100);
-      expect(aliceEvents).toEqual([]);
+      expect(received).toEqual([]);
 
       tab2.close();
       observer.close();
@@ -203,22 +216,33 @@ describe('Socket.IO プレゼンス連携', () => {
 
     it('away 状態のユーザーが heartbeat を送ると online に復帰し、他クライアントが presence:state を受信する', async () => {
       const observer = await connectClient(port, 999, 'observer');
-      const a = await connectClient(port, 100, 'alice');
 
-      // alice を強制的に away にする
-      // presenceService の handleHeartbeat / scheduleAway は内部状態に依存するため、
-      // ここでは state を直接書き換えるユーティリティが無いので、broadcast 経路を確認するために
-      // 一旦 listener をローカルに用意して、heartbeat 後に online 通知が走るかだけを観察する。
+      // heartbeat 後に online 通知が再度走らない（過剰 broadcast を出さない）ことを確認する。
       // → 既に online のユーザーの heartbeat では state 変化なし（仕様）。
-      //   away からの復帰の broadcast は、別経路（presenceService 単体テスト）で確認済み。
-      // ここでは「heartbeat を受信した後に再度 online で broadcast する」処理が走っても
-      // すでに online であれば変化なしとなることを示す（過剰 broadcast を出さない確認）。
+      //   away からの復帰の broadcast は別経路（presenceService 単体テスト）で確認済み。
+      // #381 フレーク対策: alice 接続時の online broadcast は並列負荷下で遅延しうる。
+      // リスナーは alice 接続「前」に貼り（接続時 online を取りこぼさない）、その online を
+      // 受信し切ってから記録モードに切り替える。これで遅延イベントの received 混入を防ぐ。
+      let recording = false;
       const received: Array<{ userId: number; state: string }> = [];
-      observer.on('presence:state', (p) => {
-        if (p.userId === 100) received.push(p);
+      const initialOnline = new Promise<void>((resolve) => {
+        observer.on('presence:state', (p) => {
+          if (p.userId !== 100) return;
+          if (recording) {
+            received.push(p);
+          } else if (p.state === 'online') {
+            resolve();
+          }
+        });
       });
+
+      const a = await connectClient(port, 100, 'alice');
+      // alice 接続時の online が observer に伝播し切るのを待つ
+      await initialOnline;
+
+      recording = true;
       a.emit('presence:heartbeat');
-      await new Promise((r) => setTimeout(r, 100));
+      await new Promise((r) => setTimeout(r, 200));
       // 既に online なので新たな state 変化通知は無い
       expect(received).toEqual([]);
 
@@ -231,7 +255,7 @@ describe('Socket.IO プレゼンス連携', () => {
     it('presence:state は接続中ユーザー集合（同一ワークスペース）にだけ broadcast される', async () => {
       const observer = await connectClient(port, 999, 'observer');
       const statePromise = new Promise<{ userId: number; state: string }>((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error('state not received')), 2000);
+        const timer = setTimeout(() => reject(new Error('state not received')), 5000);
         observer.on('presence:state', (p) => {
           if (p.userId === 100 && p.state === 'online') {
             clearTimeout(timer);


### PR DESCRIPTION
## 概要
`npm run test`（`jest --maxWorkers=50%` = 並列）でのみ発生していたサーバーテストのフレークを、テスト設計の堅牢化で根治する。本 PR は #381 の方針 **Phase 1（socket/timing 根治）** に対応。

## 調査（実測ベース）
- 並列実行でフレークを再現（本セッションでは `presence-socket.test.ts` が落ちた）。直列は安定。
- `presenceService` / `rateLimitService` は純 in-memory（DB 不使用）→ 「実 postgres 接続」が presence 系フレークの原因ではない。
- 落ちていた2テストは **クライアント接続時の `online` broadcast が CPU 競合下で遅延し、記録用リスナーを接続後に貼る順序だとその遅延イベントが `received` に混入する**テスト設計上の競合だった（`Expected [] / Received [{online}]`）。
- `socket-handler.test.ts` は**モックソケット**使用で `setTimeout(0)` はマイクロタスク後に確実実行＝決定論的のため対象外。

## 変更内容（`packages/server/src/__tests__/presence-socket.test.ts`）
- 「away→online heartbeat」「複数タブ」テストで、**記録用リスナーを接続前に貼り**、接続時 `online` の到達を待ってから記録モードへ切り替える（決定論化）
- イベント待ちの reject タイムアウトを `2000ms → 5000ms` に緩和（並列負荷耐性。イベントは依然必須＝アサーションは不変）
- 各修正には `#381 フレーク対策` のコメントで理由を明記

**アサーションは一切弱めていない**（待機方法と後始末の堅牢化のみ）。

## 動作確認・テスト結果
- presence-socket 単体: 8/8 通過
- **フルスイート並列（`--maxWorkers=50%`）を 20 回連続実行 → 0 失敗**
- `npm run build` 成功 / サーバーテスト 1809 件全通過 / lint エラー 0（新規警告なし）

## 受け入れ条件
- [x] `--maxWorkers=50%` を 10 回連続実行してサーバーテストが全通過する（実測 **20/20**）
- [x] フレークの原因（接続時 broadcast の遅延 × 記録順序）が解消され、修正理由がコメントで明示されている
- [x] 既存のアサーションを弱めずに安定化している

## 補足
- Issue が挙げていた統合系フレーク（rateLimit 404 / channel 403 等）は本セッションでは 20 連続でも再発せず（#382 の先行修正＋本修正で実質収束）。
- 予防的ハードニング（`clearMocks`/`restoreMocks`・シングルトンの全体リセット・`forceExit` 撤廃）は受け入れ条件達成済みのため本 PR では見送り。必要なら別途 Phase 2 以降として扱える。

## 関連Issue
Fixes #381
検出経緯: #372 / #379、先行対応: #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)