### PR TITLE
feat: ピン留めメッセージのカテゴリ分けを追加

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -703,6 +703,60 @@ table "channel_read_status" {
   }
 }
 
+table "pin_categories" {
+  schema  = schema.public
+  comment = "ピン留めメッセージのカテゴリ"
+  column "id" {
+    null    = false
+    type    = serial
+    comment = "カテゴリID"
+  }
+  column "channel_id" {
+    null    = false
+    type    = integer
+    comment = "チャンネルID"
+  }
+  column "name" {
+    null    = false
+    type    = text
+    comment = "カテゴリ名"
+  }
+  column "is_default" {
+    null    = false
+    type    = boolean
+    default = false
+    comment = "デフォルトカテゴリか"
+  }
+  column "position" {
+    null    = false
+    type    = integer
+    default = 0
+    comment = "並び順"
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("NOW()")
+    comment = "作成日時"
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "fk_pin_categories_channel" {
+    columns     = [column.channel_id]
+    ref_columns = [table.channels.column.id]
+    on_update   = NO_ACTION
+    on_delete   = CASCADE
+  }
+  index "idx_pin_categories_channel_name" {
+    unique  = true
+    columns = [column.channel_id, column.name]
+  }
+  index "idx_pin_categories_channel_position" {
+    columns = [column.channel_id, column.position]
+  }
+}
+
 table "pinned_messages" {
   schema  = schema.public
   comment = "ピン留めメッセージ"
@@ -732,6 +786,11 @@ table "pinned_messages" {
     default = sql("NOW()")
     comment = "ピン留め日時"
   }
+  column "category_id" {
+    null    = true
+    type    = integer
+    comment = "ピンカテゴリID（NULLは未分類）"
+  }
   primary_key {
     columns = [column.id]
   }
@@ -752,6 +811,12 @@ table "pinned_messages" {
     ref_columns = [table.messages.column.id]
     on_update   = NO_ACTION
     on_delete   = CASCADE
+  }
+  foreign_key "fk_pinned_messages_category" {
+    columns     = [column.category_id]
+    ref_columns = [table.pin_categories.column.id]
+    on_update   = NO_ACTION
+    on_delete   = SET_NULL
   }
   index "idx_pinned_messages_message_channel" {
     unique  = true

--- a/packages/client/src/__tests__/ChatPage.test.tsx
+++ b/packages/client/src/__tests__/ChatPage.test.tsx
@@ -92,7 +92,8 @@ vi.mock('../components/Channel/CreateChannelDialog', () => ({
     ) : null,
 }));
 
-vi.mock('../components/Chat/MessageList', () => ({ default: () => null }));
+const MockMessageList = vi.hoisted(() => vi.fn(() => null));
+vi.mock('../components/Chat/MessageList', () => ({ default: MockMessageList }));
 // RichEditor を props キャプチャ可能なモックに差し替え（#113 で disabled prop を検証する）
 const MockRichEditor = vi.hoisted(() => vi.fn(() => null));
 vi.mock('../components/Chat/RichEditor', () => ({ default: MockRichEditor }));
@@ -131,6 +132,7 @@ vi.mock('../contexts/SnackbarContext', () => ({
 const mockSearch = vi.hoisted(() => vi.fn().mockResolvedValue({ messages: [] }));
 const mockBookmarksList = vi.hoisted(() => vi.fn().mockResolvedValue({ bookmarks: [] }));
 const mockDraftsGetAll = vi.hoisted(() => vi.fn().mockResolvedValue({ drafts: [] }));
+const mockPinsList = vi.hoisted(() => vi.fn().mockResolvedValue({ pinnedMessages: [] }));
 // #247 #248 ?channel 直リンク時は ChatPage が自前で channels.list() を呼んで activeChannel を埋める
 const mockChannelsList = vi.hoisted(() => vi.fn().mockResolvedValue({ channels: [] }));
 
@@ -140,6 +142,7 @@ vi.mock('../api/client', () => ({
     bookmarks: { list: mockBookmarksList },
     drafts: { getAll: mockDraftsGetAll },
     channels: { list: mockChannelsList },
+    pins: { list: mockPinsList },
   },
 }));
 
@@ -182,9 +185,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   MockChannelList.mockImplementation(() => null);
   MockRichEditor.mockImplementation(() => null);
+  MockMessageList.mockImplementation(() => null);
   mockSearch.mockResolvedValue({ messages: [] });
   mockBookmarksList.mockResolvedValue({ bookmarks: [] });
   mockChannelsList.mockResolvedValue({ channels: [] });
+  mockPinsList.mockResolvedValue({ pinnedMessages: [] });
   // useAuth のユーザーをデフォルトにリセット
   mockUser.current = { id: 1, role: 'user', isActive: true, username: 'testuser' };
   // socket モックをデフォルトの null に戻す
@@ -618,6 +623,81 @@ describe('ChatPage', () => {
       // ContextRail は vi.mock でスタブ化されているため、ChatPage 直接の呼び出しのみ MockPinnedMessages がカウントする
       renderChatPage();
       expect(MockPinnedMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ピン留めカテゴリのSocket伝播 (#395)', () => {
+    const channel = {
+      id: 5,
+      name: 'pins',
+      description: null,
+      topic: null,
+      createdBy: 1,
+      isPrivate: false,
+      postingPermission: 'everyone',
+      isArchived: false,
+      isRecommended: false,
+      createdAt: '2024-01-01T00:00:00Z',
+      unreadCount: 0,
+      mentionCount: 0,
+    };
+
+    const getPinHandler = () => {
+      const calls = MockMessageList.mock.calls as unknown as Array<
+        [{ onPinMessage: (messageId: number, categoryId: number | null) => void }]
+      >;
+      return calls[calls.length - 1][0].onPinMessage;
+    };
+
+    const getMessageListProps = () => {
+      const calls = MockMessageList.mock.calls as unknown as Array<
+        [
+          {
+            onUnpinMessage: (messageId: number) => void;
+            pinnedMessageIds: Set<number>;
+          },
+        ]
+      >;
+      return calls[calls.length - 1][0];
+    };
+
+    it('MessageActionsで選択したカテゴリIDをpin_messageイベントへ含める', async () => {
+      const emit = vi.fn();
+      mockSocketRef.current = { on: vi.fn(), off: vi.fn(), emit };
+      mockChannelsList.mockResolvedValue({ channels: [channel] });
+      renderChatPage('/chat?channel=5');
+      await waitFor(() => expect(MockMessageList).toHaveBeenCalled());
+      getPinHandler()(10, 3);
+      expect(emit).toHaveBeenCalledWith('pin_message', {
+        messageId: 10,
+        channelId: 5,
+        categoryId: 3,
+      });
+    });
+
+    it('未分類を選択した場合はcategoryId nullをpin_messageイベントへ含める', async () => {
+      const emit = vi.fn();
+      mockSocketRef.current = { on: vi.fn(), off: vi.fn(), emit };
+      mockChannelsList.mockResolvedValue({ channels: [channel] });
+      renderChatPage('/chat?channel=5');
+      await waitFor(() => expect(MockMessageList).toHaveBeenCalled());
+      getPinHandler()(11, null);
+      expect(emit).toHaveBeenCalledWith('pin_message', {
+        messageId: 11,
+        channelId: 5,
+        categoryId: null,
+      });
+    });
+
+    it('取得したピン状態をMessageListへ渡し、解除操作はunpin_messageを送信する', async () => {
+      const emit = vi.fn();
+      mockSocketRef.current = { on: vi.fn(), off: vi.fn(), emit };
+      mockChannelsList.mockResolvedValue({ channels: [channel] });
+      mockPinsList.mockResolvedValue({ pinnedMessages: [{ messageId: 12 }] });
+      renderChatPage('/chat?channel=5');
+      await waitFor(() => expect(getMessageListProps().pinnedMessageIds.has(12)).toBe(true));
+      getMessageListProps().onUnpinMessage(12);
+      expect(emit).toHaveBeenCalledWith('unpin_message', { messageId: 12, channelId: 5 });
     });
   });
 

--- a/packages/client/src/__tests__/ChatPagePermalink.test.tsx
+++ b/packages/client/src/__tests__/ChatPagePermalink.test.tsx
@@ -79,6 +79,7 @@ vi.mock('../contexts/SnackbarContext', () => ({
 const mockBookmarksList = vi.hoisted(() => vi.fn().mockResolvedValue({ bookmarks: [] }));
 const mockDraftsGetAll = vi.hoisted(() => vi.fn().mockResolvedValue({ drafts: [] }));
 const mockChannelsList = vi.hoisted(() => vi.fn().mockResolvedValue({ channels: [] }));
+const mockPinsList = vi.hoisted(() => vi.fn().mockResolvedValue({ pinnedMessages: [] }));
 
 vi.mock('../api/client', () => ({
   api: {
@@ -88,6 +89,7 @@ vi.mock('../api/client', () => ({
     bookmarks: { list: mockBookmarksList },
     drafts: { getAll: mockDraftsGetAll },
     channels: { list: mockChannelsList },
+    pins: { list: mockPinsList },
   },
 }));
 
@@ -134,6 +136,7 @@ beforeEach(() => {
   mockBookmarksList.mockResolvedValue({ bookmarks: [] });
   mockDraftsGetAll.mockResolvedValue({ drafts: [] });
   mockChannelsList.mockResolvedValue({ channels: [] });
+  mockPinsList.mockResolvedValue({ pinnedMessages: [] });
   mockMessages.current = [];
 });
 

--- a/packages/client/src/__tests__/MessageActions.test.tsx
+++ b/packages/client/src/__tests__/MessageActions.test.tsx
@@ -57,6 +57,7 @@ vi.mock('../components/Reminder/ReminderDialog', () => ({
 // API モック
 const mockBookmarksAdd = vi.fn();
 const mockBookmarksRemove = vi.fn();
+const mockPinCategoriesList = vi.fn();
 vi.mock('../api/client', () => ({
   api: {
     bookmarks: {
@@ -65,6 +66,9 @@ vi.mock('../api/client', () => ({
     },
     messages: {
       forward: vi.fn().mockResolvedValue({ message: { id: 99 } }),
+    },
+    pins: {
+      listCategories: (channelId: number) => mockPinCategoriesList(channelId),
     },
   },
 }));
@@ -111,6 +115,9 @@ beforeEach(() => {
   vi.resetAllMocks();
   mockBookmarksAdd.mockResolvedValue(undefined);
   mockBookmarksRemove.mockResolvedValue(undefined);
+  mockPinCategoriesList.mockResolvedValue({
+    categories: [{ id: 3, channelId: 1, name: '決定事項', isDefault: true, position: 0 }],
+  });
   // jsdom には navigator.clipboard が存在しないためモックで補完する
   Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
 });
@@ -311,22 +318,6 @@ describe('MessageActions', () => {
       expect(screen.getByRole('menuitem', { name: 'ピン留めを解除' })).toBeInTheDocument();
     });
 
-    it('メニューのピン留めをクリックすると onPinMessage が message.id を引数に呼ばれる', async () => {
-      const onPinMessage = vi.fn();
-      const message = makeMessage({ id: 7 });
-      render(
-        <MessageActions
-          message={message}
-          isOwn={false}
-          isPinned={false}
-          onPinMessage={onPinMessage}
-        />,
-      );
-      await openMenu();
-      await userEvent.click(screen.getByRole('menuitem', { name: 'ピン留め' }));
-      expect(onPinMessage).toHaveBeenCalledWith(7);
-    });
-
     it('ピン留めクリック後にメニューが閉じる', async () => {
       render(
         <MessageActions
@@ -341,6 +332,76 @@ describe('MessageActions', () => {
       await waitFor(() => {
         expect(screen.queryByRole('menu')).not.toBeInTheDocument();
       });
+    });
+
+    it('未ピン留めメッセージではピン留め時にカテゴリ選択ダイアログを開く', async () => {
+      render(<MessageActions message={makeMessage()} isOwn={false} onPinMessage={vi.fn()} />);
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: 'ピン留め' }));
+      expect(
+        await screen.findByRole('dialog', { name: 'ピン留めカテゴリを選択' }),
+      ).toBeInTheDocument();
+    });
+
+    it('未分類を選んで確定するとカテゴリなしでピン留めを依頼する', async () => {
+      const onPinMessage = vi.fn();
+      render(
+        <MessageActions
+          message={makeMessage({ id: 7 })}
+          isOwn={false}
+          onPinMessage={onPinMessage}
+        />,
+      );
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: 'ピン留め' }));
+      await userEvent.click(await screen.findByRole('button', { name: 'ピン留めする' }));
+      expect(onPinMessage).toHaveBeenCalledWith(7, null);
+    });
+
+    it('カテゴリを選んで確定すると選択したカテゴリIDでピン留めを依頼する', async () => {
+      const onPinMessage = vi.fn();
+      render(
+        <MessageActions
+          message={makeMessage({ id: 8 })}
+          isOwn={false}
+          onPinMessage={onPinMessage}
+        />,
+      );
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: 'ピン留め' }));
+      await userEvent.click(await screen.findByRole('radio', { name: '決定事項' }));
+      await userEvent.click(screen.getByRole('button', { name: 'ピン留めする' }));
+      expect(onPinMessage).toHaveBeenCalledWith(8, 3);
+    });
+
+    it('ピン留め済みメッセージはカテゴリ選択を開かず従来どおり解除を依頼する', async () => {
+      const onPinMessage = vi.fn();
+      const onUnpinMessage = vi.fn();
+      render(
+        <MessageActions
+          message={makeMessage({ id: 9 })}
+          isOwn={false}
+          isPinned
+          onPinMessage={onPinMessage}
+          onUnpinMessage={onUnpinMessage}
+        />,
+      );
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: 'ピン留めを解除' }));
+      expect(onUnpinMessage).toHaveBeenCalledWith(9);
+      expect(onPinMessage).not.toHaveBeenCalled();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('カテゴリ一覧の取得に失敗した場合はエラーを表示してピン留めを依頼しない', async () => {
+      const onPinMessage = vi.fn();
+      mockPinCategoriesList.mockRejectedValueOnce(new Error('failed'));
+      render(<MessageActions message={makeMessage()} isOwn={false} onPinMessage={onPinMessage} />);
+      await openMenu();
+      await userEvent.click(screen.getByRole('menuitem', { name: 'ピン留め' }));
+      await waitFor(() => expect(mockPinCategoriesList).toHaveBeenCalled());
+      expect(onPinMessage).not.toHaveBeenCalled();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/client/src/__tests__/PinnedMessages.test.tsx
+++ b/packages/client/src/__tests__/PinnedMessages.test.tsx
@@ -1,0 +1,272 @@
+/**
+ * テスト対象: components/Channel/PinnedMessages.tsx のカテゴリ分類機能
+ * テスト戦略: API をモックし、カテゴリタブによる絞り込み、未分類、後付け変更、
+ * 任意カテゴリ追加という複数状態をまたぐ振る舞いを検証する。
+ */
+
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PinnedMessages from '../components/Channel/PinnedMessages';
+import { makeMessage } from './__fixtures__/messages';
+
+const mockList = vi.fn();
+const mockListCategories = vi.fn();
+const mockUpdateCategory = vi.fn();
+const mockCreateCategory = vi.fn();
+const mockShowError = vi.fn();
+
+vi.mock('../api/client', () => ({
+  api: {
+    pins: {
+      list: (channelId: number) => mockList(channelId),
+      listCategories: (channelId: number) => mockListCategories(channelId),
+      updateCategory: (channelId: number, messageId: number, categoryId: number | null) =>
+        mockUpdateCategory(channelId, messageId, categoryId),
+      createCategory: (channelId: number, name: string) => mockCreateCategory(channelId, name),
+    },
+  },
+}));
+
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({ showError: mockShowError }),
+}));
+
+const categories = [
+  { id: 1, channelId: 1, name: '決定事項', isDefault: true, position: 0 },
+  { id: 2, channelId: 1, name: 'FAQ', isDefault: true, position: 1 },
+  { id: 3, channelId: 1, name: '重要', isDefault: false, position: 2 },
+];
+
+const pins = [
+  {
+    id: 1,
+    messageId: 1,
+    channelId: 1,
+    pinnedBy: 1,
+    pinnedAt: '2024-01-01',
+    categoryId: 1,
+    category: categories[0],
+    message: makeMessage({ id: 1, content: '決定メッセージ' }),
+  },
+  {
+    id: 2,
+    messageId: 2,
+    channelId: 1,
+    pinnedBy: 1,
+    pinnedAt: '2024-01-02',
+    categoryId: null,
+    category: null,
+    message: makeMessage({ id: 2, content: '未分類メッセージ' }),
+  },
+];
+
+function renderSubject() {
+  return render(<PinnedMessages channelId={1} currentUserId={1} onUnpin={vi.fn()} />);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockList.mockResolvedValue({ pinnedMessages: pins });
+  mockListCategories.mockResolvedValue({ categories });
+  mockUpdateCategory.mockResolvedValue({ pinnedMessage: pins[0] });
+  mockCreateCategory.mockResolvedValue({
+    category: { id: 4, channelId: 1, name: '新規', isDefault: false, position: 3 },
+  });
+});
+
+describe('PinnedMessages', () => {
+  it('チャンネル切替後に旧チャンネルの応答が返っても新チャンネルの表示を上書きしない', async () => {
+    let resolveOldPins!: (value: { pinnedMessages: typeof pins }) => void;
+    let resolveOldCategories!: (value: { categories: typeof categories }) => void;
+    mockList.mockImplementation((channelId: number) =>
+      channelId === 1
+        ? new Promise((resolve) => {
+            resolveOldPins = resolve;
+          })
+        : Promise.resolve({
+            pinnedMessages: [
+              {
+                ...pins[0],
+                id: 20,
+                messageId: 20,
+                channelId: 2,
+                message: makeMessage({ id: 20, content: '新チャンネル' }),
+              },
+            ],
+          }),
+    );
+    mockListCategories.mockImplementation((channelId: number) =>
+      channelId === 1
+        ? new Promise((resolve) => {
+            resolveOldCategories = resolve;
+          })
+        : Promise.resolve({ categories: [] }),
+    );
+    const { rerender } = renderSubject();
+    rerender(<PinnedMessages channelId={2} currentUserId={1} onUnpin={vi.fn()} />);
+    expect(await screen.findByText('新チャンネル')).toBeInTheDocument();
+    resolveOldPins({ pinnedMessages: pins });
+    resolveOldCategories({ categories });
+    await Promise.resolve();
+    expect(screen.getByText('新チャンネル')).toBeInTheDocument();
+    expect(screen.queryByText('決定メッセージ')).not.toBeInTheDocument();
+  });
+
+  it('チャンネル切替時に選択タブと開いているダイアログを初期化する', async () => {
+    const { rerender } = renderSubject();
+    await userEvent.click(await screen.findByRole('tab', { name: '決定事項' }));
+    const row = screen.getByText('決定メッセージ').closest('[data-pin-id]') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: 'カテゴリを変更' }));
+    rerender(<PinnedMessages channelId={2} currentUserId={1} onUnpin={vi.fn()} />);
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(screen.getByRole('tab', { name: 'すべて' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  describe('カテゴリタブによる絞り込み', () => {
+    it('すべて・未分類・デフォルトカテゴリ・任意カテゴリのタブを表示する', async () => {
+      renderSubject();
+      for (const name of ['すべて', '未分類', '決定事項', 'FAQ', '重要']) {
+        expect(await screen.findByRole('tab', { name })).toBeInTheDocument();
+      }
+    });
+
+    it('すべてタブでは分類済みと未分類の両方のピンを表示する', async () => {
+      renderSubject();
+      expect(await screen.findByText('決定メッセージ')).toBeInTheDocument();
+      expect(screen.getByText('未分類メッセージ')).toBeInTheDocument();
+    });
+
+    it('カテゴリタブを選ぶと該当カテゴリのピンだけを表示する', async () => {
+      renderSubject();
+      await userEvent.click(await screen.findByRole('tab', { name: '決定事項' }));
+      expect(screen.getByText('決定メッセージ')).toBeInTheDocument();
+      expect(screen.queryByText('未分類メッセージ')).not.toBeInTheDocument();
+    });
+
+    it('未分類タブを選ぶとカテゴリ未設定のピンだけを表示する', async () => {
+      renderSubject();
+      await userEvent.click(await screen.findByRole('tab', { name: '未分類' }));
+      expect(screen.getByText('未分類メッセージ')).toBeInTheDocument();
+      expect(screen.queryByText('決定メッセージ')).not.toBeInTheDocument();
+    });
+
+    it('該当するピンがないカテゴリでは空状態を表示する', async () => {
+      renderSubject();
+      await userEvent.click(await screen.findByRole('tab', { name: 'FAQ' }));
+      expect(screen.getByText('このカテゴリにピンはありません')).toBeInTheDocument();
+    });
+  });
+
+  describe('ピン留め後のカテゴリ変更', () => {
+    it('ピンのカテゴリ変更を確定するとAPIを呼び表示を再取得する', async () => {
+      renderSubject();
+      const row = (await screen.findByText('決定メッセージ')).closest(
+        '[data-pin-id]',
+      ) as HTMLElement;
+      await userEvent.click(within(row).getByRole('button', { name: 'カテゴリを変更' }));
+      await userEvent.click(screen.getByRole('radio', { name: 'FAQ' }));
+      await userEvent.click(screen.getByRole('button', { name: '変更する' }));
+      await waitFor(() => expect(mockUpdateCategory).toHaveBeenCalledWith(1, 1, 2));
+      expect(mockList).toHaveBeenCalledTimes(2);
+    });
+
+    it('カテゴリ変更中にチャンネルを切り替えると旧チャンネルの完了後に再読込しない', async () => {
+      let resolveUpdate!: (value: { pinnedMessage: (typeof pins)[number] }) => void;
+      mockUpdateCategory.mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveUpdate = resolve;
+        }),
+      );
+      const { rerender } = renderSubject();
+      const row = (await screen.findByText('決定メッセージ')).closest(
+        '[data-pin-id]',
+      ) as HTMLElement;
+      await userEvent.click(within(row).getByRole('button', { name: 'カテゴリを変更' }));
+      await userEvent.click(screen.getByRole('button', { name: '変更する' }));
+      await waitFor(() => expect(mockUpdateCategory).toHaveBeenCalled());
+      rerender(<PinnedMessages channelId={2} currentUserId={1} onUnpin={vi.fn()} />);
+      await waitFor(() => expect(mockList).toHaveBeenCalledWith(2));
+      resolveUpdate({ pinnedMessage: pins[0] });
+      await Promise.resolve();
+      expect(mockList).toHaveBeenCalledTimes(2);
+    });
+
+    it('カテゴリを未分類へ変更できる', async () => {
+      renderSubject();
+      const row = (await screen.findByText('決定メッセージ')).closest(
+        '[data-pin-id]',
+      ) as HTMLElement;
+      await userEvent.click(within(row).getByRole('button', { name: 'カテゴリを変更' }));
+      await userEvent.click(screen.getByRole('radio', { name: '未分類' }));
+      await userEvent.click(screen.getByRole('button', { name: '変更する' }));
+      expect(mockUpdateCategory).toHaveBeenCalledWith(1, 1, null);
+    });
+
+    it('カテゴリ変更APIが失敗した場合は元カテゴリ・選択タブ・一覧を維持する', async () => {
+      mockUpdateCategory.mockRejectedValueOnce(new Error('failed'));
+      renderSubject();
+      await userEvent.click(await screen.findByRole('tab', { name: '決定事項' }));
+      const row = screen.getByText('決定メッセージ').closest('[data-pin-id]') as HTMLElement;
+      await userEvent.click(within(row).getByRole('button', { name: 'カテゴリを変更' }));
+      await userEvent.click(screen.getByRole('radio', { name: 'FAQ' }));
+      await userEvent.click(screen.getByRole('button', { name: '変更する' }));
+      await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+      expect(screen.getByRole('tab', { name: '決定事項' })).toHaveAttribute(
+        'aria-selected',
+        'true',
+      );
+      expect(screen.getByText('決定メッセージ')).toBeInTheDocument();
+    });
+  });
+
+  describe('任意カテゴリ追加', () => {
+    it('新しいカテゴリを追加するとタブとカテゴリ選択肢へ反映する', async () => {
+      renderSubject();
+      await userEvent.click(await screen.findByRole('button', { name: 'カテゴリを追加' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'カテゴリ名' }), '新規');
+      await userEvent.click(screen.getByRole('button', { name: '追加する' }));
+      expect(await screen.findByRole('tab', { name: '新規' })).toBeInTheDocument();
+    });
+
+    it('カテゴリ追加中にチャンネルを切り替えると旧チャンネルのカテゴリを追加しない', async () => {
+      let resolveCreate!: (value: { category: (typeof categories)[number] }) => void;
+      mockCreateCategory.mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+      );
+      const { rerender } = renderSubject();
+      await userEvent.click(await screen.findByRole('button', { name: 'カテゴリを追加' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'カテゴリ名' }), '旧カテゴリ');
+      await userEvent.click(screen.getByRole('button', { name: '追加する' }));
+      await waitFor(() => expect(mockCreateCategory).toHaveBeenCalled());
+      rerender(<PinnedMessages channelId={2} currentUserId={1} onUnpin={vi.fn()} />);
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+      resolveCreate({
+        category: { id: 9, channelId: 1, name: '旧カテゴリ', isDefault: false, position: 9 },
+      });
+      await Promise.resolve();
+      expect(screen.queryByRole('tab', { name: '旧カテゴリ' })).not.toBeInTheDocument();
+    });
+
+    it('カテゴリ追加APIが失敗した場合はエラーを表示して現在の一覧を維持する', async () => {
+      mockCreateCategory.mockRejectedValueOnce(new Error('failed'));
+      renderSubject();
+      await userEvent.click(await screen.findByRole('button', { name: 'カテゴリを追加' }));
+      await userEvent.type(screen.getByRole('textbox', { name: 'カテゴリ名' }), '失敗');
+      await userEvent.click(screen.getByRole('button', { name: '追加する' }));
+      await waitFor(() => expect(mockShowError).toHaveBeenCalled());
+      expect(screen.getByText('決定メッセージ')).toBeInTheDocument();
+    });
+  });
+
+  describe('読込エラー', () => {
+    it('カテゴリ一覧の取得に失敗した場合はエラー状態を表示する', async () => {
+      mockListCategories.mockRejectedValueOnce(new Error('failed'));
+      renderSubject();
+      expect(await screen.findByText('ピン留めの読み込みに失敗しました')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/client/src/api/client.ts
+++ b/packages/client/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   OffsetPaged,
   CursorPaged,
   PinnedMessage,
+  PinCategory,
   PinnedChannel,
   Bookmark,
   BookmarkTag,
@@ -329,12 +330,25 @@ export const api = {
   pins: {
     list: (channelId: number) =>
       request<{ pinnedMessages: PinnedMessage[] }>(`/channels/${channelId}/pins`),
-    pin: (channelId: number, messageId: number) =>
+    pin: (channelId: number, messageId: number, categoryId?: number | null) =>
       request<{ pinnedMessage: PinnedMessage }>(`/channels/${channelId}/pins/${messageId}`, {
         method: 'POST',
+        body: JSON.stringify(categoryId === undefined ? {} : { categoryId }),
       }),
     unpin: (channelId: number, messageId: number) =>
       request<void>(`/channels/${channelId}/pins/${messageId}`, { method: 'DELETE' }),
+    listCategories: (channelId: number) =>
+      request<{ categories: PinCategory[] }>(`/channels/${channelId}/pins/categories`),
+    createCategory: (channelId: number, name: string) =>
+      request<{ category: PinCategory }>(`/channels/${channelId}/pins/categories`, {
+        method: 'POST',
+        body: JSON.stringify({ name }),
+      }),
+    updateCategory: (channelId: number, messageId: number, categoryId: number | null) =>
+      request<{ pinnedMessage: PinnedMessage }>(
+        `/channels/${channelId}/pins/${messageId}/category`,
+        { method: 'PATCH', body: JSON.stringify({ categoryId }) },
+      ),
   },
   bookmarks: {
     list: (filters: BookmarkListFilters = {}) => {

--- a/packages/client/src/components/Channel/PinnedMessages.tsx
+++ b/packages/client/src/components/Channel/PinnedMessages.tsx
@@ -1,132 +1,30 @@
-import { use, useState, useMemo, Suspense } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Box,
-  Typography,
-  IconButton,
-  Tooltip,
-  Collapse,
-  Divider,
+  Button,
   CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  IconButton,
+  Radio,
+  RadioGroup,
+  Tab,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
 } from '@mui/material';
-import PushPinIcon from '@mui/icons-material/PushPin';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
-import type { PinnedMessage } from '@chat-app/shared';
+import EditIcon from '@mui/icons-material/Edit';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import type { PinCategory, PinnedMessage } from '@chat-app/shared';
 import { api } from '../../api/client';
-
-interface PinnedMessagesInnerProps {
-  channelId: number;
-  pinsPromise: Promise<{ pinnedMessages: PinnedMessage[] }>;
-  onUnpin: (messageId: number) => void;
-  currentUserId: number;
-}
-
-function PinnedMessagesInner({
-  pinsPromise,
-  onUnpin,
-  currentUserId,
-}: PinnedMessagesInnerProps) {
-  const { pinnedMessages } = use(pinsPromise);
-  const [expanded, setExpanded] = useState(true);
-
-  if (pinnedMessages.length === 0) return null;
-
-  return (
-    <Box
-      sx={{
-        bgcolor: 'action.hover',
-        borderBottom: 1,
-        borderColor: 'divider',
-        px: 2,
-        py: 0.5,
-      }}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          cursor: 'pointer',
-        }}
-        onClick={() => setExpanded((v) => !v)}
-      >
-        <PushPinIcon fontSize="small" color="primary" />
-        <Typography variant="caption" fontWeight={600}>
-          ピン留め ({pinnedMessages.length})
-        </Typography>
-        <Box sx={{ ml: 'auto' }}>
-          {expanded ? (
-            <ExpandLessIcon fontSize="small" />
-          ) : (
-            <ExpandMoreIcon fontSize="small" />
-          )}
-        </Box>
-      </Box>
-
-      <Collapse in={expanded}>
-        <Divider sx={{ my: 0.5 }} />
-        {pinnedMessages.map((pin) => (
-          <Box
-            key={pin.id}
-            sx={{
-              display: 'flex',
-              alignItems: 'flex-start',
-              gap: 1,
-              py: 0.5,
-            }}
-          >
-            <PushPinIcon fontSize="small" sx={{ mt: 0.25, color: 'text.secondary' }} />
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Typography variant="caption" color="text.secondary">
-                {pin.pinnedByUser?.username ?? '不明なユーザー'} がピン留め
-              </Typography>
-              <Typography
-                variant="body2"
-                sx={{
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                {pin.message
-                  ? (() => {
-                      try {
-                        const delta = JSON.parse(pin.message.content) as {
-                          ops?: { insert?: string }[];
-                        };
-                        return (
-                          delta.ops
-                            ?.map((op) => (typeof op.insert === 'string' ? op.insert : ''))
-                            .join('')
-                            .trim() ?? ''
-                        );
-                      } catch {
-                        return pin.message.content;
-                      }
-                    })()
-                  : '(メッセージが見つかりません)'}
-              </Typography>
-            </Box>
-            {pin.pinnedBy === currentUserId && (
-              <Tooltip title="ピン留めを解除">
-                <IconButton
-                  size="small"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onUnpin(pin.messageId);
-                  }}
-                >
-                  <CloseIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            )}
-          </Box>
-        ))}
-      </Collapse>
-    </Box>
-  );
-}
+import { useSnackbar } from '../../contexts/SnackbarContext';
+import { extractMessageText } from '../../utils/extractMessageText';
 
 interface PinnedMessagesProps {
   channelId: number;
@@ -135,32 +33,231 @@ interface PinnedMessagesProps {
   onUnpin: (messageId: number) => void;
 }
 
+type SelectedTab = 'all' | 'unclassified' | number;
+
 export default function PinnedMessages({
   channelId,
   currentUserId,
   refreshKey = 0,
   onUnpin,
 }: PinnedMessagesProps) {
-  const pinsPromise = useMemo(
-    () => api.pins.list(channelId),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [channelId, refreshKey],
-  );
+  const [pins, setPins] = useState<PinnedMessage[]>([]);
+  const [categories, setCategories] = useState<PinCategory[]>([]);
+  const [selectedTab, setSelectedTab] = useState<SelectedTab>('all');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [editingPin, setEditingPin] = useState<PinnedMessage | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState('unclassified');
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const loadRequestId = useRef(0);
+  const currentChannelId = useRef(channelId);
+  currentChannelId.current = channelId;
+  const { showError } = useSnackbar();
+
+  const load = useCallback(async () => {
+    const requestId = ++loadRequestId.current;
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const [pinsResponse, categoriesResponse] = await Promise.all([
+        api.pins.list(channelId),
+        api.pins.listCategories(channelId),
+      ]);
+      if (loadRequestId.current === requestId) {
+        setPins(pinsResponse.pinnedMessages);
+        setCategories(categoriesResponse.categories);
+      }
+    } catch {
+      if (loadRequestId.current === requestId) setLoadError(true);
+    } finally {
+      if (loadRequestId.current === requestId) setLoading(false);
+    }
+  }, [channelId]);
+
+  useEffect(() => {
+    setSelectedTab('all');
+    setEditingPin(null);
+    setSelectedCategory('unclassified');
+    setAddDialogOpen(false);
+    setNewCategoryName('');
+    void load();
+    return () => {
+      loadRequestId.current += 1;
+    };
+  }, [load, refreshKey]);
+
+  const visiblePins = pins.filter((pin) => {
+    if (selectedTab === 'all') return true;
+    if (selectedTab === 'unclassified') return pin.categoryId === null;
+    return pin.categoryId === selectedTab;
+  });
+
+  const openCategoryEditor = (pin: PinnedMessage) => {
+    setEditingPin(pin);
+    setSelectedCategory(pin.categoryId === null ? 'unclassified' : String(pin.categoryId));
+  };
+
+  const updateCategory = async () => {
+    if (!editingPin) return;
+    const operationChannelId = channelId;
+    const categoryId = selectedCategory === 'unclassified' ? null : Number(selectedCategory);
+    try {
+      await api.pins.updateCategory(operationChannelId, editingPin.messageId, categoryId);
+      if (currentChannelId.current !== operationChannelId) return;
+      setEditingPin(null);
+      await load();
+    } catch {
+      if (currentChannelId.current !== operationChannelId) return;
+      showError('カテゴリの変更に失敗しました');
+      setEditingPin(null);
+    }
+  };
+
+  const createCategory = async () => {
+    const operationChannelId = channelId;
+    try {
+      const { category } = await api.pins.createCategory(operationChannelId, newCategoryName);
+      if (currentChannelId.current !== operationChannelId) return;
+      setCategories((current) => [...current, category]);
+      setNewCategoryName('');
+      setAddDialogOpen(false);
+    } catch {
+      if (currentChannelId.current !== operationChannelId) return;
+      showError('カテゴリの追加に失敗しました');
+    }
+  };
+
+  if (loading) {
+    return <CircularProgress size={20} aria-label="ピン留めを読み込み中" />;
+  }
+  if (loadError) {
+    return <Typography color="error">ピン留めの読み込みに失敗しました</Typography>;
+  }
 
   return (
-    <Suspense
-      fallback={
-        <Box sx={{ display: 'flex', justifyContent: 'center', p: 1 }}>
-          <CircularProgress size={16} />
-        </Box>
-      }
-    >
-      <PinnedMessagesInner
-        channelId={channelId}
-        pinsPromise={pinsPromise}
-        onUnpin={onUnpin}
-        currentUserId={currentUserId}
-      />
-    </Suspense>
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <PushPinIcon fontSize="small" color="primary" />
+        <Typography variant="subtitle2">ピン留め ({pins.length})</Typography>
+        <Button
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => setAddDialogOpen(true)}
+          sx={{ ml: 'auto' }}
+        >
+          カテゴリを追加
+        </Button>
+      </Box>
+
+      <Tabs
+        value={selectedTab}
+        onChange={(_, value: SelectedTab) => setSelectedTab(value)}
+        variant="scrollable"
+        scrollButtons="auto"
+        sx={{ mb: 1, minHeight: 34, '& .MuiTab-root': { minHeight: 34, px: 1 } }}
+      >
+        <Tab value="all" label="すべて" />
+        <Tab value="unclassified" label="未分類" />
+        {categories.map((category) => (
+          <Tab key={category.id} value={category.id} label={category.name} />
+        ))}
+      </Tabs>
+
+      {visiblePins.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          このカテゴリにピンはありません
+        </Typography>
+      ) : (
+        visiblePins.map((pin) => (
+          <Box
+            key={pin.id}
+            data-pin-id={pin.id}
+            sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5, py: 0.75 }}
+          >
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography variant="caption" color="text.secondary">
+                {pin.category?.name ?? '未分類'}
+              </Typography>
+              <Typography variant="body2" noWrap>
+                {pin.message
+                  ? extractMessageText(pin.message.content)
+                  : '(メッセージが見つかりません)'}
+              </Typography>
+            </Box>
+            <Tooltip title="カテゴリを変更">
+              <IconButton
+                size="small"
+                aria-label="カテゴリを変更"
+                onClick={() => openCategoryEditor(pin)}
+              >
+                <EditIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            {pin.pinnedBy === currentUserId && (
+              <Tooltip title="ピン留めを解除">
+                <IconButton
+                  size="small"
+                  aria-label="ピン留めを解除"
+                  onClick={() => onUnpin(pin.messageId)}
+                >
+                  <CloseIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
+          </Box>
+        ))
+      )}
+
+      <Dialog open={editingPin !== null} onClose={() => setEditingPin(null)}>
+        <DialogTitle>カテゴリを変更</DialogTitle>
+        <DialogContent>
+          <RadioGroup
+            value={selectedCategory}
+            onChange={(event) => setSelectedCategory(event.target.value)}
+          >
+            <FormControlLabel value="unclassified" control={<Radio />} label="未分類" />
+            {categories.map((category) => (
+              <FormControlLabel
+                key={category.id}
+                value={String(category.id)}
+                control={<Radio />}
+                label={category.name}
+              />
+            ))}
+          </RadioGroup>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditingPin(null)}>キャンセル</Button>
+          <Button variant="contained" onClick={() => void updateCategory()}>
+            変更する
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={addDialogOpen} onClose={() => setAddDialogOpen(false)}>
+        <DialogTitle>カテゴリを追加</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            label="カテゴリ名"
+            value={newCategoryName}
+            onChange={(event) => setNewCategoryName(event.target.value)}
+            inputProps={{ maxLength: 50 }}
+            sx={{ mt: 1 }}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddDialogOpen(false)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            disabled={newCategoryName.trim().length === 0}
+            onClick={() => void createCategory()}
+          >
+            追加する
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
   );
 }

--- a/packages/client/src/components/Chat/MessageActions.tsx
+++ b/packages/client/src/components/Chat/MessageActions.tsx
@@ -8,6 +8,14 @@ import {
   MenuItem,
   ListItemIcon,
   ListItemText,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
 } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -25,7 +33,7 @@ import ForwardIcon from '@mui/icons-material/Forward';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import AssignmentIcon from '@mui/icons-material/Assignment';
 import MenuBookIcon from '@mui/icons-material/MenuBook';
-import type { Message } from '@chat-app/shared';
+import type { Message, PinCategory } from '@chat-app/shared';
 import EmojiPicker from './EmojiPicker';
 import ReminderDialog from '../Reminder/ReminderDialog';
 import ForwardMessageDialog from './ForwardMessageDialog';
@@ -44,7 +52,8 @@ interface Props {
   onBookmarkChange?: (messageId: number, bookmarked: boolean) => void;
   onQuoteReply?: (message: Message) => void;
   onOpenThread?: (messageId: number) => void;
-  onPinMessage?: (messageId: number) => void;
+  onPinMessage?: (messageId: number, categoryId?: number | null) => void;
+  onUnpinMessage?: (messageId: number) => void;
   onEdit?: () => void;
   onEditTags?: () => void;
 }
@@ -58,6 +67,7 @@ export default function MessageActions({
   onQuoteReply,
   onOpenThread,
   onPinMessage,
+  onUnpinMessage,
   onEdit,
   onEditTags,
 }: Props) {
@@ -68,6 +78,9 @@ export default function MessageActions({
   const [forwardDialogOpen, setForwardDialogOpen] = useState(false);
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
   const [createTaskDialogOpen, setCreateTaskDialogOpen] = useState(false);
+  const [pinDialogOpen, setPinDialogOpen] = useState(false);
+  const [pinCategories, setPinCategories] = useState<PinCategory[]>([]);
+  const [selectedPinCategory, setSelectedPinCategory] = useState<string>('unclassified');
   const socket = useSocket();
   const { showSuccess, showError } = useSnackbar();
   const navigate = useNavigate();
@@ -116,6 +129,22 @@ export default function MessageActions({
   };
 
   const closeMenu = () => setMenuAnchor(null);
+
+  const handlePinMenuClick = async () => {
+    closeMenu();
+    if (isPinned) {
+      onUnpinMessage?.(message.id);
+      return;
+    }
+    try {
+      const response = await api.pins.listCategories(message.channelId);
+      setPinCategories(response.categories);
+      setSelectedPinCategory('unclassified');
+      setPinDialogOpen(true);
+    } catch {
+      showError('ピン留めカテゴリの取得に失敗しました');
+    }
+  };
 
   return (
     <>
@@ -213,8 +242,7 @@ export default function MessageActions({
         {/* ピン留め / ピン留め解除 */}
         <MenuItem
           onClick={() => {
-            onPinMessage?.(message.id);
-            closeMenu();
+            void handlePinMenuClick();
           }}
         >
           <ListItemIcon>
@@ -320,6 +348,44 @@ export default function MessageActions({
           </MenuItem>
         )}
       </Menu>
+
+      <Dialog
+        open={pinDialogOpen}
+        onClose={() => setPinDialogOpen(false)}
+        aria-labelledby="pin-category-dialog-title"
+      >
+        <DialogTitle id="pin-category-dialog-title">ピン留めカテゴリを選択</DialogTitle>
+        <DialogContent>
+          <RadioGroup
+            value={selectedPinCategory}
+            onChange={(event) => setSelectedPinCategory(event.target.value)}
+          >
+            <FormControlLabel value="unclassified" control={<Radio />} label="未分類" />
+            {pinCategories.map((category) => (
+              <FormControlLabel
+                key={category.id}
+                value={String(category.id)}
+                control={<Radio />}
+                label={category.name}
+              />
+            ))}
+          </RadioGroup>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPinDialogOpen(false)}>キャンセル</Button>
+          <Button
+            variant="contained"
+            onClick={() => {
+              const categoryId =
+                selectedPinCategory === 'unclassified' ? null : Number(selectedPinCategory);
+              onPinMessage?.(message.id, categoryId);
+              setPinDialogOpen(false);
+            }}
+          >
+            ピン留めする
+          </Button>
+        </DialogActions>
+      </Dialog>
 
       {/* 絵文字ピッカー */}
       <EmojiPicker

--- a/packages/client/src/components/Chat/MessageItem.tsx
+++ b/packages/client/src/components/Chat/MessageItem.tsx
@@ -23,7 +23,8 @@ interface Props {
   currentUserId: number;
   users: User[];
   onOpenThread?: (messageId: number) => void;
-  onPinMessage?: (messageId: number) => void;
+  onPinMessage?: (messageId: number, categoryId?: number | null) => void;
+  onUnpinMessage?: (messageId: number) => void;
   isPinned?: boolean;
   isBookmarked?: boolean;
   onBookmarkChange?: (messageId: number, bookmarked: boolean) => void;
@@ -45,6 +46,7 @@ export default function MessageItem({
   users,
   onOpenThread,
   onPinMessage,
+  onUnpinMessage,
   isPinned = false,
   isBookmarked = false,
   onBookmarkChange,
@@ -415,6 +417,7 @@ export default function MessageItem({
             onQuoteReply={onQuoteReply}
             onOpenThread={onOpenThread}
             onPinMessage={onPinMessage}
+            onUnpinMessage={onUnpinMessage}
             onEdit={() => setEditing(true)}
             onEditTags={() => setTagEditing(true)}
           />

--- a/packages/client/src/components/Chat/MessageList.tsx
+++ b/packages/client/src/components/Chat/MessageList.tsx
@@ -13,7 +13,8 @@ interface Props {
   currentUserId: number | null;
   users?: User[];
   onOpenThread?: (messageId: number) => void;
-  onPinMessage?: (messageId: number) => void;
+  onPinMessage?: (messageId: number, categoryId?: number | null) => void;
+  onUnpinMessage?: (messageId: number) => void;
   pinnedMessageIds?: Set<number>;
   bookmarkedMessageIds?: Set<number>;
   onBookmarkChange?: (messageId: number, bookmarked: boolean) => void;
@@ -56,6 +57,7 @@ export default function MessageList({
   users = [],
   onOpenThread,
   onPinMessage,
+  onUnpinMessage,
   pinnedMessageIds = new Set(),
   bookmarkedMessageIds = new Set(),
   onBookmarkChange,
@@ -178,6 +180,7 @@ export default function MessageList({
           users={users}
           onOpenThread={onOpenThread}
           onPinMessage={onPinMessage}
+          onUnpinMessage={onUnpinMessage}
           isPinned={pinnedMessageIds.has(msg.id)}
           isBookmarked={bookmarkedMessageIds.has(msg.id)}
           onBookmarkChange={onBookmarkChange}

--- a/packages/client/src/pages/ChatPage.tsx
+++ b/packages/client/src/pages/ChatPage.tsx
@@ -70,6 +70,7 @@ export default function ChatPage({ users }: Props) {
     return true;
   })();
   const [pinRefreshKey, setPinRefreshKey] = useState(0);
+  const [pinnedMessageIds, setPinnedMessageIds] = useState<Set<number>>(new Set());
   // ContextRail 開閉状態を localStorage に永続化
   const [contextRailOpen, setContextRailOpen] = useState<boolean>(
     () => window.localStorage.getItem('contextRail.open') === 'true',
@@ -297,6 +298,25 @@ export default function ChatPage({ users }: Props) {
     };
   }, [socket, activeChannelId]);
 
+  useEffect(() => {
+    if (!activeChannelId) {
+      setPinnedMessageIds(new Set());
+      return;
+    }
+    let active = true;
+    void api.pins
+      .list(activeChannelId)
+      .then(({ pinnedMessages }) => {
+        if (active) setPinnedMessageIds(new Set(pinnedMessages.map((pin) => pin.messageId)));
+      })
+      .catch(() => {
+        if (active) setPinnedMessageIds(new Set());
+      });
+    return () => {
+      active = false;
+    };
+  }, [activeChannelId, pinRefreshKey]);
+
   // #117 NG ワード関連: 送信エラー / 警告を Socket 経由で受信
   const { showError, showInfo } = useSnackbar();
   useEffect(() => {
@@ -324,9 +344,9 @@ export default function ChatPage({ users }: Props) {
   }, [socket, showError, showInfo]);
 
   const handlePinMessage = useCallback(
-    (messageId: number) => {
+    (messageId: number, categoryId?: number | null) => {
       if (!activeChannelId || !socket) return;
-      socket.emit('pin_message', { messageId, channelId: activeChannelId });
+      socket.emit('pin_message', { messageId, channelId: activeChannelId, categoryId });
     },
     [activeChannelId, socket],
   );
@@ -652,6 +672,8 @@ export default function ChatPage({ users }: Props) {
                 users={users}
                 onOpenThread={handleOpenThread}
                 onPinMessage={handlePinMessage}
+                onUnpinMessage={handleUnpinMessage}
+                pinnedMessageIds={pinnedMessageIds}
                 bookmarkedMessageIds={bookmarkedMessageIds}
                 onBookmarkChange={handleBookmarkChange}
                 onQuoteReply={handleQuoteReply}

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -134,12 +134,23 @@ export function createTestDatabase() {
       PRIMARY KEY (user_id, channel_id)
     );
 
+    CREATE TABLE IF NOT EXISTS pin_categories (
+      id SERIAL PRIMARY KEY,
+      channel_id INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+      name TEXT NOT NULL,
+      is_default BOOLEAN NOT NULL DEFAULT FALSE,
+      position INTEGER NOT NULL DEFAULT 0,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      UNIQUE (channel_id, name)
+    );
+
     CREATE TABLE IF NOT EXISTS pinned_messages (
       id SERIAL PRIMARY KEY,
       message_id INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
       channel_id INTEGER NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
       pinned_by INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
       pinned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      category_id INTEGER REFERENCES pin_categories(id) ON DELETE SET NULL,
       UNIQUE (message_id, channel_id)
     );
 
@@ -622,6 +633,7 @@ export async function resetTestData(db: TestDatabase): Promise<void> {
   await db.execute('DELETE FROM bookmark_tags', []);
   await db.execute('DELETE FROM bookmarks', []);
   await db.execute('DELETE FROM pinned_messages', []);
+  await db.execute('DELETE FROM pin_categories', []);
   await db.execute('DELETE FROM pinned_channels', []);
   await db.execute('DELETE FROM channel_read_status', []);
   await db.execute('DELETE FROM message_reactions', []);

--- a/packages/server/src/__tests__/integration/pinRoutes.test.ts
+++ b/packages/server/src/__tests__/integration/pinRoutes.test.ts
@@ -1,0 +1,345 @@
+/**
+ * テスト対象: routes/pins.ts のピン留めカテゴリHTTP API
+ * 戦略: supertest と pg-mem を使い、認証、入力、ステータス、レスポンス契約、
+ * 失敗時の非更新をHTTPレベルで検証する。
+ */
+
+import { createTestDatabase, resetTestData } from '../__fixtures__/pgTestHelper';
+
+const testDb = createTestDatabase();
+jest.mock('../../db/database', () => testDb);
+
+import request from 'supertest';
+import { createApp } from '../../app';
+import { createChannelReq, insertMessage, registerUser } from '../__fixtures__/testHelpers';
+
+const app = createApp();
+
+async function setup(suffix: string) {
+  await resetTestData(testDb);
+  const { token, userId } = await registerUser(app, `pin_${suffix}`, `pin_${suffix}@example.com`);
+  const channelId = await createChannelReq(app, token, `pin-${suffix}`);
+  const messageId = await insertMessage(channelId, userId, 'pin message');
+  return { token, userId, channelId, messageId };
+}
+
+async function firstCategory(token: string, channelId: number) {
+  const response = await request(app)
+    .get(`/api/channels/${channelId}/pins/categories`)
+    .set('Cookie', `token=${token}`);
+  return response.body.categories[0] as { id: number; name: string };
+}
+
+describe('ピン留めカテゴリ REST API', () => {
+  describe('GET /api/channels/:channelId/pins/categories', () => {
+    it('認証済みユーザーへ200でデフォルトと任意カテゴリの一覧を返す', async () => {
+      const { token, channelId } = await setup('list');
+      await request(app)
+        .post(`/api/channels/${channelId}/pins/categories`)
+        .set('Cookie', `token=${token}`)
+        .send({ name: '任意' });
+      const response = await request(app)
+        .get(`/api/channels/${channelId}/pins/categories`)
+        .set('Cookie', `token=${token}`);
+      expect(response.status).toBe(200);
+      expect(response.body.categories.map((category: { name: string }) => category.name)).toEqual([
+        '決定事項',
+        'リンク',
+        'FAQ',
+        '任意',
+      ]);
+    });
+
+    it('未認証では401を返す', async () => {
+      const { channelId } = await setup('list_auth');
+      expect((await request(app).get(`/api/channels/${channelId}/pins/categories`)).status).toBe(
+        401,
+      );
+    });
+
+    it('不正なチャンネルIDでは400を返す', async () => {
+      const { token } = await setup('list_bad');
+      const response = await request(app)
+        .get('/api/channels/invalid/pins/categories')
+        .set('Cookie', `token=${token}`);
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/channels/:channelId/pins/categories', () => {
+    it('カテゴリ名を送ると201で作成したカテゴリを返す', async () => {
+      const { token, channelId } = await setup('create');
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/categories`)
+        .set('Cookie', `token=${token}`)
+        .send({ name: '重要' });
+      expect(response.status).toBe(201);
+      expect(response.body.category).toMatchObject({ name: '重要', channelId });
+    });
+
+    it('未認証では401を返す', async () => {
+      const { channelId } = await setup('create_auth');
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/categories`)
+        .send({ name: '重要' });
+      expect(response.status).toBe(401);
+    });
+
+    it('存在しないチャンネルでは404を返す', async () => {
+      const { token } = await setup('create_missing');
+      const response = await request(app)
+        .post('/api/channels/99999/pins/categories')
+        .set('Cookie', `token=${token}`)
+        .send({ name: '重要' });
+      expect(response.status).toBe(404);
+    });
+
+    it('空白だけのカテゴリ名では400を返しDBを変更しない', async () => {
+      const { token, channelId } = await setup('create_blank');
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/categories`)
+        .set('Cookie', `token=${token}`)
+        .send({ name: '  ' });
+      expect(response.status).toBe(400);
+      expect(
+        await testDb.query('SELECT * FROM pin_categories WHERE channel_id = $1', [channelId]),
+      ).toEqual([]);
+    });
+
+    it('同名カテゴリでは409を返しDBを変更しない', async () => {
+      const { token, channelId } = await setup('create_duplicate');
+      const url = `/api/channels/${channelId}/pins/categories`;
+      await request(app).post(url).set('Cookie', `token=${token}`).send({ name: '重要' });
+      const response = await request(app)
+        .post(url)
+        .set('Cookie', `token=${token}`)
+        .send({ name: '重要' });
+      expect(response.status).toBe(409);
+      const rows = await testDb.query(
+        'SELECT * FROM pin_categories WHERE channel_id = $1 AND name = $2',
+        [channelId, '重要'],
+      );
+      expect(rows).toHaveLength(1);
+    });
+  });
+
+  describe('POST /api/channels/:channelId/pins/:messageId', () => {
+    it('categoryId付きのリクエストは201でカテゴリ付きピンを返す', async () => {
+      const { token, channelId, messageId } = await setup('pin_category');
+      const category = await firstCategory(token, channelId);
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/${messageId}`)
+        .set('Cookie', `token=${token}`)
+        .send({ categoryId: category.id });
+      expect(response.status).toBe(201);
+      expect(response.body.pinnedMessage.categoryId).toBe(category.id);
+    });
+
+    it('categoryId省略の従来リクエストは201でcategoryId nullのピンを返す', async () => {
+      const { token, channelId, messageId } = await setup('pin_legacy');
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/${messageId}`)
+        .set('Cookie', `token=${token}`);
+      expect(response.status).toBe(201);
+      expect(response.body.pinnedMessage.categoryId).toBeNull();
+    });
+
+    it('未認証では401を返す', async () => {
+      const { channelId, messageId } = await setup('pin_auth');
+      expect((await request(app).post(`/api/channels/${channelId}/pins/${messageId}`)).status).toBe(
+        401,
+      );
+    });
+
+    it('不正型のcategoryIdでは400を返しピンを作成しない', async () => {
+      const { token, channelId, messageId } = await setup('pin_bad');
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/${messageId}`)
+        .set('Cookie', `token=${token}`)
+        .send({ categoryId: 'bad' });
+      expect(response.status).toBe(400);
+      expect(await testDb.query('SELECT * FROM pinned_messages', [])).toEqual([]);
+    });
+
+    it('別チャンネルのカテゴリでは400を返しピンを作成しない', async () => {
+      const { token, channelId, messageId } = await setup('pin_other');
+      const otherChannelId = await createChannelReq(app, token, 'pin-other-category');
+      const category = await firstCategory(token, otherChannelId);
+      const response = await request(app)
+        .post(`/api/channels/${channelId}/pins/${messageId}`)
+        .set('Cookie', `token=${token}`)
+        .send({ categoryId: category.id });
+      expect(response.status).toBe(400);
+      expect(await testDb.query('SELECT * FROM pinned_messages', [])).toEqual([]);
+    });
+  });
+
+  describe('PATCH /api/channels/:channelId/pins/:messageId/category', () => {
+    async function setupPinned(suffix: string) {
+      const data = await setup(suffix);
+      const category = await firstCategory(data.token, data.channelId);
+      await request(app)
+        .post(`/api/channels/${data.channelId}/pins/${data.messageId}`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ categoryId: category.id });
+      return { ...data, category };
+    }
+
+    it('categoryIdを送ると200で変更後のピンを返す', async () => {
+      const data = await setupPinned('update');
+      const created = await request(app)
+        .post(`/api/channels/${data.channelId}/pins/categories`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ name: '変更先' });
+      const response = await request(app)
+        .patch(`/api/channels/${data.channelId}/pins/${data.messageId}/category`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ categoryId: created.body.category.id });
+      expect(response.status).toBe(200);
+      expect(response.body.pinnedMessage.category.name).toBe('変更先');
+    });
+
+    it('categoryId nullを送ると200で未分類のピンを返す', async () => {
+      const data = await setupPinned('update_null');
+      const response = await request(app)
+        .patch(`/api/channels/${data.channelId}/pins/${data.messageId}/category`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ categoryId: null });
+      expect(response.status).toBe(200);
+      expect(response.body.pinnedMessage.categoryId).toBeNull();
+    });
+
+    it('未認証では401を返す', async () => {
+      const data = await setupPinned('update_auth');
+      const response = await request(app)
+        .patch(`/api/channels/${data.channelId}/pins/${data.messageId}/category`)
+        .send({ categoryId: null });
+      expect(response.status).toBe(401);
+    });
+
+    it('不正なメッセージIDでは400を返す', async () => {
+      const data = await setupPinned('update_bad_id');
+      const response = await request(app)
+        .patch(`/api/channels/${data.channelId}/pins/invalid/category`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ categoryId: null });
+      expect(response.status).toBe(400);
+    });
+
+    it('不正型または欠落したcategoryIdでは400を返し元カテゴリを維持する', async () => {
+      const data = await setupPinned('update_bad_category');
+      const url = `/api/channels/${data.channelId}/pins/${data.messageId}/category`;
+      expect(
+        (
+          await request(app)
+            .patch(url)
+            .set('Cookie', `token=${data.token}`)
+            .send({ categoryId: 'bad' })
+        ).status,
+      ).toBe(400);
+      expect(
+        (await request(app).patch(url).set('Cookie', `token=${data.token}`).send({})).status,
+      ).toBe(400);
+      const [row] = await testDb.query<{ category_id: number }>(
+        'SELECT category_id FROM pinned_messages WHERE message_id = $1',
+        [data.messageId],
+      );
+      expect(row.category_id).toBe(data.category.id);
+    });
+
+    it('存在しないカテゴリでは404を返し元カテゴリを維持する', async () => {
+      const data = await setupPinned('update_missing_category');
+      const response = await request(app)
+        .patch(`/api/channels/${data.channelId}/pins/${data.messageId}/category`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ categoryId: 99999 });
+      expect(response.status).toBe(404);
+      const [row] = await testDb.query<{ category_id: number }>(
+        'SELECT category_id FROM pinned_messages WHERE message_id = $1',
+        [data.messageId],
+      );
+      expect(row.category_id).toBe(data.category.id);
+    });
+
+    it('別チャンネルのカテゴリでは400を返し元カテゴリを維持する', async () => {
+      const data = await setupPinned('update_other');
+      const otherChannelId = await createChannelReq(app, data.token, 'update-other');
+      const category = await firstCategory(data.token, otherChannelId);
+      const response = await request(app)
+        .patch(`/api/channels/${data.channelId}/pins/${data.messageId}/category`)
+        .set('Cookie', `token=${data.token}`)
+        .send({ categoryId: category.id });
+      expect(response.status).toBe(400);
+      const [row] = await testDb.query<{ category_id: number }>(
+        'SELECT category_id FROM pinned_messages WHERE message_id = $1',
+        [data.messageId],
+      );
+      expect(row.category_id).toBe(data.category.id);
+    });
+
+    it('存在しないピンでは404を返す', async () => {
+      const { token, channelId, messageId } = await setup('update_missing_pin');
+      const response = await request(app)
+        .patch(`/api/channels/${channelId}/pins/${messageId}/category`)
+        .set('Cookie', `token=${token}`)
+        .send({ categoryId: null });
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('プライベートチャンネルのアクセス制御', () => {
+    it('非メンバーはカテゴリ・ピンの取得、作成、変更、解除をすべて403にする', async () => {
+      await resetTestData(testDb);
+      const owner = await registerUser(app, 'pin_private_owner', 'pin_private_owner@example.com');
+      const outsider = await registerUser(
+        app,
+        'pin_private_outsider',
+        'pin_private_outsider@example.com',
+      );
+      const createResponse = await request(app)
+        .post('/api/channels')
+        .set('Cookie', `token=${owner.token}`)
+        .send({ name: 'pin-private', is_private: true });
+      const channelId = createResponse.body.channel.id as number;
+      const messageId = await insertMessage(channelId, owner.userId, 'private pin');
+      const category = await firstCategory(owner.token, channelId);
+      await request(app)
+        .post(`/api/channels/${channelId}/pins/${messageId}`)
+        .set('Cookie', `token=${owner.token}`)
+        .send({ categoryId: category.id });
+
+      const cookie = `token=${outsider.token}`;
+      const responses = await Promise.all([
+        request(app).get(`/api/channels/${channelId}/pins`).set('Cookie', cookie),
+        request(app).get(`/api/channels/${channelId}/pins/categories`).set('Cookie', cookie),
+        request(app)
+          .post(`/api/channels/${channelId}/pins/categories`)
+          .set('Cookie', cookie)
+          .send({ name: '侵入' }),
+        request(app)
+          .post(`/api/channels/${channelId}/pins/${messageId}`)
+          .set('Cookie', cookie)
+          .send({ categoryId: null }),
+        request(app)
+          .patch(`/api/channels/${channelId}/pins/${messageId}/category`)
+          .set('Cookie', cookie)
+          .send({ categoryId: null }),
+        request(app).delete(`/api/channels/${channelId}/pins/${messageId}`).set('Cookie', cookie),
+      ]);
+
+      expect(responses.map((response) => response.status)).toEqual([403, 403, 403, 403, 403, 403]);
+      expect(
+        await testDb.query('SELECT * FROM pin_categories WHERE channel_id = $1 AND name = $2', [
+          channelId,
+          '侵入',
+        ]),
+      ).toEqual([]);
+      expect(
+        await testDb.query<{ category_id: number }>(
+          'SELECT category_id FROM pinned_messages WHERE message_id = $1',
+          [messageId],
+        ),
+      ).toEqual([expect.objectContaining({ category_id: category.id })]);
+    });
+  });
+});

--- a/packages/server/src/__tests__/pin-message.test.ts
+++ b/packages/server/src/__tests__/pin-message.test.ts
@@ -10,7 +10,14 @@ const testDb = createTestDatabase();
 
 jest.mock('../db/database', () => testDb);
 
-import { pinMessage, unpinMessage, getPinnedMessages } from '../services/pinMessageService';
+import {
+  pinMessage,
+  unpinMessage,
+  getPinnedMessages,
+  getPinCategories,
+  createPinCategory,
+  updatePinCategory,
+} from '../services/pinMessageService';
 
 let userId1: number;
 let userId2: number;
@@ -20,19 +27,19 @@ let deletedMessageId: number;
 
 async function setupFixtures() {
   const r1 = await testDb.execute(
-    "INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id",
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
     ['user1', 'u1@t.com', 'h'],
   );
   userId1 = r1.rows[0].id as number;
 
   const r2 = await testDb.execute(
-    "INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id",
+    'INSERT INTO users (username, email, password_hash) VALUES ($1, $2, $3) RETURNING id',
     ['user2', 'u2@t.com', 'h'],
   );
   userId2 = r2.rows[0].id as number;
 
   const rc = await testDb.execute(
-    "INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id",
+    'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
     ['test-channel', userId1],
   );
   channelId = rc.rows[0].id as number;
@@ -86,28 +93,28 @@ describe('pinMessage', () => {
 describe('unpinMessage', () => {
   it('ピン留めを解除できる', async () => {
     await pinMessage(messageId, channelId, userId1);
-    await expect(unpinMessage(messageId, channelId)).resolves.not.toThrow();
+    await expect(unpinMessage(messageId, channelId, userId1)).resolves.not.toThrow();
   });
 
   it('ピン留めされていないメッセージの解除はエラーになる', async () => {
-    await expect(unpinMessage(messageId, channelId)).rejects.toThrow('Pin not found');
+    await expect(unpinMessage(messageId, channelId, userId1)).rejects.toThrow('Pin not found');
   });
 
   it('存在しないメッセージの解除はエラーになる', async () => {
-    await expect(unpinMessage(99999, channelId)).rejects.toThrow('Message not found');
+    await expect(unpinMessage(99999, channelId, userId1)).rejects.toThrow('Message not found');
   });
 });
 
 describe('getPinnedMessages', () => {
   it('チャンネルのピン留めメッセージ一覧を返す', async () => {
     await pinMessage(messageId, channelId, userId1);
-    const list = await getPinnedMessages(channelId);
+    const list = await getPinnedMessages(channelId, userId1);
     expect(list.length).toBe(1);
     expect(list[0].messageId).toBe(messageId);
   });
 
   it('ピン留めが存在しないチャンネルでは空配列を返す', async () => {
-    const list = await getPinnedMessages(channelId);
+    const list = await getPinnedMessages(channelId, userId1);
     expect(list).toEqual([]);
   });
 
@@ -122,7 +129,7 @@ describe('getPinnedMessages', () => {
     await pinMessage(messageId, channelId, userId1);
     await pinMessage(messageId2, channelId, userId2);
 
-    const list = await getPinnedMessages(channelId);
+    const list = await getPinnedMessages(channelId, userId1);
     expect(list.length).toBe(2);
     // 後でピン留めされたものが先頭
     expect(new Date(list[0].pinnedAt) >= new Date(list[1].pinnedAt)).toBe(true);
@@ -136,7 +143,7 @@ describe('getPinnedMessages', () => {
       [deletedMessageId, channelId, userId1],
     );
 
-    const list = await getPinnedMessages(channelId);
+    const list = await getPinnedMessages(channelId, userId1);
     const hasDeleted = list.some((p) => p.messageId === deletedMessageId);
     expect(hasDeleted).toBe(false);
   });
@@ -156,7 +163,7 @@ describe('Socket経由でのピン留め操作', () => {
 
   it('unpin_message イベントで pinned_messages テーブルからレコードが削除される', async () => {
     await pinMessage(messageId, channelId, userId1);
-    await unpinMessage(messageId, channelId);
+    await unpinMessage(messageId, channelId, userId1);
 
     const row = await testDb.queryOne(
       'SELECT * FROM pinned_messages WHERE message_id = $1 AND channel_id = $2',
@@ -175,14 +182,14 @@ describe('Socket経由でのピン留め操作', () => {
   it('unpin_message 後に message_unpinned イベントがチャンネルメンバー全員に emit される', async () => {
     // サービス層のテストのためSocketのemitは検証しない
     await pinMessage(messageId, channelId, userId1);
-    await expect(unpinMessage(messageId, channelId)).resolves.not.toThrow();
+    await expect(unpinMessage(messageId, channelId, userId1)).resolves.not.toThrow();
   });
 });
 
 describe('REST API: GET /api/channels/:channelId/pins', () => {
   it('200 でピン留めメッセージ一覧を返す', async () => {
     await pinMessage(messageId, channelId, userId1);
-    const list = await getPinnedMessages(channelId);
+    const list = await getPinnedMessages(channelId, userId1);
     expect(Array.isArray(list)).toBe(true);
     expect(list.length).toBeGreaterThan(0);
   });
@@ -193,9 +200,7 @@ describe('REST API: GET /api/channels/:channelId/pins', () => {
   });
 
   it('存在しないチャンネルIDで 404 を返す', async () => {
-    // 存在しないチャンネルでも空配列を返す（チャンネル存在チェックはAPIルート層の責務）
-    const list = await getPinnedMessages(99999);
-    expect(list).toEqual([]);
+    await expect(getPinnedMessages(99999, userId1)).rejects.toThrow('Channel not found');
   });
 });
 
@@ -222,7 +227,7 @@ describe('REST API: POST /api/channels/:channelId/pins/:messageId', () => {
 describe('REST API: DELETE /api/channels/:channelId/pins/:messageId', () => {
   it('ピン留め解除成功で 204 を返す', async () => {
     await pinMessage(messageId, channelId, userId1);
-    await expect(unpinMessage(messageId, channelId)).resolves.not.toThrow();
+    await expect(unpinMessage(messageId, channelId, userId1)).resolves.not.toThrow();
   });
 
   it('認証なしで 401 を返す', () => {
@@ -231,6 +236,150 @@ describe('REST API: DELETE /api/channels/:channelId/pins/:messageId', () => {
   });
 
   it('ピン留めが存在しない場合 404 を返す', async () => {
-    await expect(unpinMessage(messageId, channelId)).rejects.toThrow('Pin not found');
+    await expect(unpinMessage(messageId, channelId, userId1)).rejects.toThrow('Pin not found');
+  });
+});
+
+describe('ピン留めカテゴリ', () => {
+  describe('カテゴリ一覧と任意カテゴリ追加', () => {
+    it('初回取得時にデフォルトカテゴリ「決定事項」「リンク」「FAQ」を返す', async () => {
+      const categories = await getPinCategories(channelId, userId1);
+      expect(categories.map((category) => category.name)).toEqual(['決定事項', 'リンク', 'FAQ']);
+      expect(categories.every((category) => category.isDefault)).toBe(true);
+    });
+
+    it('デフォルトカテゴリを複数回取得しても重複して作成しない', async () => {
+      await getPinCategories(channelId, userId1);
+      await getPinCategories(channelId, userId1);
+      const rows = await testDb.query<{ count: number }>(
+        'SELECT COUNT(*)::int AS count FROM pin_categories WHERE channel_id = $1',
+        [channelId],
+      );
+      expect(Number(rows[0].count)).toBe(3);
+    });
+
+    it('チャンネルに任意カテゴリを追加できる', async () => {
+      const category = await createPinCategory(channelId, '重要', userId1);
+      expect(category).toMatchObject({ channelId, name: '重要', isDefault: false });
+    });
+
+    it('空白だけのカテゴリ名は追加できない', async () => {
+      await expect(createPinCategory(channelId, '   ', userId1)).rejects.toThrow(
+        'Invalid category name',
+      );
+    });
+
+    it('同じチャンネルに同名カテゴリを重複して追加できない', async () => {
+      await createPinCategory(channelId, '重要', userId1);
+      await expect(createPinCategory(channelId, '重要', userId1)).rejects.toThrow(
+        'Pin category already exists',
+      );
+    });
+  });
+
+  describe('ピン留め時のカテゴリ設定と既存互換', () => {
+    it('指定したカテゴリでメッセージをピン留めできる', async () => {
+      const [category] = await getPinCategories(channelId, userId1);
+      const pinned = await pinMessage(messageId, channelId, userId1, category.id);
+      expect(pinned.categoryId).toBe(category.id);
+      expect(pinned.category?.name).toBe('決定事項');
+    });
+
+    it('カテゴリを指定しない従来の呼び出しでは未分類としてピン留めできる', async () => {
+      const pinned = await pinMessage(messageId, channelId, userId1);
+      expect(pinned.categoryId).toBeNull();
+      expect(pinned.category).toBeNull();
+    });
+
+    it('既存のカテゴリ未設定DB行は一覧で categoryId null として返す', async () => {
+      await testDb.execute(
+        'INSERT INTO pinned_messages (message_id, channel_id, pinned_by) VALUES ($1, $2, $3)',
+        [messageId, channelId, userId1],
+      );
+      const [pinned] = await getPinnedMessages(channelId, userId1);
+      expect(pinned.categoryId).toBeNull();
+    });
+
+    it('別チャンネルのカテゴリを指定してピン留めできない', async () => {
+      const otherChannel = await testDb.execute(
+        'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+        ['other', userId1],
+      );
+      const category = await createPinCategory(otherChannel.rows[0].id as number, '他', userId1);
+      await expect(pinMessage(messageId, channelId, userId1, category.id)).rejects.toThrow(
+        'Pin category does not belong to channel',
+      );
+    });
+
+    it('指定チャンネルに所属しないメッセージをピン留めできない', async () => {
+      const otherChannel = await testDb.execute(
+        'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+        ['other-message', userId1],
+      );
+      await expect(
+        pinMessage(messageId, otherChannel.rows[0].id as number, userId1),
+      ).rejects.toThrow('Message does not belong to channel');
+    });
+
+    it('ピン一覧に設定済みカテゴリを含めて返す', async () => {
+      const category = await createPinCategory(channelId, '重要', userId1);
+      await pinMessage(messageId, channelId, userId1, category.id);
+      const [pinned] = await getPinnedMessages(channelId, userId1);
+      expect(pinned.category).toMatchObject({ id: category.id, name: '重要' });
+    });
+
+    it('デフォルトカテゴリと任意カテゴリは別チャンネルの一覧に混在しない', async () => {
+      await createPinCategory(channelId, 'チャンネル1', userId1);
+      const otherChannel = await testDb.execute(
+        'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+        ['other-categories', userId1],
+      );
+      const categories = await getPinCategories(otherChannel.rows[0].id as number, userId1);
+      expect(categories.map((category) => category.name)).toEqual(['決定事項', 'リンク', 'FAQ']);
+    });
+  });
+
+  describe('ピン留め後のカテゴリ変更', () => {
+    it('ピン留め済みメッセージのカテゴリを後から変更できる', async () => {
+      const category = await createPinCategory(channelId, '変更先', userId1);
+      await pinMessage(messageId, channelId, userId1);
+      const updated = await updatePinCategory(messageId, channelId, category.id, userId1);
+      expect(updated.categoryId).toBe(category.id);
+    });
+
+    it('カテゴリを解除すると未分類に戻せる', async () => {
+      const category = await createPinCategory(channelId, '解除元', userId1);
+      await pinMessage(messageId, channelId, userId1, category.id);
+      const updated = await updatePinCategory(messageId, channelId, null, userId1);
+      expect(updated.categoryId).toBeNull();
+    });
+
+    it('別チャンネルのカテゴリへ変更できない', async () => {
+      await pinMessage(messageId, channelId, userId1);
+      const otherChannel = await testDb.execute(
+        'INSERT INTO channels (name, created_by) VALUES ($1, $2) RETURNING id',
+        ['other-update', userId1],
+      );
+      const category = await createPinCategory(otherChannel.rows[0].id as number, '他', userId1);
+      await expect(updatePinCategory(messageId, channelId, category.id, userId1)).rejects.toThrow(
+        'Pin category does not belong to channel',
+      );
+    });
+
+    it('存在しないピンのカテゴリ変更はエラーになる', async () => {
+      await expect(updatePinCategory(messageId, channelId, null, userId1)).rejects.toThrow(
+        'Pin not found',
+      );
+    });
+
+    it('カテゴリ変更に失敗した場合は元のカテゴリを維持する', async () => {
+      const category = await createPinCategory(channelId, '元', userId1);
+      await pinMessage(messageId, channelId, userId1, category.id);
+      await expect(updatePinCategory(messageId, channelId, 99999, userId1)).rejects.toThrow(
+        'Pin category not found',
+      );
+      const [pinned] = await getPinnedMessages(channelId, userId1);
+      expect(pinned.categoryId).toBe(category.id);
+    });
   });
 });

--- a/packages/server/src/__tests__/socket-handler.test.ts
+++ b/packages/server/src/__tests__/socket-handler.test.ts
@@ -37,6 +37,7 @@ import * as messageService from '../services/messageService';
 import * as pushService from '../services/pushService';
 import * as channelNotificationService from '../services/channelNotificationService';
 import * as moderationService from '../services/moderationService';
+import * as pinMessageService from '../services/pinMessageService';
 import { createAuthMiddleware } from '../socket/socketAuthMiddleware';
 import { registerChannelHandlers } from '../socket/channelHandler';
 import { registerMessageHandlers } from '../socket/messageHandler';
@@ -49,6 +50,7 @@ const mockedNotificationService = channelNotificationService as jest.Mocked<
   typeof channelNotificationService
 >;
 const mockedModerationService = moderationService as jest.Mocked<typeof moderationService>;
+const mockedPinMessageService = pinMessageService as jest.Mocked<typeof pinMessageService>;
 // デフォルトでは NG ワード判定なし
 beforeEach(() => {
   mockedModerationService.checkContent.mockResolvedValue(null);
@@ -343,6 +345,91 @@ describe('Socket.IO ハンドラ', () => {
   // ===========================
 
   describe('メッセージハンドラ (messageHandler)', () => {
+    describe('pin_message イベントのカテゴリ契約', () => {
+      function setupPinHandler() {
+        const socket = createMockSocket();
+        socket.data.userId = TEST_USER_ID;
+        socket.data.username = TEST_USERNAME;
+        const handlers: Record<string, (...args: any[]) => void> = {};
+        socket.on.mockImplementation((event: string, callback: (...args: any[]) => void) => {
+          handlers[event] = callback;
+        });
+        const io = { to: jest.fn().mockReturnThis(), emit: jest.fn() };
+        registerMessageHandlers(io as any, socket as any);
+        return { socket, handlers, io };
+      }
+
+      it('カテゴリID付きpayloadを受信するとカテゴリIDをサービスへ渡してピン留めする', async () => {
+        mockedPinMessageService.pinMessage.mockResolvedValue({
+          pinnedAt: '2024-01-01',
+          categoryId: 3,
+        } as any);
+        const { handlers } = setupPinHandler();
+        handlers.pin_message({ messageId: 1, channelId: 2, categoryId: 3 });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(mockedPinMessageService.pinMessage).toHaveBeenCalledWith(1, 2, TEST_USER_ID, 3);
+      });
+
+      it('カテゴリIDを省略した従来payloadを受信すると未分類でピン留めする', async () => {
+        mockedPinMessageService.pinMessage.mockResolvedValue({
+          pinnedAt: '2024-01-01',
+          categoryId: null,
+        } as any);
+        const { handlers } = setupPinHandler();
+        handlers.pin_message({ messageId: 1, channelId: 2 });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(mockedPinMessageService.pinMessage).toHaveBeenCalledWith(
+          1,
+          2,
+          TEST_USER_ID,
+          undefined,
+        );
+      });
+
+      it('categoryId nullのpayloadを受信すると未分類でピン留めする', async () => {
+        mockedPinMessageService.pinMessage.mockResolvedValue({
+          pinnedAt: '2024-01-01',
+          categoryId: null,
+        } as any);
+        const { handlers } = setupPinHandler();
+        handlers.pin_message({ messageId: 1, channelId: 2, categoryId: null });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(mockedPinMessageService.pinMessage).toHaveBeenCalledWith(1, 2, TEST_USER_ID, null);
+      });
+
+      it('ピン留め成功時はカテゴリ情報を含むmessage_pinnedをチャンネルへ送信する', async () => {
+        mockedPinMessageService.pinMessage.mockResolvedValue({
+          pinnedAt: '2024-01-01',
+          categoryId: 3,
+        } as any);
+        const { handlers, io } = setupPinHandler();
+        handlers.pin_message({ messageId: 1, channelId: 2, categoryId: 3 });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(io.to).toHaveBeenCalledWith('channel:2');
+        expect(io.emit).toHaveBeenCalledWith(
+          'message_pinned',
+          expect.objectContaining({ categoryId: 3 }),
+        );
+      });
+
+      it('カテゴリ不整合で失敗した場合はmessage_pinnedを送信せずエラーを返す', async () => {
+        mockedPinMessageService.pinMessage.mockRejectedValue(new Error('category mismatch'));
+        const { handlers, io, socket } = setupPinHandler();
+        handlers.pin_message({ messageId: 1, channelId: 2, categoryId: 3 });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(io.emit).not.toHaveBeenCalledWith('message_pinned', expect.anything());
+        expect(socket.emit).toHaveBeenCalledWith('error', 'Failed to pin message');
+      });
+
+      it('ピン解除時は認証ユーザーIDをサービスへ渡す', async () => {
+        mockedPinMessageService.unpinMessage.mockResolvedValue();
+        const { handlers } = setupPinHandler();
+        handlers.unpin_message({ messageId: 1, channelId: 2 });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(mockedPinMessageService.unpinMessage).toHaveBeenCalledWith(1, 2, TEST_USER_ID);
+      });
+    });
+
     /** モック io (チャンネルへの broadcast 用) */
     function createMockIo() {
       const io = {

--- a/packages/server/src/routes/pins.ts
+++ b/packages/server/src/routes/pins.ts
@@ -5,26 +5,90 @@ import * as pinService from '../services/pinMessageService';
 
 const router = Router({ mergeParams: true });
 
+function parseChannelId(value: string): number | null {
+  const channelId = Number(value);
+  return Number.isInteger(channelId) && channelId > 0 ? channelId : null;
+}
+
+function parseMessageId(value: string): number | null {
+  const messageId = Number(value);
+  return Number.isInteger(messageId) && messageId > 0 ? messageId : null;
+}
+
+router.get('/categories', authenticateToken, async (req, res, next) => {
+  const channelId = parseChannelId(req.params.channelId);
+  const userId = (req as AuthenticatedRequest).userId;
+  if (channelId === null) return next(createError('Invalid channelId', 400));
+  try {
+    const categories = await pinService.getPinCategories(channelId, userId);
+    return res.json({ categories });
+  } catch (error) {
+    if ((error as Error).message === 'Channel not found')
+      return next(createError('Channel not found', 404));
+    if ((error as Error).message === 'Forbidden') return next(createError('Forbidden', 403));
+    return next(createError('Internal server error', 500));
+  }
+});
+
+router.post('/categories', authenticateToken, async (req, res, next) => {
+  const channelId = parseChannelId(req.params.channelId);
+  const userId = (req as AuthenticatedRequest).userId;
+  if (channelId === null) return next(createError('Invalid channelId', 400));
+  if (typeof req.body.name !== 'string') return next(createError('Invalid category name', 400));
+  try {
+    const category = await pinService.createPinCategory(channelId, req.body.name, userId);
+    return res.status(201).json({ category });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === 'Channel not found') return next(createError(message, 404));
+    if (message === 'Forbidden') return next(createError(message, 403));
+    if (message === 'Invalid category name') return next(createError(message, 400));
+    if (message === 'Pin category already exists') return next(createError(message, 409));
+    return next(createError('Internal server error', 500));
+  }
+});
+
 router.get('/', authenticateToken, async (req, res, next) => {
   const channelId = parseInt(req.params.channelId, 10);
   if (isNaN(channelId)) {
     return next(createError('Invalid channelId', 400));
   }
-  const pinnedMessages = await pinService.getPinnedMessages(channelId);
-  return res.json({ pinnedMessages });
+  const userId = (req as AuthenticatedRequest).userId;
+  try {
+    const pinnedMessages = await pinService.getPinnedMessages(channelId, userId);
+    return res.json({ pinnedMessages });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === 'Channel not found') return next(createError(message, 404));
+    if (message === 'Forbidden') return next(createError(message, 403));
+    return next(createError('Internal server error', 500));
+  }
 });
 
 router.post('/:messageId', authenticateToken, async (req, res, next) => {
-  const channelId = parseInt(req.params.channelId, 10);
-  const messageId = parseInt(req.params.messageId, 10);
+  const channelId = parseChannelId(req.params.channelId);
+  const messageId = parseMessageId(req.params.messageId);
   const userId = (req as AuthenticatedRequest).userId;
 
-  if (isNaN(channelId) || isNaN(messageId)) {
+  if (channelId === null || messageId === null) {
     return next(createError('Invalid parameters', 400));
+  }
+  const { categoryId } = req.body as { categoryId?: unknown };
+  if (
+    categoryId !== undefined &&
+    categoryId !== null &&
+    (!Number.isInteger(categoryId) || (categoryId as number) <= 0)
+  ) {
+    return next(createError('Invalid categoryId', 400));
   }
 
   try {
-    const pinned = await pinService.pinMessage(messageId, channelId, userId);
+    const pinned = await pinService.pinMessage(
+      messageId,
+      channelId,
+      userId,
+      categoryId as number | null | undefined,
+    );
     return res.status(201).json({ pinnedMessage: pinned });
   } catch (err: unknown) {
     const error = err as Error;
@@ -37,6 +101,47 @@ router.post('/:messageId', authenticateToken, async (req, res, next) => {
     if (error.message === 'Cannot pin a deleted message') {
       return next(createError(error.message, 400));
     }
+    if (
+      error.message === 'Pin category does not belong to channel' ||
+      error.message === 'Message does not belong to channel'
+    ) {
+      return next(createError(error.message, 400));
+    }
+    if (error.message === 'Pin category not found') return next(createError(error.message, 404));
+    if (error.message === 'Forbidden') return next(createError(error.message, 403));
+    return next(createError('Internal server error', 500));
+  }
+});
+
+router.patch('/:messageId/category', authenticateToken, async (req, res, next) => {
+  const channelId = parseChannelId(req.params.channelId);
+  const messageId = parseMessageId(req.params.messageId);
+  const userId = (req as AuthenticatedRequest).userId;
+  if (channelId === null || messageId === null) return next(createError('Invalid parameters', 400));
+  if (!Object.prototype.hasOwnProperty.call(req.body, 'categoryId')) {
+    return next(createError('categoryId is required', 400));
+  }
+  const { categoryId } = req.body as { categoryId: unknown };
+  if (categoryId !== null && (!Number.isInteger(categoryId) || (categoryId as number) <= 0)) {
+    return next(createError('Invalid categoryId', 400));
+  }
+  try {
+    const pinnedMessage = await pinService.updatePinCategory(
+      messageId,
+      channelId,
+      categoryId as number | null,
+      userId,
+    );
+    return res.json({ pinnedMessage });
+  } catch (error) {
+    const message = (error as Error).message;
+    if (message === 'Pin not found' || message === 'Pin category not found') {
+      return next(createError(message, 404));
+    }
+    if (message === 'Pin category does not belong to channel') {
+      return next(createError(message, 400));
+    }
+    if (message === 'Forbidden') return next(createError(message, 403));
     return next(createError('Internal server error', 500));
   }
 });
@@ -44,19 +149,21 @@ router.post('/:messageId', authenticateToken, async (req, res, next) => {
 router.delete('/:messageId', authenticateToken, async (req, res, next) => {
   const channelId = parseInt(req.params.channelId, 10);
   const messageId = parseInt(req.params.messageId, 10);
+  const userId = (req as AuthenticatedRequest).userId;
 
   if (isNaN(channelId) || isNaN(messageId)) {
     return next(createError('Invalid parameters', 400));
   }
 
   try {
-    await pinService.unpinMessage(messageId, channelId);
+    await pinService.unpinMessage(messageId, channelId, userId);
     return res.status(204).send();
   } catch (err: unknown) {
     const error = err as Error;
     if (error.message === 'Message not found' || error.message === 'Pin not found') {
       return next(createError(error.message, 404));
     }
+    if (error.message === 'Forbidden') return next(createError(error.message, 403));
     return next(createError('Internal server error', 500));
   }
 });

--- a/packages/server/src/services/pinMessageService.ts
+++ b/packages/server/src/services/pinMessageService.ts
@@ -1,5 +1,16 @@
 import { query, queryOne, execute } from '../db/database';
-import type { PinnedMessage, Message } from '@chat-app/shared';
+import { isChannelMember } from './permissionService';
+import type { PinnedMessage, Message, PinCategory } from '@chat-app/shared';
+
+const DEFAULT_CATEGORY_NAMES = ['決定事項', 'リンク', 'FAQ'] as const;
+
+interface PinCategoryRow {
+  id: number;
+  channel_id: number;
+  name: string;
+  is_default: boolean;
+  position: number;
+}
 
 interface PinnedMessageRow {
   id: number;
@@ -7,6 +18,10 @@ interface PinnedMessageRow {
   channel_id: number;
   pinned_by: number;
   pinned_at: string;
+  category_id: number | null;
+  category_name: string | null;
+  category_is_default: boolean | null;
+  category_position: number | null;
   msg_id: number | null;
   msg_channel_id: number | null;
   msg_user_id: number | null;
@@ -21,18 +36,40 @@ interface PinnedMessageRow {
   pinned_by_avatar_url: string | null;
 }
 
-function toIsoString(val: unknown): string {
-  if (val instanceof Date) return val.toISOString();
-  return String(val);
+function toIsoString(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  return String(value);
+}
+
+function rowToPinCategory(row: PinCategoryRow): PinCategory {
+  return {
+    id: row.id,
+    channelId: row.channel_id,
+    name: row.name,
+    isDefault: row.is_default,
+    position: row.position,
+  };
 }
 
 function rowToPinnedMessage(row: PinnedMessageRow): PinnedMessage {
-  const pm: PinnedMessage = {
+  const category =
+    row.category_id === null
+      ? null
+      : {
+          id: row.category_id,
+          channelId: row.channel_id,
+          name: row.category_name ?? '',
+          isDefault: row.category_is_default === true,
+          position: row.category_position ?? 0,
+        };
+  const pinned: PinnedMessage = {
     id: row.id,
     messageId: row.message_id,
     channelId: row.channel_id,
     pinnedBy: row.pinned_by,
     pinnedAt: toIsoString(row.pinned_at),
+    categoryId: row.category_id,
+    category,
   };
 
   if (row.msg_id !== null && row.msg_content !== null) {
@@ -55,11 +92,11 @@ function rowToPinnedMessage(row: PinnedMessageRow): PinnedMessage {
       quotedMessageId: null,
       quotedMessage: null,
     };
-    pm.message = message;
+    pinned.message = message;
   }
 
   if (row.pinned_by_username !== null) {
-    pm.pinnedByUser = {
+    pinned.pinnedByUser = {
       id: row.pinned_by,
       username: row.pinned_by_username,
       email: '',
@@ -72,92 +109,162 @@ function rowToPinnedMessage(row: PinnedMessageRow): PinnedMessage {
       onboardingCompletedAt: null,
     };
   }
+  return pinned;
+}
 
-  return pm;
+const PIN_SELECT = `SELECT
+  pm.id, pm.message_id, pm.channel_id, pm.pinned_by, pm.pinned_at, pm.category_id,
+  pc.name AS category_name, pc.is_default AS category_is_default,
+  pc.position AS category_position,
+  m.id AS msg_id, m.channel_id AS msg_channel_id, m.user_id AS msg_user_id,
+  u.username AS msg_username, u.avatar_url AS msg_avatar_url,
+  m.content AS msg_content, m.is_edited AS msg_is_edited, m.is_deleted AS msg_is_deleted,
+  m.created_at AS msg_created_at, m.updated_at AS msg_updated_at,
+  pu.username AS pinned_by_username, pu.avatar_url AS pinned_by_avatar_url
+FROM pinned_messages pm
+LEFT JOIN pin_categories pc ON pc.id = pm.category_id
+LEFT JOIN messages m ON m.id = pm.message_id AND m.is_deleted = false
+LEFT JOIN users u ON u.id = m.user_id
+LEFT JOIN users pu ON pu.id = pm.pinned_by`;
+
+async function assertChannelAccess(channelId: number, userId: number): Promise<void> {
+  const channel = await queryOne<{ is_private: boolean }>(
+    'SELECT is_private FROM channels WHERE id = $1',
+    [channelId],
+  );
+  if (!channel) throw new Error('Channel not found');
+  if (channel.is_private && !(await isChannelMember(userId, channelId))) {
+    throw new Error('Forbidden');
+  }
+}
+
+async function validateCategory(channelId: number, categoryId: number): Promise<void> {
+  const category = await queryOne<{ channel_id: number }>(
+    'SELECT channel_id FROM pin_categories WHERE id = $1',
+    [categoryId],
+  );
+  if (!category) throw new Error('Pin category not found');
+  if (category.channel_id !== channelId) throw new Error('Pin category does not belong to channel');
+}
+
+async function getPinnedMessageById(id: number): Promise<PinnedMessage> {
+  const row = await queryOne<PinnedMessageRow>(`${PIN_SELECT} WHERE pm.id = $1`, [id]);
+  if (!row) throw new Error('Pin not found');
+  return rowToPinnedMessage(row);
+}
+
+export async function getPinCategories(channelId: number, userId: number): Promise<PinCategory[]> {
+  await assertChannelAccess(channelId, userId);
+  for (let position = 0; position < DEFAULT_CATEGORY_NAMES.length; position += 1) {
+    await execute(
+      `INSERT INTO pin_categories (channel_id, name, is_default, position)
+       VALUES ($1, $2, true, $3) ON CONFLICT (channel_id, name) DO NOTHING`,
+      [channelId, DEFAULT_CATEGORY_NAMES[position], position],
+    );
+  }
+  const rows = await query<PinCategoryRow>(
+    'SELECT id, channel_id, name, is_default, position FROM pin_categories WHERE channel_id = $1 ORDER BY position, id',
+    [channelId],
+  );
+  return rows.map(rowToPinCategory);
+}
+
+export async function createPinCategory(
+  channelId: number,
+  name: string,
+  userId: number,
+): Promise<PinCategory> {
+  const normalized = name.trim();
+  if (normalized.length === 0 || normalized.length > 50) throw new Error('Invalid category name');
+  await getPinCategories(channelId, userId);
+  try {
+    const row = await queryOne<PinCategoryRow>(
+      `INSERT INTO pin_categories (channel_id, name, position)
+       VALUES ($1, $2, COALESCE((SELECT MAX(position) + 1 FROM pin_categories WHERE channel_id = $1), 0))
+       RETURNING id, channel_id, name, is_default, position`,
+      [channelId, normalized],
+    );
+    return rowToPinCategory(row!);
+  } catch (error) {
+    if ((error as { code?: string }).code === '23505')
+      throw new Error('Pin category already exists');
+    throw error;
+  }
 }
 
 export async function pinMessage(
   messageId: number,
   channelId: number,
   pinnedBy: number,
+  categoryId?: number | null,
 ): Promise<PinnedMessage> {
-  const msg = await queryOne<{ id: number; is_deleted: boolean }>(
-    'SELECT id, is_deleted FROM messages WHERE id = $1',
+  await assertChannelAccess(channelId, pinnedBy);
+  const message = await queryOne<{ id: number; channel_id: number; is_deleted: boolean }>(
+    'SELECT id, channel_id, is_deleted FROM messages WHERE id = $1',
     [messageId],
   );
-  if (!msg) {
-    throw new Error('Message not found');
-  }
-  if (msg.is_deleted) {
-    throw new Error('Cannot pin a deleted message');
-  }
+  if (!message) throw new Error('Message not found');
+  if (message.channel_id !== channelId) throw new Error('Message does not belong to channel');
+  if (message.is_deleted) throw new Error('Cannot pin a deleted message');
+  if (categoryId !== undefined && categoryId !== null)
+    await validateCategory(channelId, categoryId);
 
   try {
     const result = await queryOne<{ id: number }>(
-      'INSERT INTO pinned_messages (message_id, channel_id, pinned_by) VALUES ($1, $2, $3) RETURNING id',
-      [messageId, channelId, pinnedBy],
+      `INSERT INTO pinned_messages (message_id, channel_id, pinned_by, category_id)
+       VALUES ($1, $2, $3, $4) RETURNING id`,
+      [messageId, channelId, pinnedBy, categoryId ?? null],
     );
-
-    const row = await queryOne<PinnedMessageRow>(
-      `SELECT
-        pm.id, pm.message_id, pm.channel_id, pm.pinned_by, pm.pinned_at,
-        m.id AS msg_id, m.channel_id AS msg_channel_id, m.user_id AS msg_user_id,
-        u.username AS msg_username, u.avatar_url AS msg_avatar_url,
-        m.content AS msg_content, m.is_edited AS msg_is_edited, m.is_deleted AS msg_is_deleted,
-        m.created_at AS msg_created_at, m.updated_at AS msg_updated_at,
-        pu.username AS pinned_by_username, pu.avatar_url AS pinned_by_avatar_url
-      FROM pinned_messages pm
-      LEFT JOIN messages m ON m.id = pm.message_id
-      LEFT JOIN users u ON u.id = m.user_id
-      LEFT JOIN users pu ON pu.id = pm.pinned_by
-      WHERE pm.id = $1`,
-      [result!.id],
-    );
-
-    return rowToPinnedMessage(row!);
-  } catch (err: unknown) {
-    const error = err as { code?: string };
-    if (error.code === '23505') {
+    return getPinnedMessageById(result!.id);
+  } catch (error) {
+    if ((error as { code?: string }).code === '23505') {
       throw new Error('Message is already pinned in this channel');
     }
-    throw err;
+    throw error;
   }
 }
 
-export async function unpinMessage(messageId: number, channelId: number): Promise<void> {
-  const msg = await queryOne('SELECT id FROM messages WHERE id = $1', [messageId]);
-  if (!msg) {
+export async function updatePinCategory(
+  messageId: number,
+  channelId: number,
+  categoryId: number | null,
+  userId: number,
+): Promise<PinnedMessage> {
+  await assertChannelAccess(channelId, userId);
+  if (categoryId !== null) await validateCategory(channelId, categoryId);
+  const result = await queryOne<{ id: number }>(
+    `UPDATE pinned_messages SET category_id = $1
+     WHERE message_id = $2 AND channel_id = $3 RETURNING id`,
+    [categoryId, messageId, channelId],
+  );
+  if (!result) throw new Error('Pin not found');
+  return getPinnedMessageById(result.id);
+}
+
+export async function unpinMessage(
+  messageId: number,
+  channelId: number,
+  userId: number,
+): Promise<void> {
+  await assertChannelAccess(channelId, userId);
+  if (!(await queryOne('SELECT id FROM messages WHERE id = $1', [messageId]))) {
     throw new Error('Message not found');
   }
-
   const result = await execute(
     'DELETE FROM pinned_messages WHERE message_id = $1 AND channel_id = $2',
     [messageId, channelId],
   );
-
-  if (result.rowCount === 0) {
-    throw new Error('Pin not found');
-  }
+  if (result.rowCount === 0) throw new Error('Pin not found');
 }
 
-export async function getPinnedMessages(channelId: number): Promise<PinnedMessage[]> {
+export async function getPinnedMessages(
+  channelId: number,
+  userId: number,
+): Promise<PinnedMessage[]> {
+  await assertChannelAccess(channelId, userId);
   const rows = await query<PinnedMessageRow>(
-    `SELECT
-      pm.id, pm.message_id, pm.channel_id, pm.pinned_by, pm.pinned_at,
-      m.id AS msg_id, m.channel_id AS msg_channel_id, m.user_id AS msg_user_id,
-      u.username AS msg_username, u.avatar_url AS msg_avatar_url,
-      m.content AS msg_content, m.is_edited AS msg_is_edited, m.is_deleted AS msg_is_deleted,
-      m.created_at AS msg_created_at, m.updated_at AS msg_updated_at,
-      pu.username AS pinned_by_username, pu.avatar_url AS pinned_by_avatar_url
-    FROM pinned_messages pm
-    LEFT JOIN messages m ON m.id = pm.message_id AND m.is_deleted = false
-    LEFT JOIN users u ON u.id = m.user_id
-    LEFT JOIN users pu ON pu.id = pm.pinned_by
-    WHERE pm.channel_id = $1
-      AND m.id IS NOT NULL
-    ORDER BY pm.pinned_at DESC`,
+    `${PIN_SELECT} WHERE pm.channel_id = $1 AND m.id IS NOT NULL ORDER BY pm.pinned_at DESC`,
     [channelId],
   );
-
   return rows.map(rowToPinnedMessage);
 }

--- a/packages/server/src/socket/messageHandler.ts
+++ b/packages/server/src/socket/messageHandler.ts
@@ -277,12 +277,18 @@ export function registerMessageHandlers(io: ChatServer, socket: ChatSocket): voi
   socket.on('pin_message', (data) => {
     void (async () => {
       try {
-        const pinned = await pinMessageService.pinMessage(data.messageId, data.channelId, userId);
+        const pinned = await pinMessageService.pinMessage(
+          data.messageId,
+          data.channelId,
+          userId,
+          data.categoryId,
+        );
         io.to(`channel:${data.channelId}`).emit('message_pinned', {
           messageId: data.messageId,
           channelId: data.channelId,
           pinnedBy: userId,
           pinnedAt: pinned.pinnedAt,
+          categoryId: pinned.categoryId,
         });
       } catch {
         socket.emit('error', 'Failed to pin message');
@@ -293,7 +299,7 @@ export function registerMessageHandlers(io: ChatServer, socket: ChatSocket): voi
   socket.on('unpin_message', (data) => {
     void (async () => {
       try {
-        await pinMessageService.unpinMessage(data.messageId, data.channelId);
+        await pinMessageService.unpinMessage(data.messageId, data.channelId, userId);
         io.to(`channel:${data.channelId}`).emit('message_unpinned', {
           messageId: data.messageId,
           channelId: data.channelId,

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -103,6 +103,16 @@ export interface PinnedMessage {
   channelId: number;
   pinnedBy: number;
   pinnedAt: string;
+  categoryId: number | null;
+  category: PinCategory | null;
   message?: Message;
   pinnedByUser?: import('./user').User;
+}
+
+export interface PinCategory {
+  id: number;
+  channelId: number;
+  name: string;
+  isDefault: boolean;
+  position: number;
 }

--- a/packages/shared/src/types/socket.ts
+++ b/packages/shared/src/types/socket.ts
@@ -23,6 +23,7 @@ export interface ServerToClientEvents {
     channelId: number;
     pinnedBy: number;
     pinnedAt: string;
+    categoryId: number | null;
   }) => void;
   message_unpinned: (data: { messageId: number; channelId: number }) => void;
   pinned_messages_list: (data: {
@@ -96,7 +97,7 @@ export interface ClientToServerEvents {
     mentionedUserIds?: number[];
     attachmentIds?: number[];
   }) => void;
-  pin_message: (data: { messageId: number; channelId: number }) => void;
+  pin_message: (data: { messageId: number; channelId: number; categoryId?: number | null }) => void;
   unpin_message: (data: { messageId: number; channelId: number }) => void;
   send_dm: (data: { conversationId: number; content: string }) => void;
   dm_typing_start: (conversationId: number) => void;


### PR DESCRIPTION
## 概要

ピン留めメッセージをデフォルト／任意カテゴリで分類し、カテゴリタブで絞り込めるようにします。

## 変更内容

- ピンカテゴリテーブルとピンのカテゴリ参照をスキーマへ追加
- 「決定事項」「リンク」「FAQ」のデフォルトカテゴリをチャンネル単位で自動作成
- ピン留め時のカテゴリ指定、後からのカテゴリ変更、任意カテゴリ追加 API を実装
- 未分類を含むカテゴリタブと絞り込み UI を実装
- REST / Socket の認証済みユーザーによるチャンネルアクセス制御を追加
- チャンネル切替時の非同期応答競合を防止

## 仕様・受け入れ条件
- 関連 Issue: #395
- 満たした受け入れ条件:
  - ピン留め時／後からカテゴリを設定できる
  - デフォルトカテゴリと任意カテゴリ追加に対応
  - カテゴリタブで絞り込み表示できる
  - 未設定ピンを「未分類」で表示する
  - 既存ピンは `categoryId: null` として互換性を維持する

## AI テスト設計レビュー
- Verdict: APPROVED
- レビュアー: 実装担当とは別コンテキストの Codex
- レビュー対象: Issue #395、関連仕様、既存実装・テスト、`it.todo` テストスケルトン
- 主な指摘と対応: カテゴリ整合性、既存ピン互換、API エラー、Socket 契約、チャンネル切替競合、プライベートチャンネル認可をテストへ反映
- 採用したテスト観点: サービス／REST／Socket、カテゴリ絞り込み、未分類、後付け変更、任意追加、失敗時状態維持、非同期競合
- Prune したテストと理由: ボタンの活性・スタイル・aria 属性のみなど、画面確認で十分な微細 UI 状態

## 高リスク変更
- [ ] 該当なし
- [x] DB マイグレーション
- [x] 認証・認可
- [ ] 削除・外部書き込み
- [ ] 機密情報

## AI 実装レビュー（高リスク変更の場合）
- Verdict: APPROVED
- 主な指摘と対応: 全操作のプライベートチャンネル認可、解除コールバック配線、通常読込およびカテゴリ追加・変更中のチャンネル切替競合を修正し、同一レビュアーの再レビューで承認

## 影響範囲

- DB スキーマ（`pin_categories`、`pinned_messages.category_id`）
- サーバーのピンサービス、REST、Socket
- 共有型
- メッセージ操作 UI、ピン一覧 UI、ChatPage

## 検証結果
- [x] `npm run build` が成功した
- [x] `npm run test` が成功した
- [x] `it.todo` / 空ボディの `it` が残っていない
- 実行結果: server 86 suites / 1,958 tests、client 147 files / 2,612 tests が成功。クライアントは実行環境の CPU 競合回避のため `--maxWorkers=4` を指定

## Playwright 画面動作確認
- 結果: 成功
- N/A の場合の理由: N/A
- 確認したユーザーフロー: メッセージ投稿 → デフォルトカテゴリ指定でピン留め → ピン一覧表示 → 任意カテゴリ追加 → 後からカテゴリ変更 → タブ絞り込み → ピン解除
- コンソール・ネットワーク確認: コンソールエラー 0 件。関連 API は 200 / 201 で成功（ログイン前の初期 401 を除く）
- スクリーンショット等: ローカル `output/playwright/issue-395/` に保存し、PR には含めない

## 既存テストの変更
- 変更ファイル: `pin-message.test.ts`、`socket-handler.test.ts`、`MessageActions.test.tsx`、`ChatPage.test.tsx`、`ChatPagePermalink.test.tsx`
- 変更理由: 仕様変更（カテゴリ契約）、バグ修正（認可・解除配線・非同期競合）、テストダブル契約更新
- アサーションを弱めた、または削除した場合の根拠: なし

## 未解決事項・人間に求める仕様判断
- なし

## 関連Issue
Fixes #395

## チェックリスト
- [x] AI テスト設計レビューが `APPROVED` になっている
- [x] Blocking 指摘への対応を再レビュー済み
- [x] 高リスク変更の場合、AI 実装レビューが `APPROVED` になっている
- [x] Playwright 確認を実施した、または `N/A` の根拠を記載した
- [x] 不要なデバッグコードやコメントが残っていない
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）
