### PR TITLE
[codex] feat: 孤立ファイルクリーンアップ

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -448,6 +448,11 @@ table "message_attachments" {
     default = sql("NOW()")
     comment = "作成日時"
   }
+  column "uploaded_by" {
+    null    = true
+    type    = integer
+    comment = "アップロードしたユーザーID（既存データ・削除済みユーザーはNULL）"
+  }
   column "scheduled_message_id" {
     null    = true
     type    = integer
@@ -478,6 +483,16 @@ table "message_attachments" {
     ref_columns = [table.drafts.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  foreign_key "fk_attachments_uploader" {
+    columns     = [column.uploaded_by]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
+  }
+  index "idx_attachments_orphan_candidates" {
+    columns = [column.created_at]
+    where   = "message_id IS NULL AND draft_id IS NULL AND scheduled_message_id IS NULL"
   }
 }
 

--- a/packages/client/src/__tests__/AdminPage.test.tsx
+++ b/packages/client/src/__tests__/AdminPage.test.tsx
@@ -13,7 +13,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 let user: ReturnType<typeof userEvent.setup>;
 import { MemoryRouter } from 'react-router-dom';
 import AdminPage from '../pages/AdminPage';
-import type { AdminUser, AdminChannel, AdminStats, AdminHealthDetails } from '../types/admin';
+import type {
+  AdminUser,
+  AdminChannel,
+  AdminStats,
+  AdminHealthDetails,
+  OrphanFile,
+} from '../types/admin';
 
 const mockNavigate = vi.hoisted(() => vi.fn());
 
@@ -156,6 +162,8 @@ vi.mock('../api/client', () => ({
       getJobMonitoring: vi.fn(),
       getUsers: vi.fn(),
       getChannels: vi.fn(),
+      getOrphanFiles: vi.fn(),
+      deleteOrphanFiles: vi.fn(),
       updateUserRole: vi.fn(),
       updateUserStatus: vi.fn(),
       deleteUser: vi.fn(),
@@ -219,6 +227,8 @@ const mockedApi = api as unknown as {
     getJobMonitoring: ReturnType<typeof vi.fn>;
     getUsers: ReturnType<typeof vi.fn>;
     getChannels: ReturnType<typeof vi.fn>;
+    getOrphanFiles: ReturnType<typeof vi.fn>;
+    deleteOrphanFiles: ReturnType<typeof vi.fn>;
     updateUserRole: ReturnType<typeof vi.fn>;
     updateUserStatus: ReturnType<typeof vi.fn>;
     deleteUser: ReturnType<typeof vi.fn>;
@@ -279,6 +289,13 @@ beforeEach(() => {
   mockedApi.admin.getJobMonitoring.mockResolvedValue(mockJobMonitoring);
   mockedApi.admin.getUsers.mockResolvedValue({ users: mockAdminUsers });
   mockedApi.admin.getChannels.mockResolvedValue({ channels: mockAdminChannels });
+  mockedApi.admin.getOrphanFiles.mockResolvedValue({ files: [] });
+  mockedApi.admin.deleteOrphanFiles.mockResolvedValue({
+    deletedCount: 0,
+    deletedIds: [],
+    skippedIds: [],
+    failed: [],
+  });
   mockedApi.admin.updateUserRole.mockResolvedValue({ success: true });
   mockedApi.admin.updateUserStatus.mockResolvedValue({ success: true });
   mockedApi.admin.deleteUser.mockResolvedValue(undefined);
@@ -1141,5 +1158,102 @@ describe('AdminPage: バックグラウンドジョブ監視 (#391)', () => {
     await openJobMonitoringTab();
     expect(screen.getAllByText('未実行')).toHaveLength(2);
     expect(screen.getByText('なし')).toBeInTheDocument();
+  });
+});
+describe('孤立ファイル管理', () => {
+  const orphanFiles: OrphanFile[] = [
+    {
+      id: 101,
+      originalName: '古い資料.pdf',
+      size: 2048,
+      createdAt: '2026-06-20T00:00:00.000Z',
+      uploader: { id: 2, username: 'bob' },
+    },
+    {
+      id: 102,
+      originalName: 'unused.png',
+      size: 1024,
+      createdAt: '2026-06-19T00:00:00.000Z',
+      uploader: null,
+    },
+  ];
+
+  async function openOrphanFilesTab() {
+    mockedApi.admin.getOrphanFiles.mockResolvedValue({ files: orphanFiles });
+    await renderAdminPage();
+    await user.click(screen.getByRole('tab', { name: '孤立ファイル' }));
+    await screen.findByText('古い資料.pdf');
+  }
+
+  it('孤立ファイル一覧にファイル名・サイズ・アップロード日時・アップロード者を表示する', async () => {
+    await openOrphanFilesTab();
+    expect(screen.getByText('古い資料.pdf')).toBeInTheDocument();
+    expect(screen.getByText('2 KB')).toBeInTheDocument();
+    expect(
+      screen.getByText(new Date(orphanFiles[0].createdAt).toLocaleString('ja-JP')),
+    ).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByText('不明なユーザー')).toBeInTheDocument();
+  });
+
+  it('個別削除の確認をキャンセルすると削除APIを呼ばず対象行を維持する', async () => {
+    await openOrphanFilesTab();
+    await user.click(screen.getByRole('button', { name: '削除: 古い資料.pdf' }));
+    await user.click(screen.getByRole('button', { name: 'キャンセル' }));
+    expect(mockedApi.admin.deleteOrphanFiles).not.toHaveBeenCalled();
+    expect(screen.getByText('古い資料.pdf')).toBeInTheDocument();
+  });
+
+  it('個別削除を確認すると対象IDで削除APIを呼び対象行だけを一覧から除く', async () => {
+    mockedApi.admin.deleteOrphanFiles.mockResolvedValue({
+      deletedCount: 1,
+      deletedIds: [101],
+      skippedIds: [],
+      failed: [],
+    });
+    await openOrphanFilesTab();
+    await user.click(screen.getByRole('button', { name: '削除: 古い資料.pdf' }));
+    await user.click(screen.getByRole('button', { name: '削除する' }));
+    await waitFor(() => expect(screen.queryByText('古い資料.pdf')).not.toBeInTheDocument());
+    expect(mockedApi.admin.deleteOrphanFiles).toHaveBeenCalledWith([101]);
+    expect(screen.getByText('unused.png')).toBeInTheDocument();
+  });
+
+  it('選択した複数ファイルの一括削除を確認すると選択IDで削除APIを呼び対象行を一覧から除く', async () => {
+    mockedApi.admin.deleteOrphanFiles.mockResolvedValue({
+      deletedCount: 2,
+      deletedIds: [101, 102],
+      skippedIds: [],
+      failed: [],
+    });
+    await openOrphanFilesTab();
+    await user.click(screen.getByRole('checkbox', { name: '選択: 古い資料.pdf' }));
+    await user.click(screen.getByRole('checkbox', { name: '選択: unused.png' }));
+    await user.click(screen.getByRole('button', { name: '選択した2件を削除' }));
+    await user.click(screen.getByRole('button', { name: '削除する' }));
+    await waitFor(() => expect(screen.queryByText('古い資料.pdf')).not.toBeInTheDocument());
+    expect(mockedApi.admin.deleteOrphanFiles).toHaveBeenCalledWith([101, 102]);
+    expect(screen.queryByText('unused.png')).not.toBeInTheDocument();
+  });
+
+  it('個別削除に失敗するとエラー通知を表示して対象行を維持する', async () => {
+    mockedApi.admin.deleteOrphanFiles.mockRejectedValue(new Error('削除失敗'));
+    await openOrphanFilesTab();
+    await user.click(screen.getByRole('button', { name: '削除: 古い資料.pdf' }));
+    await user.click(screen.getByRole('button', { name: '削除する' }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalledWith('ファイルの削除に失敗しました'));
+    expect(screen.getByText('古い資料.pdf')).toBeInTheDocument();
+  });
+
+  it('一括削除に失敗するとエラー通知を表示して対象行を維持する', async () => {
+    mockedApi.admin.deleteOrphanFiles.mockRejectedValue(new Error('削除失敗'));
+    await openOrphanFilesTab();
+    await user.click(screen.getByRole('checkbox', { name: '選択: 古い資料.pdf' }));
+    await user.click(screen.getByRole('checkbox', { name: '選択: unused.png' }));
+    await user.click(screen.getByRole('button', { name: '選択した2件を削除' }));
+    await user.click(screen.getByRole('button', { name: '削除する' }));
+    await waitFor(() => expect(mockShowError).toHaveBeenCalledWith('ファイルの削除に失敗しました'));
+    expect(screen.getByText('古い資料.pdf')).toBeInTheDocument();
+    expect(screen.getByText('unused.png')).toBeInTheDocument();
   });
 });

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -574,6 +574,13 @@ export const api = {
       }),
     deleteUser: (id: number) => request<void>(`/admin/users/${id}`, { method: 'DELETE' }),
     getChannels: () => request<{ channels: AdminChannel[] }>('/admin/channels'),
+    getOrphanFiles: () =>
+      request<{ files: import('../types/admin').OrphanFile[] }>('/admin/orphan-files'),
+    deleteOrphanFiles: (ids: number[]) =>
+      request<import('../types/admin').DeleteOrphanFilesResult>('/admin/orphan-files', {
+        method: 'DELETE',
+        body: JSON.stringify({ ids }),
+      }),
     setChannelRecommended: (id: number, isRecommended: boolean) =>
       request<{ channel: AdminChannel }>(`/admin/channels/${id}/recommend`, {
         method: 'PATCH',

--- a/packages/client/src/pages/AdminPage.tsx
+++ b/packages/client/src/pages/AdminPage.tsx
@@ -64,6 +64,7 @@ import type {
   AdminHealthDetails,
   HealthStatus,
   JobMonitoringStatus,
+  OrphanFile,
 } from '../types/admin';
 import {
   ResponsiveContainer,
@@ -1063,6 +1064,150 @@ function ChannelsContent({
   );
 }
 
+function formatOrphanFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function OrphanFilesContent({ filesPromise }: { filesPromise: Promise<{ files: OrphanFile[] }> }) {
+  const { files: initialFiles } = use(filesPromise);
+  const [files, setFiles] = useState(initialFiles);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<number[] | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const { showSuccess, showError } = useSnackbar();
+
+  const toggleSelected = (id: number) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleDelete = async () => {
+    if (!pendingDeleteIds || pendingDeleteIds.length === 0) return;
+    setDeleting(true);
+    try {
+      const result = await api.admin.deleteOrphanFiles(pendingDeleteIds);
+      const deleted = new Set(result.deletedIds);
+      setFiles((current) => current.filter((file) => !deleted.has(file.id)));
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        result.deletedIds.forEach((id) => next.delete(id));
+        return next;
+      });
+      if (result.deletedCount > 0) {
+        showSuccess(`${result.deletedCount}件のファイルを削除しました`);
+      }
+      if (result.failed.length > 0 || result.skippedIds.length > 0) {
+        showError('一部のファイルを削除できませんでした');
+      }
+      setPendingDeleteIds(null);
+    } catch {
+      showError('ファイルの削除に失敗しました');
+      setPendingDeleteIds(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+        <Box>
+          <Typography variant="h6">孤立ファイル</Typography>
+          <Typography variant="body2" color="text.secondary">
+            どこからも参照されず、アップロードから24時間以上経過したファイルです。
+          </Typography>
+        </Box>
+        <Button
+          variant="contained"
+          color="error"
+          disabled={selectedIds.size === 0}
+          onClick={() => setPendingDeleteIds(Array.from(selectedIds))}
+        >
+          選択した{selectedIds.size}件を削除
+        </Button>
+      </Box>
+
+      {files.length === 0 ? (
+        <Alert severity="success">削除候補のファイルはありません</Alert>
+      ) : (
+        <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox" />
+                <TableCell>ファイル名</TableCell>
+                <TableCell>サイズ</TableCell>
+                <TableCell>アップロード日時</TableCell>
+                <TableCell>アップロード者</TableCell>
+                <TableCell align="right">操作</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {files.map((file) => (
+                <TableRow key={file.id}>
+                  <TableCell padding="checkbox">
+                    <Checkbox
+                      checked={selectedIds.has(file.id)}
+                      onChange={() => toggleSelected(file.id)}
+                      inputProps={{ 'aria-label': `選択: ${file.originalName}` }}
+                    />
+                  </TableCell>
+                  <TableCell>{file.originalName}</TableCell>
+                  <TableCell>{formatOrphanFileSize(file.size)}</TableCell>
+                  <TableCell>{new Date(file.createdAt).toLocaleString('ja-JP')}</TableCell>
+                  <TableCell>{file.uploader?.username ?? '不明なユーザー'}</TableCell>
+                  <TableCell align="right">
+                    <Button
+                      color="error"
+                      size="small"
+                      aria-label={`削除: ${file.originalName}`}
+                      onClick={() => setPendingDeleteIds([file.id])}
+                    >
+                      削除
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Paper>
+      )}
+
+      <Dialog
+        open={pendingDeleteIds !== null}
+        onClose={() => !deleting && setPendingDeleteIds(null)}
+      >
+        <DialogTitle>孤立ファイルを削除しますか？</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            {pendingDeleteIds?.length ?? 0}
+            件のファイルを完全に削除します。この操作は元に戻せません。
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button disabled={deleting} onClick={() => setPendingDeleteIds(null)}>
+            キャンセル
+          </Button>
+          <Button
+            disabled={deleting}
+            color="error"
+            variant="contained"
+            onClick={() => void handleDelete()}
+          >
+            削除する
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}
+
 // ─── メンテナンスモード設定タブ（Issue #392） ─────────────────
 function MaintenanceModeContent({
   maintenancePromise,
@@ -1438,6 +1583,10 @@ export default function AdminPage() {
           }),
     [tab],
   );
+  const orphanFilesPromise = useMemo(
+    () => (tab === 10 ? api.admin.getOrphanFiles() : Promise.resolve({ files: [] })),
+    [tab],
+  );
   const actorsPromise = useMemo(
     () =>
       api.admin.getUsers().then((r) => r.users.map((u) => ({ id: u.id, username: u.username }))),
@@ -1512,6 +1661,7 @@ export default function AdminPage() {
             <Tab label="ジョブ監視" />
             <Tab label="メンテナンスモード" />
             <Tab label="設定入出力" />
+            <Tab label="孤立ファイル" />
           </Tabs>
 
           {tab === 0 && (
@@ -1573,6 +1723,13 @@ export default function AdminPage() {
             </ErrorBoundary>
           )}
           {tab === 9 && <SettingsImportExportContent />}
+          {tab === 10 && (
+            <ErrorBoundary>
+              <Suspense fallback={fallback}>
+                <OrphanFilesContent filesPromise={orphanFilesPromise} />
+              </Suspense>
+            </ErrorBoundary>
+          )}
         </Box>
       </Box>
     </AppLayout>

--- a/packages/client/src/types/admin.ts
+++ b/packages/client/src/types/admin.ts
@@ -19,6 +19,21 @@ export interface AdminChannel {
   createdAt: string;
 }
 
+export interface OrphanFile {
+  id: number;
+  originalName: string;
+  size: number;
+  createdAt: string;
+  uploader: { id: number; username: string } | null;
+}
+
+export interface DeleteOrphanFilesResult {
+  deletedCount: number;
+  deletedIds: number[];
+  skippedIds: number[];
+  failed: Array<{ id: number; error: string }>;
+}
+
 export interface AdminStats {
   totalUsers: number;
   totalChannels: number;

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -324,6 +324,11 @@ export function createTestDatabase() {
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
 
+    ALTER TABLE message_attachments
+      ADD COLUMN IF NOT EXISTS scheduled_message_id INTEGER REFERENCES scheduled_messages(id) ON DELETE CASCADE;
+    ALTER TABLE message_attachments
+      ADD COLUMN IF NOT EXISTS uploaded_by INTEGER REFERENCES users(id) ON DELETE SET NULL;
+
     CREATE TABLE IF NOT EXISTS job_monitoring (
       job_key TEXT PRIMARY KEY,
       last_run_at TIMESTAMPTZ NOT NULL,

--- a/packages/server/src/__tests__/integration/adminController.test.ts
+++ b/packages/server/src/__tests__/integration/adminController.test.ts
@@ -1307,3 +1307,162 @@ describe('GET /api/admin/channels（isRecommended フィールド）', () => {
     });
   });
 });
+describe('GET /api/admin/orphan-files', () => {
+  it('管理者が取得すると200と孤立ファイルのID・ファイル名・サイズ・アップロード日時・アップロード者を返す', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'orphan_list_admin',
+      'orphan_list_admin@example.com',
+    );
+    await makeAdmin(userId);
+    const inserted = await testDb.execute(
+      `INSERT INTO message_attachments
+        (url, original_name, size, mime_type, uploaded_by, created_at)
+       VALUES ('/uploads/list.txt', 'list.txt', 2048, 'text/plain', $1, NOW() - INTERVAL '25 hours')
+       RETURNING id`,
+      [userId],
+    );
+
+    const res = await request(app).get('/api/admin/orphan-files').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.files).toContainEqual({
+      id: Number(inserted.rows[0].id),
+      originalName: 'list.txt',
+      size: 2048,
+      createdAt: expect.any(String),
+      uploader: { id: userId, username: 'orphan_list_admin' },
+    });
+  });
+
+  it('候補がない場合は200と空配列を返す', async () => {
+    const { token, userId } = await registerUser(
+      app,
+      'orphan_empty_admin',
+      'orphan_empty_admin@example.com',
+    );
+    await makeAdmin(userId);
+    await testDb.execute('DELETE FROM message_attachments');
+
+    const res = await request(app).get('/api/admin/orphan-files').set('Cookie', `token=${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ files: [] });
+  });
+
+  it('未認証ユーザーは401を返す', async () => {
+    expect((await request(app).get('/api/admin/orphan-files')).status).toBe(401);
+  });
+
+  it('一般ユーザーは403を返す', async () => {
+    const { token } = await registerUser(app, 'orphan_list_user', 'orphan_list_user@example.com');
+    expect(
+      (await request(app).get('/api/admin/orphan-files').set('Cookie', `token=${token}`)).status,
+    ).toBe(403);
+  });
+});
+
+describe('DELETE /api/admin/orphan-files', () => {
+  async function setupAdminAndOrphans(count: number) {
+    const suffix = `${count}_${Date.now()}_${Math.random()}`;
+    const { token, userId } = await registerUser(
+      app,
+      `orphan_del_${suffix}`,
+      `orphan_del_${suffix}@example.com`,
+    );
+    await makeAdmin(userId);
+    const ids: number[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const result = await testDb.execute(
+        `INSERT INTO message_attachments
+          (url, original_name, size, mime_type, uploaded_by, created_at)
+         VALUES ($1, $2, 10, 'text/plain', $3, NOW() - INTERVAL '25 hours') RETURNING id`,
+        [`/uploads/missing-${suffix}-${index}.txt`, `missing-${index}.txt`, userId],
+      );
+      ids.push(Number(result.rows[0].id));
+    }
+    return { token, ids };
+  }
+
+  it('管理者が1件の候補IDを指定すると削除件数と削除対象IDを返す', async () => {
+    const { token, ids } = await setupAdminAndOrphans(1);
+    const res = await request(app)
+      .delete('/api/admin/orphan-files')
+      .set('Cookie', `token=${token}`)
+      .send({ ids });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ deletedCount: 1, deletedIds: ids, skippedIds: [], failed: [] });
+  });
+
+  it('管理者が複数の候補IDを指定すると一括削除結果を返す', async () => {
+    const { token, ids } = await setupAdminAndOrphans(2);
+    const res = await request(app)
+      .delete('/api/admin/orphan-files')
+      .set('Cookie', `token=${token}`)
+      .send({ ids });
+    expect(res.status).toBe(200);
+    expect(res.body.deletedIds).toEqual(ids);
+    expect(res.body.deletedCount).toBe(2);
+  });
+
+  it.each([[[]], [['1']], [[1.5]], [[0]], [[-1]]])(
+    '削除対象IDが空配列または整数以外を含む場合は400を返す: %j',
+    async (ids: unknown[]) => {
+      const { token } = await setupAdminAndOrphans(0);
+      const res = await request(app)
+        .delete('/api/admin/orphan-files')
+        .set('Cookie', `token=${token}`)
+        .send({ ids });
+      expect(res.status).toBe(400);
+    },
+  );
+
+  it('重複したIDを指定しても削除件数を水増ししない', async () => {
+    const { token, ids } = await setupAdminAndOrphans(1);
+    const res = await request(app)
+      .delete('/api/admin/orphan-files')
+      .set('Cookie', `token=${token}`)
+      .send({ ids: [ids[0], ids[0]] });
+    expect(res.body.deletedCount).toBe(1);
+    expect(res.body.deletedIds).toEqual(ids);
+  });
+
+  it('候補外または存在しないIDを指定しても対象ファイルを削除しない', async () => {
+    const { token, ids } = await setupAdminAndOrphans(1);
+    await testDb.execute('UPDATE message_attachments SET created_at = NOW() WHERE id = $1', [
+      ids[0],
+    ]);
+    const res = await request(app)
+      .delete('/api/admin/orphan-files')
+      .set('Cookie', `token=${token}`)
+      .send({ ids: [ids[0], 999999] });
+    expect(res.body).toEqual({
+      deletedCount: 0,
+      deletedIds: [],
+      skippedIds: [ids[0], 999999],
+      failed: [],
+    });
+  });
+
+  it('未認証ユーザーは401を返す', async () => {
+    expect(
+      (
+        await request(app)
+          .delete('/api/admin/orphan-files')
+          .send({ ids: [1] })
+      ).status,
+    ).toBe(401);
+  });
+
+  it('一般ユーザーは403を返す', async () => {
+    const { token } = await registerUser(app, 'orphan_del_user', 'orphan_del_user@example.com');
+    expect(
+      (
+        await request(app)
+          .delete('/api/admin/orphan-files')
+          .set('Cookie', `token=${token}`)
+          .send({ ids: [1] })
+      ).status,
+    ).toBe(403);
+  });
+});

--- a/packages/server/src/__tests__/integration/fileStorage.test.ts
+++ b/packages/server/src/__tests__/integration/fileStorage.test.ts
@@ -189,3 +189,26 @@ describe('POST /api/files/upload', () => {
     });
   });
 });
+describe('アップロード者の記録', () => {
+  it('認証ユーザーがアップロードするとmessage_attachmentsにそのユーザーIDを記録する', async () => {
+    const app = createApp();
+    const uploadedBy = await register(
+      `owner_${Date.now()}`,
+      `owner_${Date.now()}@example.com`,
+      'password123',
+    );
+    const ownerToken = generateToken(uploadedBy.id, uploadedBy.username);
+
+    const res = await request(app)
+      .post('/api/files/upload')
+      .set('Cookie', `token=${ownerToken}`)
+      .attach('file', Buffer.from('owner data'), 'owner.txt');
+    const row = await testDb.queryOne<{ uploaded_by: number }>(
+      'SELECT uploaded_by FROM message_attachments WHERE id = $1',
+      [res.body.id],
+    );
+
+    expect(res.status).toBe(200);
+    expect(row?.uploaded_by).toBe(uploadedBy.id);
+  });
+});

--- a/packages/server/src/__tests__/unit/adminOrphanFiles.test.ts
+++ b/packages/server/src/__tests__/unit/adminOrphanFiles.test.ts
@@ -1,0 +1,233 @@
+/**
+ * 管理者向け孤立ファイルクリーンアップのサービステスト
+ *
+ * テスト対象: packages/server/src/services/adminService.ts
+ * 戦略: pg-mem と fs モックを使い、孤立判定・保護期間・メタデータ・
+ * DB/実ファイル削除の整合性を検証する。
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { getSharedTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+
+const testDb = getSharedTestDatabase();
+
+jest.mock('../../db/database', () => testDb);
+
+import { deleteOrphanFiles, getOrphanFiles } from '../../services/adminService';
+
+const NOW = new Date('2026-06-21T12:00:00.000Z');
+const OLD = '2026-06-20T11:59:59.000Z';
+const BOUNDARY = '2026-06-20T12:00:00.000Z';
+const RECENT = '2026-06-20T12:00:01.000Z';
+
+let uploaderId: number;
+let messageId: number;
+let draftId: number;
+let scheduledMessageId: number;
+
+async function insertAttachment(
+  overrides: {
+    messageId?: number | null;
+    draftId?: number | null;
+    scheduledMessageId?: number | null;
+    uploadedBy?: number | null;
+    url?: string;
+    originalName?: string;
+    size?: number;
+    createdAt?: string;
+  } = {},
+): Promise<number> {
+  const result = await testDb.execute(
+    `INSERT INTO message_attachments
+       (message_id, draft_id, scheduled_message_id, uploaded_by, url, original_name, size, mime_type, created_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'text/plain', $8)
+     RETURNING id`,
+    [
+      overrides.messageId ?? null,
+      overrides.draftId ?? null,
+      overrides.scheduledMessageId ?? null,
+      overrides.uploadedBy === undefined ? uploaderId : overrides.uploadedBy,
+      overrides.url ?? '/uploads/orphan.txt',
+      overrides.originalName ?? 'orphan.txt',
+      overrides.size ?? 1234,
+      overrides.createdAt ?? OLD,
+    ],
+  );
+  return Number(result.rows[0].id);
+}
+
+beforeEach(async () => {
+  await resetTestData(testDb);
+  jest.restoreAllMocks();
+
+  const user = await testDb.execute(
+    `INSERT INTO users (username, email, password_hash)
+     VALUES ('uploader', 'uploader@example.com', 'hash') RETURNING id`,
+  );
+  uploaderId = Number(user.rows[0].id);
+  const channel = await testDb.execute(
+    `INSERT INTO channels (name, created_by) VALUES ('cleanup', $1) RETURNING id`,
+    [uploaderId],
+  );
+  const channelId = Number(channel.rows[0].id);
+  const message = await testDb.execute(
+    `INSERT INTO messages (channel_id, user_id, content) VALUES ($1, $2, '{}') RETURNING id`,
+    [channelId, uploaderId],
+  );
+  messageId = Number(message.rows[0].id);
+  const draft = await testDb.execute(
+    `INSERT INTO drafts (user_id, channel_id, content) VALUES ($1, $2, '{}') RETURNING id`,
+    [uploaderId, channelId],
+  );
+  draftId = Number(draft.rows[0].id);
+  const scheduled = await testDb.execute(
+    `INSERT INTO scheduled_messages (user_id, channel_id, content, scheduled_at)
+     VALUES ($1, $2, '{}', '2026-06-22T12:00:00.000Z') RETURNING id`,
+    [uploaderId, channelId],
+  );
+  scheduledMessageId = Number(scheduled.rows[0].id);
+});
+
+describe('管理者向け孤立ファイルクリーンアップ', () => {
+  describe('孤立ファイル一覧', () => {
+    it('3つの参照IDがすべてNULLでアップロードから24時間以上経過したファイルを返す', async () => {
+      const id = await insertAttachment();
+      expect(await getOrphanFiles(NOW)).toEqual([
+        expect.objectContaining({ id, originalName: 'orphan.txt' }),
+      ]);
+    });
+
+    it('message_idでメッセージに参照されたファイルを候補から除外する', async () => {
+      await insertAttachment({ messageId });
+      expect(await getOrphanFiles(NOW)).toEqual([]);
+    });
+
+    it('draft_idで下書きに参照されたファイルを候補から除外する', async () => {
+      await insertAttachment({ draftId });
+      expect(await getOrphanFiles(NOW)).toEqual([]);
+    });
+
+    it('scheduled_message_idで予約送信に参照されたファイルを候補から除外する', async () => {
+      await insertAttachment({ scheduledMessageId });
+      expect(await getOrphanFiles(NOW)).toEqual([]);
+    });
+
+    it('アップロードから24時間未満の未参照ファイルを候補から除外する', async () => {
+      await insertAttachment({ createdAt: RECENT });
+      expect(await getOrphanFiles(NOW)).toEqual([]);
+    });
+
+    it('アップロードからちょうど24時間経過した未参照ファイルを候補に含める', async () => {
+      const id = await insertAttachment({ createdAt: BOUNDARY });
+      expect((await getOrphanFiles(NOW)).map((file) => file.id)).toEqual([id]);
+    });
+
+    it('候補のID・ファイル名・サイズ・アップロード日時・アップロード者を返す', async () => {
+      const id = await insertAttachment();
+      expect(await getOrphanFiles(NOW)).toEqual([
+        {
+          id,
+          originalName: 'orphan.txt',
+          size: 1234,
+          createdAt: new Date(OLD).toISOString(),
+          uploader: { id: uploaderId, username: 'uploader' },
+        },
+      ]);
+    });
+
+    it('アップロード者が削除済みまたは不明な場合も一覧取得できる', async () => {
+      const id = await insertAttachment({ uploadedBy: null });
+      expect(await getOrphanFiles(NOW)).toEqual([expect.objectContaining({ id, uploader: null })]);
+    });
+  });
+
+  describe('孤立ファイル削除', () => {
+    it('孤立ファイルをDBとアップロードディレクトリの両方から削除する', async () => {
+      const id = await insertAttachment();
+      const unlink = jest.spyOn(fs, 'unlinkSync').mockImplementation(() => undefined);
+
+      expect(await deleteOrphanFiles([id], NOW)).toEqual({
+        deletedIds: [id],
+        skippedIds: [],
+        failed: [],
+      });
+      expect(unlink).toHaveBeenCalledWith(path.join(process.cwd(), 'uploads', 'orphan.txt'));
+      expect(
+        (await testDb.execute('SELECT id FROM message_attachments WHERE id = $1', [id])).rows,
+      ).toEqual([]);
+    });
+
+    it('パーセントエンコードされたファイルURLから対象の実ファイルを削除する', async () => {
+      const id = await insertAttachment({ url: '/uploads/%E8%B3%87%E6%96%99.txt' });
+      const unlink = jest.spyOn(fs, 'unlinkSync').mockImplementation(() => undefined);
+
+      await deleteOrphanFiles([id], NOW);
+
+      expect(unlink).toHaveBeenCalledWith(path.join(process.cwd(), 'uploads', '資料.txt'));
+    });
+
+    it('実ファイルが存在しない孤立ファイルはDBから削除する', async () => {
+      const id = await insertAttachment();
+      jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {
+        throw Object.assign(new Error('not found'), { code: 'ENOENT' });
+      });
+
+      expect((await deleteOrphanFiles([id], NOW)).deletedIds).toEqual([id]);
+      expect(
+        (await testDb.execute('SELECT id FROM message_attachments WHERE id = $1', [id])).rows,
+      ).toEqual([]);
+    });
+
+    it('複数の孤立ファイルを一括削除する', async () => {
+      const first = await insertAttachment({ url: '/uploads/first.txt' });
+      const second = await insertAttachment({ url: '/uploads/second.txt' });
+      jest.spyOn(fs, 'unlinkSync').mockImplementation(() => undefined);
+
+      expect(await deleteOrphanFiles([first, second], NOW)).toEqual({
+        deletedIds: [first, second],
+        skippedIds: [],
+        failed: [],
+      });
+    });
+
+    it('削除時点で参照済みまたは24時間未満のファイルを再判定して削除しない', async () => {
+      const referenced = await insertAttachment({ messageId });
+      const recent = await insertAttachment({ createdAt: RECENT });
+      const unlink = jest.spyOn(fs, 'unlinkSync').mockImplementation(() => undefined);
+
+      expect(await deleteOrphanFiles([referenced, recent], NOW)).toEqual({
+        deletedIds: [],
+        skippedIds: [referenced, recent],
+        failed: [],
+      });
+      expect(unlink).not.toHaveBeenCalled();
+    });
+
+    it('実ファイルの削除に失敗したファイルはDBレコードを残して失敗結果を返す', async () => {
+      const id = await insertAttachment();
+      jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {
+        throw new Error('permission denied');
+      });
+
+      expect(await deleteOrphanFiles([id], NOW)).toEqual({
+        deletedIds: [],
+        skippedIds: [],
+        failed: [{ id, error: 'permission denied' }],
+      });
+      expect(
+        (await testDb.execute('SELECT id FROM message_attachments WHERE id = $1', [id])).rows,
+      ).toHaveLength(1);
+    });
+
+    it('アップロードディレクトリ外を指す不正なURLのファイルを削除しない', async () => {
+      const id = await insertAttachment({ url: '/uploads/..%2Fsecret.txt' });
+      const unlink = jest.spyOn(fs, 'unlinkSync').mockImplementation(() => undefined);
+
+      expect((await deleteOrphanFiles([id], NOW)).failed).toEqual([
+        { id, error: '不正なファイルURLです' },
+      ]);
+      expect(unlink).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/server/src/controllers/adminController.ts
+++ b/packages/server/src/controllers/adminController.ts
@@ -18,6 +18,39 @@ export async function getUsers(
   }
 }
 
+export async function getOrphanFiles(
+  _req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    res.json({ files: await adminService.getOrphanFiles() });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function deleteOrphanFiles(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const { ids } = req.body as { ids?: unknown };
+    if (
+      !Array.isArray(ids) ||
+      ids.length === 0 ||
+      ids.some((id) => !Number.isInteger(id) || Number(id) <= 0)
+    ) {
+      throw createError('ids must be a non-empty array of positive integers', 400);
+    }
+    const result = await adminService.deleteOrphanFiles(ids as number[]);
+    res.json({ deletedCount: result.deletedIds.length, ...result });
+  } catch (err) {
+    next(err);
+  }
+}
+
 export async function updateUserRole(
   req: AuthenticatedRequest,
   res: Response,

--- a/packages/server/src/routes/admin.ts
+++ b/packages/server/src/routes/admin.ts
@@ -23,6 +23,13 @@ router.delete('/users/:id', (req, res, next) =>
   controller.deleteUser(req as unknown as AuthenticatedRequest, res, next),
 );
 
+router.get('/orphan-files', (req, res, next) =>
+  controller.getOrphanFiles(req as unknown as AuthenticatedRequest, res, next),
+);
+router.delete('/orphan-files', (req, res, next) =>
+  controller.deleteOrphanFiles(req as unknown as AuthenticatedRequest, res, next),
+);
+
 router.get('/channels', (req, res, next) =>
   controller.getChannels(req as unknown as AuthenticatedRequest, res, next),
 );

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import multer from 'multer';
-import { authenticateToken } from '../middleware/auth';
+import { authenticateToken, AuthenticatedRequest } from '../middleware/auth';
 import { saveFile } from '../services/fileStorageService';
 import { checkExtension } from '../services/moderationService';
 import { isMaintenanceRestricted } from '../services/adminService';
@@ -37,8 +37,8 @@ router.post('/upload', authenticateToken, upload.single('file'), async (req, res
     const saved = saveFile(buffer, originalname, mimetype);
 
     const result = await execute(
-      'INSERT INTO message_attachments (message_id, url, original_name, size, mime_type) VALUES (NULL, $1, $2, $3, $4) RETURNING id',
-      [saved.url, saved.originalName, saved.size, mimetype],
+      'INSERT INTO message_attachments (message_id, url, original_name, size, mime_type, uploaded_by) VALUES (NULL, $1, $2, $3, $4, $5) RETURNING id',
+      [saved.url, saved.originalName, saved.size, mimetype, (req as AuthenticatedRequest).userId],
     );
 
     res.json({

--- a/packages/server/src/services/adminService.ts
+++ b/packages/server/src/services/adminService.ts
@@ -89,6 +89,133 @@ export interface AdminStats {
   activeUsers?: number;
 }
 
+export interface OrphanFile {
+  id: number;
+  originalName: string;
+  size: number;
+  createdAt: string;
+  uploader: { id: number; username: string } | null;
+}
+
+export interface DeleteOrphanFilesResult {
+  deletedIds: number[];
+  skippedIds: number[];
+  failed: Array<{ id: number; error: string }>;
+}
+
+interface OrphanFileRow {
+  id: number;
+  url: string;
+  original_name: string;
+  size: number;
+  created_at: Date | string;
+  uploaded_by: number | null;
+  uploader_name: string | null;
+}
+
+const ORPHAN_PROTECTION_MS = 24 * 60 * 60 * 1000;
+
+function orphanCutoff(now: Date): string {
+  return new Date(now.getTime() - ORPHAN_PROTECTION_MS).toISOString();
+}
+
+function toOrphanFile(row: OrphanFileRow): OrphanFile {
+  return {
+    id: Number(row.id),
+    originalName: row.original_name,
+    size: Number(row.size),
+    createdAt: new Date(row.created_at).toISOString(),
+    uploader:
+      row.uploaded_by === null || row.uploader_name === null
+        ? null
+        : { id: Number(row.uploaded_by), username: row.uploader_name },
+  };
+}
+
+/** 24時間の保護期間を過ぎ、どこからも参照されていない添付を返す。 */
+export async function getOrphanFiles(now = new Date()): Promise<OrphanFile[]> {
+  const rows = await query<OrphanFileRow>(
+    `SELECT ma.id, ma.url, ma.original_name, ma.size, ma.created_at,
+            ma.uploaded_by, u.username AS uploader_name
+       FROM message_attachments ma
+       LEFT JOIN users u ON u.id = ma.uploaded_by
+      WHERE ma.message_id IS NULL
+        AND ma.draft_id IS NULL
+        AND ma.scheduled_message_id IS NULL
+        AND ma.created_at <= $1
+      ORDER BY ma.created_at ASC, ma.id ASC`,
+    [orphanCutoff(now)],
+  );
+  return rows.map(toOrphanFile);
+}
+
+function resolveUploadedFilePath(url: string): string {
+  const prefix = '/uploads/';
+  if (!url.startsWith(prefix)) throw new Error('不正なファイルURLです');
+  let filename: string;
+  try {
+    filename = decodeURIComponent(url.slice(prefix.length));
+  } catch {
+    throw new Error('不正なファイルURLです');
+  }
+  if (!filename || path.basename(filename) !== filename || filename.includes('\\')) {
+    throw new Error('不正なファイルURLです');
+  }
+  const filePath = path.resolve(UPLOAD_DIR, filename);
+  if (path.dirname(filePath) !== path.resolve(UPLOAD_DIR)) {
+    throw new Error('不正なファイルURLです');
+  }
+  return filePath;
+}
+
+/** 指定IDを削除時点で再判定し、孤立候補だけを実ファイルとDBから削除する。 */
+export async function deleteOrphanFiles(
+  ids: number[],
+  now = new Date(),
+): Promise<DeleteOrphanFilesResult> {
+  const result: DeleteOrphanFilesResult = { deletedIds: [], skippedIds: [], failed: [] };
+  for (const id of [...new Set(ids)]) {
+    const row = await queryOne<OrphanFileRow>(
+      `SELECT ma.id, ma.url, ma.original_name, ma.size, ma.created_at,
+              ma.uploaded_by, u.username AS uploader_name
+         FROM message_attachments ma
+         LEFT JOIN users u ON u.id = ma.uploaded_by
+        WHERE ma.id = $1
+          AND ma.message_id IS NULL
+          AND ma.draft_id IS NULL
+          AND ma.scheduled_message_id IS NULL
+          AND ma.created_at <= $2`,
+      [id, orphanCutoff(now)],
+    );
+    if (!row) {
+      result.skippedIds.push(id);
+      continue;
+    }
+
+    try {
+      const filePath = resolveUploadedFilePath(row.url);
+      try {
+        fs.unlinkSync(filePath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      await execute(
+        `DELETE FROM message_attachments
+          WHERE id = $1 AND message_id IS NULL AND draft_id IS NULL
+            AND scheduled_message_id IS NULL AND created_at <= $2`,
+        [id, orphanCutoff(now)],
+      );
+      result.deletedIds.push(id);
+    } catch (error) {
+      result.failed.push({
+        id,
+        error: error instanceof Error ? error.message : 'ファイル削除に失敗しました',
+      });
+    }
+  }
+  return result;
+}
+
 export interface GetStatsOptions {
   from?: Date;
   to?: Date;
@@ -305,7 +432,8 @@ export async function getHealthDetails(): Promise<AdminHealthDetails> {
   const jobs = {
     status: jobsStatus,
     workers,
-    message: jobsStatus === 'normal' ? 'すべてのジョブが稼働しています' : '停止中のジョブがあります',
+    message:
+      jobsStatus === 'normal' ? 'すべてのジョブが稼働しています' : '停止中のジョブがあります',
   };
 
   const storage = checkStorage();


### PR DESCRIPTION
## 概要

24時間以上経過し、メッセージ・下書き・予約送信のいずれにも紐づかない添付ファイルを管理画面から確認・削除できるようにします。

## 変更内容

- `message_attachments.uploaded_by` と孤立候補検索用インデックスを追加
- 管理者向け孤立ファイル一覧・個別/一括削除APIを追加
- 参照状態と24時間の保護期間を削除直前にも再判定
- 実ファイル欠損、削除失敗、不正パスを安全に処理
- 管理画面へ一覧、選択、確認ダイアログ、個別/一括削除UIを追加
- サービス、HTTP契約、アップロード者記録、管理画面操作のテストを追加

## 影響範囲

- 添付ファイルアップロード時のメタデータ
- 管理者API `/api/admin/orphan-files`
- 管理画面の「孤立ファイル」タブ
- PostgreSQLスキーマ（nullable列、外部キー、部分インデックス）

## 動作確認・テスト結果
- [x] フロントエンドユニットテストがすべてパスする（2,590件）
- [x] バックエンドユニットテストがすべてパスする（1,913件）
- [x] ビルドが正常に完了すること
- [x] Playwrightで一覧表示、個別削除のキャンセル、2件の一括削除、成功通知、API 200を確認
- [x] Atlas dry-runで3変更・診断なしを確認

## 関連Issue
Fixes #393

## チェックリスト
- [x] 自己レビューを行い、不要なデバッグコードやコメントが残っていないか確認した
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（更新不要）
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）
