### PR TITLE
docs: Codex用スキル定義を追加

### DIFF
--- a/.codex/skills/cleanup-worktrees/SKILL.md
+++ b/.codex/skills/cleanup-worktrees/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: cleanup-worktrees
+description: worktree と作業ブランチを整理するときに使う。手順本体は .claude/commands/cleanup-worktrees.md を正本として参照する。
+---
+
+# Cleanup Worktrees
+
+`.claude/commands/cleanup-worktrees.md` を読み、その手順に従う。
+
+## Codex での読み替え
+
+- Claude Code の `allowed-tools` は Codex で利用可能なツールに読み替える。
+- `AGENTS.md` と現在の Codex/developer 指示を優先する。
+- 削除操作は、参照先 command の確認手順どおり、ユーザーの明示的な承認後にだけ実行する。

--- a/.codex/skills/doc-pr/SKILL.md
+++ b/.codex/skills/doc-pr/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: doc-pr
+description: ドキュメント変更のみの PR 作成や差分確認を進めるときに使う。手順本体は .claude/commands/doc-pr.md を正本として参照する。
+---
+
+# Doc PR
+
+`.claude/commands/doc-pr.md` を読み、その手順に従う。
+
+## Codex での読み替え
+
+- Claude Code の `allowed-tools` は Codex で利用可能なツールに読み替える。
+- `AGENTS.md` と現在の Codex/developer 指示を優先する。
+- PR 作成前チェック、PR テンプレート、コミット規約は `AGENTS.md` に従う。
+- マージ操作は、ユーザーが明示的に依頼・承認した場合を除き実行しない。

--- a/.codex/skills/parallel-feature-dev
+++ b/.codex/skills/parallel-feature-dev
@@ -1,0 +1,1 @@
+../../.claude/skills/parallel-feature-dev

--- a/.codex/skills/plan-issues/SKILL.md
+++ b/.codex/skills/plan-issues/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: plan-issues
+description: 複数 Issue の並列開発計画と Issue 別注意点ドキュメントを生成するときに使う。手順本体は .claude/commands/plan-issues.md を正本として参照する。
+---
+
+# Plan Issues
+
+`.claude/commands/plan-issues.md` を読み、その手順に従う。
+
+## Codex での読み替え
+
+- Claude Code の `allowed-tools` は Codex で利用可能なツールに読み替える。
+- `$ARGUMENTS` はユーザーが `$plan-issues` 呼び出し時に指定した Issue 番号の範囲またはリストとして扱う。
+- `AGENTS.md` と現在の Codex/developer 指示を優先する。
+- 参照先 command の制約どおり、コード変更は行わず計画ドキュメント生成に限定する。

--- a/.codex/skills/react19-troubleshooting
+++ b/.codex/skills/react19-troubleshooting
@@ -1,0 +1,1 @@
+../../.claude/skills/react19-troubleshooting


### PR DESCRIPTION
## 概要
Codex から既存の Claude Code command / skill 手順を呼び出せるように、Codex 用の skill 定義を追加します。

## 変更内容
- `.codex/skills/cleanup-worktrees/SKILL.md` を追加
- `.codex/skills/doc-pr/SKILL.md` を追加
- `.codex/skills/plan-issues/SKILL.md` を追加
- `.codex/skills/parallel-feature-dev` を `.claude/skills/parallel-feature-dev` へのシンボリックリンクとして追加
- `.codex/skills/react19-troubleshooting` を `.claude/skills/react19-troubleshooting` へのシンボリックリンクとして追加

## 影響範囲
- Codex の skill 呼び出し定義のみ
- アプリケーションコード、DBスキーマ、テストコードへの影響なし

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする
- [x] バックエンドユニットテストがすべてパスする
- [x] ビルドが正常に完了すること
- [x] (手動確認の場合) `rg` で `it.todo` / 空ボディの `it` が残っていないことを確認

実行結果:
- `npm run build`: 成功
- `npm run test`: 成功（server 1851件、client 2573件）
- `rg "it\\.(todo|skip)\\(|it\\s*\\(\\s*['\"][^'\"]+['\"]\\s*,\\s*\\(\\s*\\)\\s*=>\\s*\\{\\s*\\}\\s*\\)" packages -g "*.test.*"`: 一致なし

## 関連Issue
Fixes #0

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）
