### PR TITLE
feat: ヘルスチェック詳細ページを追加

### DIFF
--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let user: ReturnType<typeof userEvent.setup>;
 import { MemoryRouter } from 'react-router-dom';
 import AdminPage from '../pages/AdminPage';
-import type { AdminUser, AdminChannel, AdminStats } from '../types/admin';
+import type { AdminUser, AdminChannel, AdminStats, AdminHealthDetails } from '../types/admin';
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
@@ -90,6 +90,53 @@ const mockStats: AdminStats = {
   activeUsersLast7d: 20,
 };
 
+const mockHealthDetails: AdminHealthDetails = {
+  checkedAt: '2026-01-01T00:00:00.000Z',
+  overallStatus: 'warning',
+  components: {
+    database: {
+      status: 'normal',
+      reachable: true,
+      latencyMs: 12,
+      message: 'DB は応答しています',
+    },
+    socket: {
+      status: 'normal',
+      running: true,
+      connectionCount: 3,
+      message: 'Socket サーバーは稼働しています',
+    },
+    jobs: {
+      status: 'warning',
+      workers: [
+        {
+          key: 'scheduledMessages',
+          label: '予約送信',
+          status: 'normal',
+          running: true,
+          intervalMs: 30000,
+        },
+        {
+          key: 'calendarReminders',
+          label: 'カレンダーリマインダー',
+          status: 'warning',
+          running: false,
+          intervalMs: 30000,
+        },
+      ],
+      message: '停止中のジョブがあります',
+    },
+    storage: {
+      status: 'error',
+      writable: false,
+      totalBytes: 2048,
+      fileCount: 4,
+      path: '/tmp/uploads',
+      message: 'ストレージへ書き込めません',
+    },
+  },
+};
+
 vi.mock('../api/client', () => ({
   api: {
     admin: {
@@ -97,6 +144,7 @@ vi.mock('../api/client', () => ({
       getTimeseries: vi.fn(),
       getChannelTimeseries: vi.fn(),
       getTopChannels: vi.fn(),
+      getHealthDetails: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
       updateUserRole: vi.fn(),
@@ -158,6 +206,7 @@ const mockedApi = api as unknown as {
     getTimeseries: ReturnType<typeof vi.fn>;
     getChannelTimeseries: ReturnType<typeof vi.fn>;
     getTopChannels: ReturnType<typeof vi.fn>;
+    getHealthDetails: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
     updateUserRole: ReturnType<typeof vi.fn>;
@@ -216,6 +265,7 @@ beforeEach(() => {
   mockedApi.admin.getTimeseries.mockResolvedValue({ messages: [], activeUsers: [] });
   mockedApi.admin.getChannelTimeseries.mockResolvedValue({ messagesByChannel: [] });
   mockedApi.admin.getTopChannels.mockResolvedValue({ channels: [] });
+  mockedApi.admin.getHealthDetails.mockResolvedValue(mockHealthDetails);
   mockedApi.admin.getUsers.mockResolvedValue({ users: mockAdminUsers });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: mockAdminChannels });
   mockedApi.admin.updateUserRole.mockResolvedValue({ success: true });
@@ -994,5 +1044,61 @@ describe('AdminPage: 設定エクスポート / インポート (#394)', () => {
     );
 
     await waitFor(() => expect(mockShowError).toHaveBeenCalledWith('schema error'));
+  });
+});
+
+// #390 ヘルスチェック詳細ページ
+describe('AdminPage: ヘルスチェック詳細 (#390)', () => {
+  async function openHealthTab() {
+    await renderAdminPage();
+    await user.click(screen.getByRole('tab', { name: /ヘルスチェック/ }));
+  }
+
+  it('管理画面にヘルスチェック詳細タブが表示される', async () => {
+    await renderAdminPage();
+    expect(screen.getByRole('tab', { name: /ヘルスチェック/ })).toBeInTheDocument();
+  });
+
+  it('ヘルスチェック詳細タブを開くと詳細取得 API が呼び出される', async () => {
+    await openHealthTab();
+    await waitFor(() => expect(mockedApi.admin.getHealthDetails).toHaveBeenCalled());
+  });
+
+  it('DB 接続状態の応答可否とレイテンシが表示される', async () => {
+    await openHealthTab();
+    expect(await screen.findByText('DB 接続')).toBeInTheDocument();
+    expect(screen.getByText('応答可')).toBeInTheDocument();
+    expect(screen.getByText(/12 ms/)).toBeInTheDocument();
+  });
+
+  it('Socket サーバーの稼働状態と接続数が表示される', async () => {
+    await openHealthTab();
+    expect(await screen.findByText('Socket サーバー')).toBeInTheDocument();
+    expect(screen.getAllByText('稼働中').length).toBeGreaterThan(0);
+    expect(screen.getByText('3 接続')).toBeInTheDocument();
+  });
+
+  it('予約送信・リマインダーのジョブ稼働状態が表示される', async () => {
+    await openHealthTab();
+    expect(await screen.findByText('バックグラウンドジョブ')).toBeInTheDocument();
+    expect(screen.getByText('予約送信')).toBeInTheDocument();
+    expect(screen.getByText('カレンダーリマインダー')).toBeInTheDocument();
+    expect(screen.getByText('停止中')).toBeInTheDocument();
+  });
+
+  it('ストレージの利用状況と書き込み可否が表示される', async () => {
+    await openHealthTab();
+    expect(await screen.findByText('ストレージ')).toBeInTheDocument();
+    expect(screen.getByText('書き込み不可')).toBeInTheDocument();
+    expect(screen.getByText('2 KB')).toBeInTheDocument();
+    expect(screen.getByText('4 ファイル')).toBeInTheDocument();
+  });
+
+  it('normal・warning・error のステータスごとに色分けされた Chip が表示される', async () => {
+    await openHealthTab();
+    expect(await screen.findByText('ヘルスチェック詳細')).toBeInTheDocument();
+    expect(screen.getAllByText('正常').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('警告').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('異常').length).toBeGreaterThan(0);
   });
 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -79,6 +79,7 @@ import type {
   AdminStats,
   AdminTimeseriesResponse,
   AuditLogListResponse,
+  AdminHealthDetails,
   MaintenanceModeSettings,
   SettingsExportData,
   SettingsImportPreview,
@@ -580,6 +581,7 @@ export const api = {
     deleteChannel: (id: number) => request<void>(`/admin/channels/${id}`, { method: 'DELETE' }),
     unarchiveChannel: (id: number) =>
       request<{ channel: AdminChannel }>(`/admin/channels/${id}/archive`, { method: 'DELETE' }),
+    getHealthDetails: () => request<AdminHealthDetails>('/admin/health-details'),
     maintenance: {
       get: () => request<{ settings: MaintenanceModeSettings }>('/admin/maintenance-mode'),
       update: (data: { enabled: boolean; message?: string; restrictedOperations: string[] }) =>

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -61,6 +61,8 @@ import type {
   TopChannelByMessageCount,
   MaintenanceModeSettings,
   SettingsImportPreview,
+  AdminHealthDetails,
+  HealthStatus,
 } from '../types/admin';
 import {
   ResponsiveContainer,
@@ -545,6 +547,162 @@ function StatsContent({ statsPromise }: { statsPromise: Promise<AdminStats> }) {
           </CardContent>
         </Card>
       ))}
+    </Box>
+  );
+}
+
+const HEALTH_STATUS_LABEL: Record<HealthStatus, string> = {
+  normal: '正常',
+  warning: '警告',
+  error: '異常',
+};
+
+const HEALTH_STATUS_COLOR: Record<HealthStatus, 'success' | 'warning' | 'error'> = {
+  normal: 'success',
+  warning: 'warning',
+  error: 'error',
+};
+
+function StatusChip({ status }: { status: HealthStatus }) {
+  return (
+    <Chip
+      size="small"
+      color={HEALTH_STATUS_COLOR[status]}
+      label={HEALTH_STATUS_LABEL[status]}
+      sx={{ fontWeight: 600 }}
+    />
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function HealthCard({
+  title,
+  status,
+  children,
+}: {
+  title: string;
+  status: HealthStatus;
+  children: ReactNode;
+}) {
+  return (
+    <Card
+      elevation={0}
+      sx={{
+        flex: '1 1 260px',
+        minWidth: 260,
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+      }}
+    >
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', gap: 1.25 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+          <Typography variant="subtitle1" fontWeight={600}>
+            {title}
+          </Typography>
+          <StatusChip status={status} />
+        </Box>
+        {children}
+      </CardContent>
+    </Card>
+  );
+}
+
+function HealthDetailsContent({
+  healthPromise,
+}: {
+  healthPromise: Promise<AdminHealthDetails>;
+}) {
+  const details = use(healthPromise);
+  const { database, socket, jobs, storage } = details.components;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, p: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+        <Typography variant="h6">ヘルスチェック詳細</Typography>
+        <StatusChip status={details.overallStatus} />
+        <Typography variant="body2" color="text.secondary">
+          最終確認: {new Date(details.checkedAt).toLocaleString('ja-JP')}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+        <HealthCard title="DB 接続" status={database.status}>
+          <Typography variant="body2">{database.reachable ? '応答可' : '応答不可'}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            レイテンシ: {database.latencyMs === null ? '-' : `${database.latencyMs} ms`}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {database.message}
+          </Typography>
+        </HealthCard>
+
+        <HealthCard title="Socket サーバー" status={socket.status}>
+          <Typography variant="body2">{socket.running ? '稼働中' : '停止中'}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {socket.connectionCount} 接続
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {socket.message}
+          </Typography>
+        </HealthCard>
+
+        <HealthCard title="ストレージ" status={storage.status}>
+          <Typography variant="body2">{storage.writable ? '書き込み可' : '書き込み不可'}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {formatBytes(storage.totalBytes)}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {storage.fileCount} ファイル
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {storage.message}
+          </Typography>
+        </HealthCard>
+      </Box>
+
+      <Card elevation={0} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2 }}>
+        <CardContent>
+          <Box
+            sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1.5 }}
+          >
+            <Typography variant="subtitle1" fontWeight={600}>
+              バックグラウンドジョブ
+            </Typography>
+            <StatusChip status={jobs.status} />
+          </Box>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>ジョブ</TableCell>
+                <TableCell>状態</TableCell>
+                <TableCell>間隔</TableCell>
+                <TableCell>ステータス</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {jobs.workers.map((worker) => (
+                <TableRow key={worker.key}>
+                  <TableCell>{worker.label}</TableCell>
+                  <TableCell>{worker.running ? '稼働中' : '停止中'}</TableCell>
+                  <TableCell>{Math.round(worker.intervalMs / 1000)} 秒</TableCell>
+                  <TableCell>
+                    <StatusChip status={worker.status} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+            {jobs.message}
+          </Typography>
+        </CardContent>
+      </Card>
     </Box>
   );
 }
@@ -1192,9 +1350,46 @@ export default function AdminPage() {
 
   const usersPromise = useMemo(() => api.admin.getUsers(), []);
   const channelsPromise = useMemo(() => api.admin.getChannels(), []);
-  const maintenancePromise = useMemo(
+  const healthPromise = useMemo(
     () =>
       tab === 6
+        ? api.admin.getHealthDetails()
+        : Promise.resolve({
+            checkedAt: new Date(0).toISOString(),
+            overallStatus: 'normal' as const,
+            components: {
+              database: {
+                status: 'normal' as const,
+                reachable: true,
+                latencyMs: 0,
+                message: '',
+              },
+              socket: {
+                status: 'normal' as const,
+                running: true,
+                connectionCount: 0,
+                message: '',
+              },
+              jobs: {
+                status: 'normal' as const,
+                workers: [],
+                message: '',
+              },
+              storage: {
+                status: 'normal' as const,
+                writable: true,
+                totalBytes: 0,
+                fileCount: 0,
+                path: '',
+                message: '',
+              },
+            },
+          }),
+    [tab],
+  );
+  const maintenancePromise = useMemo(
+    () =>
+      tab === 7
         ? api.admin.maintenance.get()
         : Promise.resolve({
             settings: {
@@ -1276,6 +1471,7 @@ export default function AdminPage() {
             <Tab label="監査ログ" />
             <Tab label="モデレーション設定" />
             <Tab label="通報キュー" />
+            <Tab label="ヘルスチェック" />
             <Tab label="メンテナンスモード" />
             <Tab label="設定入出力" />
           </Tabs>
@@ -1322,11 +1518,18 @@ export default function AdminPage() {
           {tab === 6 && (
             <ErrorBoundary>
               <Suspense fallback={fallback}>
+                <HealthDetailsContent healthPromise={healthPromise} />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+          {tab === 7 && (
+            <ErrorBoundary>
+              <Suspense fallback={fallback}>
                 <MaintenanceModeContent maintenancePromise={maintenancePromise} />
               </Suspense>
             </ErrorBoundary>
           )}
-          {tab === 7 && <SettingsImportExportContent />}
+          {tab === 8 && <SettingsImportExportContent />}
         </Box>
       </Box>
     </AppLayout>

--- a/packages/client/src/types/admin.ts
+++ b/packages/client/src/types/admin.ts
@@ -50,6 +50,46 @@ export interface AdminTimeseriesResponse {
   messagesByChannel?: ChannelTimeseries[];
 }
 
+export type HealthStatus = 'normal' | 'warning' | 'error';
+
+export interface AdminHealthDetails {
+  checkedAt: string;
+  overallStatus: HealthStatus;
+  components: {
+    database: {
+      status: HealthStatus;
+      reachable: boolean;
+      latencyMs: number | null;
+      message: string;
+    };
+    socket: {
+      status: HealthStatus;
+      running: boolean;
+      connectionCount: number;
+      message: string;
+    };
+    jobs: {
+      status: HealthStatus;
+      workers: Array<{
+        key: 'scheduledMessages' | 'messageReminders' | 'calendarReminders';
+        label: string;
+        status: HealthStatus;
+        running: boolean;
+        intervalMs: number;
+      }>;
+      message: string;
+    };
+    storage: {
+      status: HealthStatus;
+      writable: boolean;
+      totalBytes: number;
+      fileCount: number;
+      path: string;
+      message: string;
+    };
+  };
+}
+
 export type {
   MaintenanceModeSettings,
   MaintenanceRestriction,

--- a/packages/server/src/__tests__/integration/adminController.test.ts
+++ b/packages/server/src/__tests__/integration/adminController.test.ts
@@ -44,6 +44,137 @@ describe('GET /api/admin/users', () => {
   });
 });
 
+describe('GET /api/admin/health-details', () => {
+  it('正常: admin がリクエストすると DB・Socket・ジョブ・ストレージの状態一覧を返す', async () => {
+    const { token, userId } = await registerUser(app, 'adm_health', 'adm_health@example.com');
+    await makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('checkedAt');
+    expect(res.body).toHaveProperty('overallStatus');
+    expect(res.body.components).toEqual(
+      expect.objectContaining({
+        database: expect.any(Object),
+        socket: expect.any(Object),
+        jobs: expect.any(Object),
+        storage: expect.any(Object),
+      }),
+    );
+  });
+
+  it('正常: DB 接続状態に応答可否とレイテンシが含まれる', async () => {
+    const { token, userId } = await registerUser(app, 'adm_health_db', 'adm_health_db@example.com');
+    await makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.components.database).toEqual(
+      expect.objectContaining({
+        status: expect.stringMatching(/^(normal|warning|error)$/),
+        reachable: true,
+        latencyMs: expect.any(Number),
+      }),
+    );
+  });
+
+  it('正常: Socket サーバーの稼働状態と接続数が含まれる', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'adm_health_socket',
+      'adm_health_socket@example.com',
+    );
+    await makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.components.socket).toEqual(
+      expect.objectContaining({
+        status: expect.stringMatching(/^(normal|warning|error)$/),
+        running: expect.any(Boolean),
+        connectionCount: expect.any(Number),
+      }),
+    );
+  });
+
+  it('正常: 予約送信・リマインダーのジョブ稼働状態が含まれる', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'adm_health_jobs',
+      'adm_health_jobs@example.com',
+    );
+    await makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.components.jobs.workers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'scheduledMessages', running: expect.any(Boolean) }),
+        expect.objectContaining({ key: 'calendarReminders', running: expect.any(Boolean) }),
+      ]),
+    );
+  });
+
+  it('正常: ストレージの利用状況と書き込み可否が含まれる', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'adm_health_storage',
+      'adm_health_storage@example.com',
+    );
+    await makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.components.storage).toEqual(
+      expect.objectContaining({
+        status: expect.stringMatching(/^(normal|warning|error)$/),
+        writable: expect.any(Boolean),
+        totalBytes: expect.any(Number),
+        fileCount: expect.any(Number),
+      }),
+    );
+  });
+
+  it('正常: 各サブシステムに normal・warning・error のいずれかのステータスが付与される', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'adm_health_status',
+      'adm_health_status@example.com',
+    );
+    await makeAdmin(userId);
+
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+    const statuses = [
+      res.body.overallStatus,
+      res.body.components.database.status,
+      res.body.components.socket.status,
+      res.body.components.jobs.status,
+      res.body.components.storage.status,
+    ];
+
+    expect(res.status).toBe(200);
+    for (const status of statuses) {
+      expect(status).toMatch(/^(normal|warning|error)$/);
+    }
+  });
+
+  it('異常: 非ログインは 401 を返す', async () => {
+    const res = await request(app).get('/api/admin/health-details');
+    expect(res.status).toBe(401);
+  });
+
+  it('異常: 一般ユーザーは 403 を返す', async () => {
+    const { token } = await registerUser(app, 'adm_health_user', 'adm_health_user@example.com');
+    const res = await request(app).get('/api/admin/health-details').set('Cookie', `token=${token}`);
+    expect(res.status).toBe(403);
+  });
+});
+
 describe('PATCH /api/admin/users/:id/role', () => {
   it('正常: admin が他ユーザーのロールを変更できる', async () => {
     const { token, userId } = await registerUser(app, 'adm_role1', 'adm_role1@example.com');

--- a/packages/server/src/controllers/adminController.ts
+++ b/packages/server/src/controllers/adminController.ts
@@ -148,6 +148,19 @@ export async function getMaintenanceMode(
   }
 }
 
+export async function getHealthDetails(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const details = await adminService.getHealthDetails();
+    res.json(details);
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function updateMaintenanceMode(
   req: AuthenticatedRequest,
   res: Response,

--- a/packages/server/src/jobs/calendarReminderWorker.ts
+++ b/packages/server/src/jobs/calendarReminderWorker.ts
@@ -98,3 +98,13 @@ export function stopCalendarReminderWorker(): void {
     intervalHandle = null;
   }
 }
+
+export function getCalendarReminderWorkerStatus(): {
+  running: boolean;
+  intervalMs: number;
+} {
+  return {
+    running: intervalHandle !== null,
+    intervalMs: INTERVAL_MS,
+  };
+}

--- a/packages/server/src/jobs/scheduledMessageWorker.ts
+++ b/packages/server/src/jobs/scheduledMessageWorker.ts
@@ -4,6 +4,7 @@ import { getSocketServer } from '../socket';
 
 const PICK_LIMIT = 50;
 const INTERVAL_MS = 30_000;
+let intervalHandle: ReturnType<typeof setInterval> | null = null;
 
 /**
  * 1 tick 分の処理：期限切れ予約をピックして送信する。
@@ -43,9 +44,21 @@ export async function runOnce(): Promise<void> {
  * 30 秒ごとに runOnce を実行するスケジューラを起動する。
  * 起動直後に once 実行して、サーバー停止中に積まれた予約を即時処理する。
  */
-export function startScheduledMessageWorker(): void {
+export function startScheduledMessageWorker(): ReturnType<typeof setInterval> {
+  if (intervalHandle) return intervalHandle;
   void runOnce();
-  setInterval(() => {
+  intervalHandle = setInterval(() => {
     void runOnce();
   }, INTERVAL_MS);
+  return intervalHandle;
+}
+
+export function getScheduledMessageWorkerStatus(): {
+  running: boolean;
+  intervalMs: number;
+} {
+  return {
+    running: intervalHandle !== null,
+    intervalMs: INTERVAL_MS,
+  };
 }

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -43,6 +43,10 @@ router.put('/maintenance-mode', (req, res, next) =>
   controller.updateMaintenanceMode(req as unknown as AuthenticatedRequest, res, next),
 );
 
+router.get('/health-details', (req, res, next) =>
+  controller.getHealthDetails(req as unknown as AuthenticatedRequest, res, next),
+);
+
 router.get('/settings/export', (req, res, next) =>
   controller.exportSettings(req as unknown as AuthenticatedRequest, res, next),
 );

--- a/packages/server/src/services/adminService.ts
+++ b/packages/server/src/services/adminService.ts
@@ -1,5 +1,11 @@
+import fs from 'fs';
+import path from 'path';
 import { query, queryOne, execute } from '../db/database';
 import { createError } from '../middleware/errorHandler';
+import { getSocketServer } from '../socket';
+import { getScheduledMessageWorkerStatus } from '../jobs/scheduledMessageWorker';
+import { getCalendarReminderWorkerStatus } from '../jobs/calendarReminderWorker';
+import { getReminderSchedulerStatus } from './reminderService';
 import type {
   MaintenanceModeSettings,
   MaintenanceRestriction,
@@ -11,6 +17,46 @@ import type {
   SettingsImportDiff,
   SettingsImportPreview,
 } from '@chat-app/shared';
+
+export type HealthStatus = 'normal' | 'warning' | 'error';
+
+export interface AdminHealthDetails {
+  checkedAt: string;
+  overallStatus: HealthStatus;
+  components: {
+    database: {
+      status: HealthStatus;
+      reachable: boolean;
+      latencyMs: number | null;
+      message: string;
+    };
+    socket: {
+      status: HealthStatus;
+      running: boolean;
+      connectionCount: number;
+      message: string;
+    };
+    jobs: {
+      status: HealthStatus;
+      workers: Array<{
+        key: 'scheduledMessages' | 'messageReminders' | 'calendarReminders';
+        label: string;
+        status: HealthStatus;
+        running: boolean;
+        intervalMs: number;
+      }>;
+      message: string;
+    };
+    storage: {
+      status: HealthStatus;
+      writable: boolean;
+      totalBytes: number;
+      fileCount: number;
+      path: string;
+      message: string;
+    };
+  };
+}
 
 export interface AdminUser {
   id: number;
@@ -104,6 +150,7 @@ interface AdminChannelRow {
 
 const MAINTENANCE_SETTING_KEY = 'maintenance_mode';
 const VALID_MAINTENANCE_RESTRICTIONS: MaintenanceRestriction[] = ['posting', 'upload', 'login'];
+const UPLOAD_DIR = path.join(process.cwd(), 'uploads');
 
 const DEFAULT_MAINTENANCE_SETTINGS: MaintenanceModeSettings = {
   enabled: false,
@@ -141,6 +188,138 @@ function validateMaintenanceRestrictions(operations: unknown): MaintenanceRestri
     }
   }
   return Array.from(new Set(operations as MaintenanceRestriction[]));
+}
+
+function worstStatus(statuses: HealthStatus[]): HealthStatus {
+  if (statuses.includes('error')) return 'error';
+  if (statuses.includes('warning')) return 'warning';
+  return 'normal';
+}
+
+function directoryUsage(dir: string): { totalBytes: number; fileCount: number } {
+  if (!fs.existsSync(dir)) return { totalBytes: 0, fileCount: 0 };
+  let totalBytes = 0;
+  let fileCount = 0;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const child = directoryUsage(entryPath);
+      totalBytes += child.totalBytes;
+      fileCount += child.fileCount;
+    } else if (entry.isFile()) {
+      totalBytes += fs.statSync(entryPath).size;
+      fileCount += 1;
+    }
+  }
+  return { totalBytes, fileCount };
+}
+
+function checkStorage(): AdminHealthDetails['components']['storage'] {
+  try {
+    if (!fs.existsSync(UPLOAD_DIR)) {
+      fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+    }
+    const probePath = path.join(UPLOAD_DIR, `.healthcheck-${process.pid}-${Date.now()}`);
+    fs.writeFileSync(probePath, 'ok');
+    fs.unlinkSync(probePath);
+    const usage = directoryUsage(UPLOAD_DIR);
+    return {
+      status: 'normal',
+      writable: true,
+      totalBytes: usage.totalBytes,
+      fileCount: usage.fileCount,
+      path: UPLOAD_DIR,
+      message: 'ストレージへ書き込み可能です',
+    };
+  } catch (err) {
+    const usage = directoryUsage(UPLOAD_DIR);
+    return {
+      status: 'error',
+      writable: false,
+      totalBytes: usage.totalBytes,
+      fileCount: usage.fileCount,
+      path: UPLOAD_DIR,
+      message: err instanceof Error ? err.message : 'ストレージへ書き込めません',
+    };
+  }
+}
+
+export async function getHealthDetails(): Promise<AdminHealthDetails> {
+  const dbStart = Date.now();
+  let database: AdminHealthDetails['components']['database'];
+  try {
+    await queryOne('SELECT 1 AS ok');
+    const latencyMs = Date.now() - dbStart;
+    database = {
+      status: latencyMs > 500 ? 'warning' : 'normal',
+      reachable: true,
+      latencyMs,
+      message: latencyMs > 500 ? 'DB は応答していますが遅延しています' : 'DB は応答しています',
+    };
+  } catch (err) {
+    database = {
+      status: 'error',
+      reachable: false,
+      latencyMs: null,
+      message: err instanceof Error ? err.message : 'DB に接続できません',
+    };
+  }
+
+  const io = getSocketServer();
+  const socketRunning = io !== null;
+  const socket = {
+    status: socketRunning ? ('normal' as const) : ('warning' as const),
+    running: socketRunning,
+    connectionCount: io?.sockets.sockets.size ?? 0,
+    message: socketRunning ? 'Socket サーバーは稼働しています' : 'Socket サーバーが未初期化です',
+  };
+
+  const scheduled = getScheduledMessageWorkerStatus();
+  const messageReminders = getReminderSchedulerStatus();
+  const calendarReminders = getCalendarReminderWorkerStatus();
+  const workers: AdminHealthDetails['components']['jobs']['workers'] = [
+    {
+      key: 'scheduledMessages',
+      label: '予約送信',
+      status: scheduled.running ? 'normal' : 'warning',
+      running: scheduled.running,
+      intervalMs: scheduled.intervalMs,
+    },
+    {
+      key: 'messageReminders',
+      label: 'メッセージリマインダー',
+      status: messageReminders.running ? 'normal' : 'warning',
+      running: messageReminders.running,
+      intervalMs: messageReminders.intervalMs,
+    },
+    {
+      key: 'calendarReminders',
+      label: 'カレンダーリマインダー',
+      status: calendarReminders.running ? 'normal' : 'warning',
+      running: calendarReminders.running,
+      intervalMs: calendarReminders.intervalMs,
+    },
+  ];
+  const jobsStatus = worstStatus(workers.map((worker) => worker.status));
+  const jobs = {
+    status: jobsStatus,
+    workers,
+    message: jobsStatus === 'normal' ? 'すべてのジョブが稼働しています' : '停止中のジョブがあります',
+  };
+
+  const storage = checkStorage();
+  const overallStatus = worstStatus([database.status, socket.status, jobs.status, storage.status]);
+
+  return {
+    checkedAt: new Date().toISOString(),
+    overallStatus,
+    components: {
+      database,
+      socket,
+      jobs,
+      storage,
+    },
+  };
 }
 
 export async function getAdminUsers(): Promise<AdminUser[]> {

--- a/packages/server/src/services/reminderService.ts
+++ b/packages/server/src/services/reminderService.ts
@@ -156,8 +156,22 @@ export async function checkAndSendReminders(): Promise<void> {
   }
 }
 
+let reminderSchedulerHandle: NodeJS.Timeout | null = null;
+
 export function startReminderScheduler(): NodeJS.Timeout {
-  return setInterval(() => {
+  if (reminderSchedulerHandle) return reminderSchedulerHandle;
+  reminderSchedulerHandle = setInterval(() => {
     void checkAndSendReminders();
   }, 30 * 1000); // 30秒ごとにチェック
+  return reminderSchedulerHandle;
+}
+
+export function getReminderSchedulerStatus(): {
+  running: boolean;
+  intervalMs: number;
+} {
+  return {
+    running: reminderSchedulerHandle !== null,
+    intervalMs: 30 * 1000,
+  };
 }


### PR DESCRIPTION
## 概要

管理者向けに、DB 接続・Socket サーバー・バックグラウンドジョブ・ストレージ状態を一覧確認できるヘルスチェック詳細ページを追加します。

## 変更内容

- `GET /api/admin/health-details` を追加し、管理者のみ取得可能にしました
- DB 応答可否・レイテンシ、Socket 稼働状態・接続数、ジョブ稼働状態、ストレージ使用量・書き込み可否を集約するようにしました
- 予約送信 / メッセージリマインダー / カレンダーリマインダー worker の稼働状態 getter を追加しました
- 管理画面に「ヘルスチェック」タブを追加し、正常 / 警告 / 異常を Chip で色分け表示するようにしました
- API と管理画面のテストを追加しました

## 影響範囲

- 管理画面のタブ構成
- 管理者 API `/api/admin/*`
- worker 起動状態の参照用 API（既存処理の実行内容は変更なし）
- ストレージ確認時に `uploads` 配下へ一時 probe ファイルを作成して即時削除します

## 動作確認・テスト結果

- [x] フロントエンドユニットテストがすべてパスする
- [x] バックエンドユニットテストがすべてパスする
- [x] ビルドが正常に完了すること
- [x] (手動確認の場合) 確認した手順やスクリーンショット

実行結果:

- `npm run build` 成功
- `npm run test` 成功（server 1859件 / client 2580件）
- `rg -n "it\.todo|it\(['\"][^'\"]+['\"],\s*\(\)\s*=>\s*\{\s*\}\)" packages/client/src packages/server/src` 該当なし
- Playwright: 認証 Cookie 付きで `GET /api/admin/health-details` をブラウザから確認し、overallStatus / DB / Socket / jobs / storage の正常レスポンスを確認

補足:

- Playwright で管理画面 UI の実描画も試行しましたが、今回変更外の既存 runtime issue により画面描画前に停止しました。
  - Vite dev: `ReferenceError: init_emotion_react_browser_development_esm is not defined`
  - build preview: `/admin` 直接遷移で `Minified React error #130`
- そのため UI は Vitest で検証し、Playwright では API の実ブラウザ確認まで実施しています。

## 関連Issue

Fixes #390

## チェックリスト

- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）