### PR TITLE
feat: タスクボードのガント表示を日付軸付きUIに改善する

### DIFF
--- a/db/schema.hcl
+++ b/db/schema.hcl
@@ -2096,6 +2096,11 @@ table "tasks" {
     type    = timestamptz
     comment = "期限日時"
   }
+  column "start_at" {
+    null    = true
+    type    = timestamptz
+    comment = "ガント表示用の開始日時"
+  }
   column "source_message_id" {
     null    = true
     type    = integer

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -177,9 +177,11 @@ vi.mock('../components/Task/TaskGanttChart', () => ({
   default: ({
     tasks,
     onDueAtChange,
+    onStartAtChange,
   }: {
     tasks: Task[];
     onDueAtChange?: (task: Task, dueAt: string | null) => void;
+    onStartAtChange?: (task: Task, startAt: string | null) => void;
   }) => {
     const scheduledTasks = tasks.filter((task) => task.dueAt != null);
     mockGanttTasks(scheduledTasks);
@@ -190,6 +192,9 @@ vi.mock('../components/Task/TaskGanttChart', () => ({
           <>
             <button onClick={() => onDueAtChange?.(target, '2026-06-20T00:00:00.000Z')}>
               change-gantt-due
+            </button>
+            <button onClick={() => onStartAtChange?.(target, '2026-06-05T00:00:00.000Z')}>
+              change-gantt-start
             </button>
             <button onClick={() => onDueAtChange?.(target, null)}>clear-gantt-due</button>
           </>
@@ -483,6 +488,76 @@ describe('TaskBoardPage', () => {
       );
       expect(mockGanttTasks).toHaveBeenLastCalledWith([
         expect.objectContaining({ id: 10, dueAt: '2026-06-10T00:00:00Z' }),
+      ]);
+    });
+
+    it('簡易ガントから開始日変更するとapi.tasks.updateでstartAtだけを更新し、API解決前にガントへ楽観反映する', async () => {
+      let resolveUpdate!: (value: unknown) => void;
+      mockTasksUpdate.mockReturnValue(
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        }),
+      );
+      mockTasksList.mockResolvedValue({
+        tasks: [
+          makeTask({
+            id: 10,
+            title: '対象',
+            createdAt: '2026-06-01T00:00:00Z',
+            startAt: '2026-06-03T00:00:00Z',
+            dueAt: '2026-06-10T00:00:00Z',
+          }),
+        ],
+      });
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () =>
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        ),
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'ガント' }));
+      await userEvent.click(screen.getByRole('button', { name: 'change-gantt-start' }));
+
+      expect(mockTasksUpdate).toHaveBeenCalledWith(10, { startAt: '2026-06-05T00:00:00.000Z' });
+      await waitFor(() => {
+        expect(mockGanttTasks).toHaveBeenLastCalledWith([
+          expect.objectContaining({ id: 10, startAt: '2026-06-05T00:00:00.000Z' }),
+        ]);
+      });
+      await act(async () => resolveUpdate({ task: makeTask({ id: 10 }) }));
+    });
+
+    it('簡易ガントの開始日変更が失敗した場合は更新前startAtへロールバックしてエラー通知する', async () => {
+      mockTasksUpdate.mockRejectedValue(new Error('更新失敗'));
+      mockTasksList.mockResolvedValue({
+        tasks: [
+          makeTask({
+            id: 10,
+            title: '対象',
+            createdAt: '2026-06-01T00:00:00Z',
+            startAt: '2026-06-03T00:00:00Z',
+            dueAt: '2026-06-10T00:00:00Z',
+          }),
+        ],
+      });
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () =>
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        ),
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'ガント' }));
+      await userEvent.click(screen.getByRole('button', { name: 'change-gantt-start' }));
+
+      await waitFor(() =>
+        expect(mockShowError).toHaveBeenCalledWith('タスクの開始日を更新できませんでした'),
+      );
+      expect(mockGanttTasks).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 10, startAt: '2026-06-03T00:00:00Z' }),
       ]);
     });
   });

--- a/packages/client/src/__tests__/TaskBoardPage.test.tsx
+++ b/packages/client/src/__tests__/TaskBoardPage.test.tsx
@@ -58,6 +58,7 @@ const mockAuthUsers = vi.fn();
 const mockChannelsList = vi.fn();
 const mockEditDialogTasks = vi.fn();
 const mockGanttTasks = vi.fn();
+const mockShowError = vi.fn();
 
 vi.mock('../api/client', () => ({
   api: {
@@ -122,6 +123,14 @@ vi.mock('../contexts/SocketContext', () => ({
   useSocket: () => null,
 }));
 
+vi.mock('../contexts/SnackbarContext', () => ({
+  useSnackbar: () => ({
+    showSuccess: vi.fn(),
+    showError: mockShowError,
+    showInfo: vi.fn(),
+  }),
+}));
+
 // Step 8b: Sidebar 中身 (ChannelList + SidebarDmList) を stub 化して onSelect 動線とレンダリングを検証可能にする
 vi.mock('../components/Channel/ChannelList', () => ({
   default: ({ onSelect }: { onSelect?: (id: number, name: string) => void }) => (
@@ -165,10 +174,29 @@ vi.mock('../components/Task/EditTaskDialog', () => ({
 }));
 
 vi.mock('../components/Task/TaskGanttChart', () => ({
-  default: ({ tasks }: { tasks: Task[] }) => (
-    mockGanttTasks(tasks),
-    (<div data-testid="gantt-chart-stub" />)
-  ),
+  default: ({
+    tasks,
+    onDueAtChange,
+  }: {
+    tasks: Task[];
+    onDueAtChange?: (task: Task, dueAt: string | null) => void;
+  }) => {
+    const scheduledTasks = tasks.filter((task) => task.dueAt != null);
+    mockGanttTasks(scheduledTasks);
+    const target = scheduledTasks[0];
+    return (
+      <div data-testid="gantt-chart-stub">
+        {target && (
+          <>
+            <button onClick={() => onDueAtChange?.(target, '2026-06-20T00:00:00.000Z')}>
+              change-gantt-due
+            </button>
+            <button onClick={() => onDueAtChange?.(target, null)}>clear-gantt-due</button>
+          </>
+        )}
+      </div>
+    );
+  },
 }));
 
 function makeTasks(): Task[] {
@@ -253,6 +281,7 @@ beforeEach(() => {
   mockTasksUpdateOrder.mockResolvedValue({ success: true });
   mockAuthUsers.mockResolvedValue({ users: [] });
   mockChannelsList.mockResolvedValue({ channels: [] });
+  mockShowError.mockReset();
 });
 
 describe('TaskBoardPage', () => {
@@ -335,7 +364,10 @@ describe('TaskBoardPage', () => {
         channels: [{ id: 7, name: '対象', description: null }],
       });
       mockTasksList.mockResolvedValue({
-        tasks: [makeTask({ id: 10, sourceChannelId: 7 }), makeTask({ id: 11, sourceChannelId: 8 })],
+        tasks: [
+          makeTask({ id: 10, sourceChannelId: 7, dueAt: '2026-06-10T00:00:00Z' }),
+          makeTask({ id: 11, sourceChannelId: 8, dueAt: '2026-06-11T00:00:00Z' }),
+        ],
       });
       const TaskBoardPage = await importTaskBoardPage();
       await act(async () =>
@@ -349,6 +381,109 @@ describe('TaskBoardPage', () => {
       await userEvent.click(screen.getByRole('option', { name: '#対象' }));
       await userEvent.click(screen.getByRole('button', { name: 'ガント' }));
       expect(mockGanttTasks).toHaveBeenLastCalledWith([expect.objectContaining({ id: 10 })]);
+    });
+
+    it('簡易ガントから期限変更するとapi.tasks.updateでdueAtだけを更新し、API解決前にガントへ楽観反映する', async () => {
+      let resolveUpdate!: (value: unknown) => void;
+      mockTasksUpdate.mockReturnValue(
+        new Promise((resolve) => {
+          resolveUpdate = resolve;
+        }),
+      );
+      mockTasksList.mockResolvedValue({
+        tasks: [
+          makeTask({
+            id: 10,
+            title: '対象',
+            createdAt: '2026-06-01T00:00:00Z',
+            dueAt: '2026-06-10T00:00:00Z',
+          }),
+        ],
+      });
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () =>
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        ),
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'ガント' }));
+      await userEvent.click(screen.getByRole('button', { name: 'change-gantt-due' }));
+
+      expect(mockTasksUpdate).toHaveBeenCalledWith(10, { dueAt: '2026-06-20T00:00:00.000Z' });
+      await waitFor(() => {
+        expect(mockGanttTasks).toHaveBeenLastCalledWith([
+          expect.objectContaining({ id: 10, dueAt: '2026-06-20T00:00:00.000Z' }),
+        ]);
+      });
+      await act(async () => resolveUpdate({ task: makeTask({ id: 10 }) }));
+    });
+
+    it('簡易ガントから期限なしにするとapi.tasks.updateでdueAt:nullだけを送り、対象タスクをガント対象外にする', async () => {
+      mockTasksUpdate.mockResolvedValue({ task: makeTask({ id: 10, dueAt: null }) });
+      mockTasksList.mockResolvedValue({
+        tasks: [
+          makeTask({
+            id: 10,
+            title: '対象',
+            createdAt: '2026-06-01T00:00:00Z',
+            dueAt: '2026-06-10T00:00:00Z',
+          }),
+          makeTask({
+            id: 11,
+            title: '残る',
+            createdAt: '2026-06-02T00:00:00Z',
+            dueAt: '2026-06-11T00:00:00Z',
+          }),
+        ],
+      });
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () =>
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        ),
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'ガント' }));
+      await userEvent.click(screen.getByRole('button', { name: 'clear-gantt-due' }));
+
+      expect(mockTasksUpdate).toHaveBeenCalledWith(10, { dueAt: null });
+      await waitFor(() => {
+        expect(mockGanttTasks).toHaveBeenLastCalledWith([expect.objectContaining({ id: 11 })]);
+      });
+    });
+
+    it('簡易ガントの期限変更が失敗した場合は更新前dueAtへロールバックしてエラー通知する', async () => {
+      mockTasksUpdate.mockRejectedValue(new Error('更新失敗'));
+      mockTasksList.mockResolvedValue({
+        tasks: [
+          makeTask({
+            id: 10,
+            title: '対象',
+            createdAt: '2026-06-01T00:00:00Z',
+            dueAt: '2026-06-10T00:00:00Z',
+          }),
+        ],
+      });
+      const TaskBoardPage = await importTaskBoardPage();
+      await act(async () =>
+        render(
+          <MemoryRouter>
+            <TaskBoardPage />
+          </MemoryRouter>,
+        ),
+      );
+      await userEvent.click(screen.getByRole('button', { name: 'ガント' }));
+      await userEvent.click(screen.getByRole('button', { name: 'change-gantt-due' }));
+
+      await waitFor(() =>
+        expect(mockShowError).toHaveBeenCalledWith('タスクの期限を更新できませんでした'),
+      );
+      expect(mockGanttTasks).toHaveBeenLastCalledWith([
+        expect.objectContaining({ id: 10, dueAt: '2026-06-10T00:00:00Z' }),
+      ]);
     });
   });
 

--- a/packages/client/src/__tests__/TaskGanttChart.test.tsx
+++ b/packages/client/src/__tests__/TaskGanttChart.test.tsx
@@ -3,17 +3,26 @@
  * 戦略:
  *   - 期限があるタスクの期間バーと依存関係ラベルを検証する
  *   - 期限なし・空状態など、画面だけでは見落としやすい境界条件を検証する
+ *   - 期限クイック編集は callback payload とキャンセル挙動を検証し、API 更新は親ページで検証する
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import TaskGanttChart from '../components/Task/TaskGanttChart';
 import { makeTask } from './__fixtures__/tasks';
 
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+function expectIsoDate(value: string | null | undefined, expectedDate: string) {
+  expect(value).toBeTruthy();
+  expect(new Date(value!).toISOString().slice(0, 10)).toBe(expectedDate);
+}
+
 describe('TaskGanttChart', () => {
   afterEach(() => {
     vi.useRealTimers();
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 
   describe('日付軸付きガントUI', () => {
@@ -108,6 +117,139 @@ describe('TaskGanttChart', () => {
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('2026/6');
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('2026/7');
       expect(screen.getByTestId('gantt-bar-1').dataset.widthPercent).not.toBe(dayWidth);
+    });
+  });
+
+  describe('期限クイック編集', () => {
+    it('行クリックで期限編集ポップオーバーを開き、Enterで変更した期限を保存する', async () => {
+      const onDueAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-05T00:00:00Z' }),
+          ]}
+          onDueAtChange={onDueAtChange}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('gantt-row-1'));
+      const input = screen.getByLabelText('期限を編集', { selector: 'input' });
+      await userEvent.clear(input);
+      await userEvent.type(input, '2026-06-08T09:30');
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      await waitFor(() => expect(onDueAtChange).toHaveBeenCalledTimes(1));
+      expect(onDueAtChange).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1 }),
+        expect.any(String),
+      );
+      expectIsoDate(onDueAtChange.mock.calls[0][1], '2026-06-08');
+    });
+
+    it('編集アイコンで期限編集ポップオーバーを開き、Blurで変更した期限を保存する', async () => {
+      const onDueAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-05T00:00:00Z' }),
+          ]}
+          onDueAtChange={onDueAtChange}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: '期限を編集' }));
+      const input = screen.getByLabelText('期限を編集', { selector: 'input' });
+      await userEvent.clear(input);
+      await userEvent.type(input, '2026-06-09T10:15');
+      fireEvent.blur(input);
+
+      await waitFor(() => expect(onDueAtChange).toHaveBeenCalledTimes(1));
+      expectIsoDate(onDueAtChange.mock.calls[0][1], '2026-06-09');
+    });
+
+    it('期限編集ポップオーバーでEscapeを押すと変更を保存せず閉じる', async () => {
+      const onDueAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-05T00:00:00Z' }),
+          ]}
+          onDueAtChange={onDueAtChange}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('gantt-row-1'));
+      const input = screen.getByLabelText('期限を編集', { selector: 'input' });
+      await userEvent.clear(input);
+      await userEvent.type(input, '2026-06-09T10:15');
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      expect(onDueAtChange).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(
+          screen.queryByLabelText('期限を編集', { selector: 'input' }),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it('期限なしにする操作でdueAtにnullを渡す', async () => {
+      const onDueAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-05T00:00:00Z' }),
+          ]}
+          onDueAtChange={onDueAtChange}
+        />,
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: '期限を編集' }));
+      await userEvent.click(screen.getByRole('button', { name: '期限なしにする' }));
+
+      expect(onDueAtChange).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), null);
+    });
+
+    it('バー端の期限ハンドルを作成日前へドラッグしても作成日に丸めず、日単位にスナップした期限を保存する', async () => {
+      const onDueAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({
+              id: 1,
+              createdAt: '2026-06-10T00:00:00Z',
+              dueAt: '2026-06-20T15:45:00Z',
+            }),
+          ]}
+          onDueAtChange={onDueAtChange}
+        />,
+      );
+      Element.prototype.getBoundingClientRect = function () {
+        if ((this as HTMLElement).dataset.testid === 'gantt-timeline-1') {
+          return {
+            x: 100,
+            y: 0,
+            left: 100,
+            top: 0,
+            right: 1100,
+            bottom: 60,
+            width: 1000,
+            height: 60,
+            toJSON: () => ({}),
+          };
+        }
+        return originalGetBoundingClientRect.call(this);
+      };
+
+      fireEvent.pointerDown(screen.getByRole('button', { name: '期限をドラッグして変更' }), {
+        clientX: 1100,
+        pointerId: 1,
+      });
+      fireEvent.pointerMove(window, { clientX: -400, pointerId: 1 });
+      fireEvent.pointerUp(window, { clientX: -400, pointerId: 1 });
+
+      await waitFor(() => expect(onDueAtChange).toHaveBeenCalledTimes(1));
+      const savedDate = new Date(onDueAtChange.mock.calls[0][1]!).toISOString().slice(0, 10);
+      expect(savedDate < '2026-06-10').toBe(true);
     });
   });
 

--- a/packages/client/src/__tests__/TaskGanttChart.test.tsx
+++ b/packages/client/src/__tests__/TaskGanttChart.test.tsx
@@ -6,11 +6,111 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import TaskGanttChart from '../components/Task/TaskGanttChart';
 import { makeTask } from './__fixtures__/tasks';
 
 describe('TaskGanttChart', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('日付軸付きガントUI', () => {
+    it('ガント表示に日付ヘッダーと対応する縦グリッドを表示する', () => {
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-03T00:00:00Z' }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('6/1');
+      expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('6/2');
+      expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('6/3');
+      expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '3');
+      expect(screen.getAllByTestId(/^gantt-grid-line-/)).toHaveLength(3);
+    });
+
+    it('タスク名列と時間軸列を分け、各バーを日付ヘッダーと同じ横軸に配置する', () => {
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-02T00:00:00Z' }),
+            makeTask({ id: 2, createdAt: '2026-06-03T00:00:00Z', dueAt: '2026-06-04T00:00:00Z' }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByTestId('gantt-task-column-header')).toHaveTextContent('タスク');
+      expect(screen.getByTestId('gantt-timeline-column-header')).toHaveTextContent('期間');
+      expect(screen.getByTestId('gantt-row-1')).toHaveAttribute('data-layout', 'task-and-timeline');
+      expect(screen.getByTestId('gantt-bar-1').dataset.timelineStart).toBe(
+        screen.getByTestId('gantt-date-axis').dataset.timelineStart,
+      );
+      expect(Number(screen.getByTestId('gantt-bar-2').dataset.startPercent)).toBeGreaterThan(
+        Number(screen.getByTestId('gantt-bar-1').dataset.startPercent),
+      );
+    });
+
+    it('各タスクの期間ラベルをバー上または近傍に表示する', () => {
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({
+              id: 1,
+              createdAt: '2026-06-01T00:00:00Z',
+              dueAt: '2026-06-05T00:00:00Z',
+            }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByTestId('gantt-period-label-1')).toHaveTextContent('2026/6/1 — 2026/6/5');
+    });
+
+    it('今日が表示範囲内にある場合だけ今日線を表示する', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-03T12:00:00+09:00'));
+      const tasks = [
+        makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-05T00:00:00Z' }),
+      ];
+
+      const { rerender } = render(<TaskGanttChart tasks={tasks} />);
+      expect(screen.getByTestId('gantt-today-line')).toHaveAttribute('aria-label', '今日');
+
+      vi.setSystemTime(new Date('2026-07-01T12:00:00+09:00'));
+      rerender(<TaskGanttChart tasks={tasks} />);
+      expect(screen.queryByTestId('gantt-today-line')).not.toBeInTheDocument();
+    });
+
+    it('日・週・月の表示粒度を切り替えられる', async () => {
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-07-10T00:00:00Z' }),
+          ]}
+        />,
+      );
+
+      expect(screen.getByTestId('task-gantt-chart')).toHaveAttribute('data-scale', 'day');
+      const dayGridCount = Number(screen.getByTestId('gantt-grid').dataset.gridCount);
+      const dayWidth = screen.getByTestId('gantt-bar-1').dataset.widthPercent;
+
+      await userEvent.click(screen.getByRole('button', { name: '週' }));
+      expect(screen.getByTestId('task-gantt-chart')).toHaveAttribute('data-scale', 'week');
+      expect(Number(screen.getByTestId('gantt-grid').dataset.gridCount)).toBeLessThan(dayGridCount);
+      expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('週');
+
+      await userEvent.click(screen.getByRole('button', { name: '月' }));
+      expect(screen.getByTestId('task-gantt-chart')).toHaveAttribute('data-scale', 'month');
+      expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('2026/6');
+      expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('2026/7');
+      expect(screen.getByTestId('gantt-bar-1').dataset.widthPercent).not.toBe(dayWidth);
+    });
+  });
+
   it('作成日から期限日までを期間バーとして描画する', () => {
     render(
       <TaskGanttChart

--- a/packages/client/src/__tests__/TaskGanttChart.test.tsx
+++ b/packages/client/src/__tests__/TaskGanttChart.test.tsx
@@ -19,6 +19,25 @@ function expectIsoDate(value: string | null | undefined, expectedDate: string) {
   expect(new Date(value!).toISOString().slice(0, 10)).toBe(expectedDate);
 }
 
+function mockTimelineRect(testId = 'gantt-timeline-1') {
+  Element.prototype.getBoundingClientRect = function () {
+    if ((this as HTMLElement).dataset.testid === testId) {
+      return {
+        x: 100,
+        y: 0,
+        left: 100,
+        top: 0,
+        right: 1100,
+        bottom: 60,
+        width: 1000,
+        height: 60,
+        toJSON: () => ({}),
+      };
+    }
+    return originalGetBoundingClientRect.call(this);
+  };
+}
+
 describe('TaskGanttChart', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -209,51 +228,121 @@ describe('TaskGanttChart', () => {
       expect(onDueAtChange).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), null);
     });
 
-    it('バー端の期限ハンドルを作成日前へドラッグしても作成日に丸めず、日単位にスナップした期限を保存する', async () => {
+    it('右端の期限ハンドルを開始日より左へドラッグしても開始位置は変えず、期限だけを開始日に丸めて保存する', async () => {
       const onDueAtChange = vi.fn();
+      const onStartAtChange = vi.fn();
       render(
         <TaskGanttChart
           tasks={[
             makeTask({
               id: 1,
-              createdAt: '2026-06-10T00:00:00Z',
-              dueAt: '2026-06-20T15:45:00Z',
+              createdAt: '2026-06-01T00:00:00Z',
+              startAt: '2026-06-10T00:00:00Z',
+              dueAt: '2026-06-20T00:00:00Z',
             }),
           ]}
           onDueAtChange={onDueAtChange}
+          onStartAtChange={onStartAtChange}
         />,
       );
-      Element.prototype.getBoundingClientRect = function () {
-        if ((this as HTMLElement).dataset.testid === 'gantt-timeline-1') {
-          return {
-            x: 100,
-            y: 0,
-            left: 100,
-            top: 0,
-            right: 1100,
-            bottom: 60,
-            width: 1000,
-            height: 60,
-            toJSON: () => ({}),
-          };
-        }
-        return originalGetBoundingClientRect.call(this);
-      };
+      mockTimelineRect();
+      const startPercentBefore = screen.getByTestId('gantt-bar-1').dataset.startPercent;
 
       fireEvent.pointerDown(screen.getByRole('button', { name: '期限をドラッグして変更' }), {
         clientX: 1100,
         pointerId: 1,
       });
       fireEvent.pointerMove(window, { clientX: -400, pointerId: 1 });
+      expect(screen.getByTestId('gantt-bar-1').dataset.startPercent).toBe(startPercentBefore);
       fireEvent.pointerUp(window, { clientX: -400, pointerId: 1 });
 
       await waitFor(() => expect(onDueAtChange).toHaveBeenCalledTimes(1));
-      const savedDate = new Date(onDueAtChange.mock.calls[0][1]!).toISOString().slice(0, 10);
-      expect(savedDate < '2026-06-10').toBe(true);
+      expectIsoDate(onDueAtChange.mock.calls[0][1], '2026-06-10');
+      expect(onStartAtChange).not.toHaveBeenCalled();
+    });
+
+    it('左端の開始日ハンドルをドラッグすると開始日だけを日単位にスナップして保存する', async () => {
+      const onDueAtChange = vi.fn();
+      const onStartAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({
+              id: 1,
+              createdAt: '2026-06-01T00:00:00Z',
+              startAt: '2026-06-10T00:00:00Z',
+              dueAt: '2026-06-20T00:00:00Z',
+            }),
+          ]}
+          onDueAtChange={onDueAtChange}
+          onStartAtChange={onStartAtChange}
+        />,
+      );
+      mockTimelineRect();
+
+      fireEvent.pointerDown(screen.getByRole('button', { name: '開始日をドラッグして変更' }), {
+        clientX: 100,
+        pointerId: 1,
+      });
+      fireEvent.pointerMove(window, { clientX: 555, pointerId: 1 });
+      fireEvent.pointerUp(window, { clientX: 555, pointerId: 1 });
+
+      await waitFor(() => expect(onStartAtChange).toHaveBeenCalledTimes(1));
+      expectIsoDate(onStartAtChange.mock.calls[0][1], '2026-06-15');
+      expect(onDueAtChange).not.toHaveBeenCalled();
+    });
+
+    it('左端の開始日ハンドルを期限日より右へドラッグすると開始日を期限日に丸めて保存する', async () => {
+      const onStartAtChange = vi.fn();
+      render(
+        <TaskGanttChart
+          tasks={[
+            makeTask({
+              id: 1,
+              createdAt: '2026-06-01T00:00:00Z',
+              startAt: '2026-06-10T00:00:00Z',
+              dueAt: '2026-06-20T00:00:00Z',
+            }),
+          ]}
+          onStartAtChange={onStartAtChange}
+        />,
+      );
+      mockTimelineRect();
+
+      fireEvent.pointerDown(screen.getByRole('button', { name: '開始日をドラッグして変更' }), {
+        clientX: 100,
+        pointerId: 1,
+      });
+      fireEvent.pointerMove(window, { clientX: 2000, pointerId: 1 });
+      fireEvent.pointerUp(window, { clientX: 2000, pointerId: 1 });
+
+      await waitFor(() => expect(onStartAtChange).toHaveBeenCalledTimes(1));
+      expectIsoDate(onStartAtChange.mock.calls[0][1], '2026-06-20');
     });
   });
 
-  it('作成日から期限日までを期間バーとして描画する', () => {
+  it('startAtがあるタスクはcreatedAtではなくstartAtから期限日までを期間バーとして描画する', () => {
+    render(
+      <TaskGanttChart
+        tasks={[
+          makeTask({ id: 1, createdAt: '2026-06-01T00:00:00Z', dueAt: '2026-06-05T00:00:00Z' }),
+          makeTask({
+            id: 2,
+            createdAt: '2026-06-01T00:00:00Z',
+            startAt: '2026-06-10T00:00:00Z',
+            dueAt: '2026-06-20T00:00:00Z',
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('gantt-period-label-2')).toHaveTextContent('2026/6/10 — 2026/6/20');
+    expect(Number(screen.getByTestId('gantt-bar-2').dataset.startPercent)).toBeGreaterThan(
+      Number(screen.getByTestId('gantt-bar-1').dataset.startPercent),
+    );
+  });
+
+  it('startAtがないタスクは作成日から期限日までを期間バーとして描画する', () => {
     render(
       <TaskGanttChart
         tasks={[

--- a/packages/client/src/__tests__/TaskGanttChart.test.tsx
+++ b/packages/client/src/__tests__/TaskGanttChart.test.tsx
@@ -16,7 +16,7 @@ const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
 
 function expectIsoDate(value: string | null | undefined, expectedDate: string) {
   expect(value).toBeTruthy();
-  expect(new Date(value!).toISOString().slice(0, 10)).toBe(expectedDate);
+  expectLocalDate(new Date(value!), expectedDate);
 }
 
 function mockTimelineRect(testId = 'gantt-timeline-1') {
@@ -38,6 +38,25 @@ function mockTimelineRect(testId = 'gantt-timeline-1') {
   };
 }
 
+function timelineRange() {
+  const axis = screen.getByTestId('gantt-date-axis');
+  return {
+    start: new Date(Number(axis.dataset.timelineStart)),
+    end: new Date(Number(axis.dataset.timelineEnd)),
+  };
+}
+
+function expectLocalDate(value: Date, expectedDate: string) {
+  const yyyy = value.getFullYear();
+  const mm = String(value.getMonth() + 1).padStart(2, '0');
+  const dd = String(value.getDate()).padStart(2, '0');
+  expect(`${yyyy}-${mm}-${dd}`).toBe(expectedDate);
+}
+
+function expectTimelineDate(value: Date, expectedDate: string) {
+  expectLocalDate(value, expectedDate);
+}
+
 describe('TaskGanttChart', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -45,6 +64,166 @@ describe('TaskGanttChart', () => {
   });
 
   describe('日付軸付きガントUI', () => {
+    describe('表示範囲ページネーション', () => {
+      it('日表示では1ヶ月分だけを表示し、次へ/前へで1ヶ月ずつ移動できる', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00+09:00'));
+        render(
+          <TaskGanttChart
+            tasks={[
+              makeTask({
+                id: 1,
+                createdAt: '2026-06-01T00:00:00Z',
+                dueAt: '2026-06-10T00:00:00Z',
+              }),
+            ]}
+          />,
+        );
+
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2026-07-01');
+        expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '30');
+
+        fireEvent.click(screen.getByRole('button', { name: '次の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2026-07-01');
+        expectTimelineDate(timelineRange().end, '2026-08-01');
+        expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '31');
+
+        fireEvent.click(screen.getByRole('button', { name: '前の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2026-07-01');
+      });
+
+      it('週表示では3ヶ月分だけを表示し、次へ/前へで3ヶ月ずつ移動できる', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00+09:00'));
+        render(
+          <TaskGanttChart
+            tasks={[
+              makeTask({
+                id: 1,
+                createdAt: '2026-06-01T00:00:00Z',
+                dueAt: '2026-06-10T00:00:00Z',
+              }),
+            ]}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: '週' }));
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2026-09-01');
+        expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '14');
+
+        fireEvent.click(screen.getByRole('button', { name: '次の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2026-09-01');
+        expectTimelineDate(timelineRange().end, '2026-12-01');
+
+        fireEvent.click(screen.getByRole('button', { name: '前の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2026-09-01');
+      });
+
+      it('月表示では2年分だけを表示し、次へ/前へで2年ずつ移動できる', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00+09:00'));
+        render(
+          <TaskGanttChart
+            tasks={[
+              makeTask({
+                id: 1,
+                createdAt: '2026-06-01T00:00:00Z',
+                dueAt: '2026-06-10T00:00:00Z',
+              }),
+            ]}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: '月' }));
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2028-06-01');
+        expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '24');
+
+        fireEvent.click(screen.getByRole('button', { name: '次の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2028-06-01');
+        expectTimelineDate(timelineRange().end, '2030-06-01');
+
+        fireEvent.click(screen.getByRole('button', { name: '前の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2028-06-01');
+      });
+
+      it('今日へ戻る操作で現在日を含む表示範囲へ戻せる', async () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00+09:00'));
+        render(
+          <TaskGanttChart
+            tasks={[
+              makeTask({
+                id: 1,
+                createdAt: '2026-06-01T00:00:00Z',
+                dueAt: '2026-06-10T00:00:00Z',
+              }),
+            ]}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: '次の表示範囲へ' }));
+        expectTimelineDate(timelineRange().start, '2026-07-01');
+
+        fireEvent.click(screen.getByRole('button', { name: '今日へ戻る' }));
+        expectTimelineDate(timelineRange().start, '2026-06-01');
+        expectTimelineDate(timelineRange().end, '2026-07-01');
+        expect(screen.getByTestId('gantt-today-line')).toHaveAttribute('aria-label', '今日');
+      });
+
+      it('表示範囲に一部でも重なるタスクだけを描画し、範囲外タスクは非表示にする', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-06-15T12:00:00+09:00'));
+        render(
+          <TaskGanttChart
+            tasks={[
+              makeTask({
+                id: 1,
+                title: '範囲開始前から入る',
+                startAt: '2026-05-25T00:00:00Z',
+                dueAt: '2026-06-05T00:00:00Z',
+              }),
+              makeTask({
+                id: 2,
+                title: '範囲内から終了後へ出る',
+                startAt: '2026-06-28T00:00:00Z',
+                dueAt: '2026-07-05T00:00:00Z',
+              }),
+              makeTask({
+                id: 3,
+                title: '範囲全体をまたぐ',
+                startAt: '2026-05-01T00:00:00Z',
+                dueAt: '2026-08-01T00:00:00Z',
+              }),
+              makeTask({
+                id: 4,
+                title: '完全に前',
+                startAt: '2026-05-01T00:00:00Z',
+                dueAt: '2026-05-20T00:00:00Z',
+              }),
+              makeTask({
+                id: 5,
+                title: '完全に後',
+                startAt: '2026-07-01T00:00:00Z',
+                dueAt: '2026-07-10T00:00:00Z',
+              }),
+            ]}
+          />,
+        );
+
+        expect(screen.getByText('範囲開始前から入る')).toBeInTheDocument();
+        expect(screen.getByText('範囲内から終了後へ出る')).toBeInTheDocument();
+        expect(screen.getByText('範囲全体をまたぐ')).toBeInTheDocument();
+        expect(screen.queryByText('完全に前')).not.toBeInTheDocument();
+        expect(screen.queryByText('完全に後')).not.toBeInTheDocument();
+      });
+    });
+
     it('ガント表示に日付ヘッダーと対応する縦グリッドを表示する', () => {
       render(
         <TaskGanttChart
@@ -57,8 +236,8 @@ describe('TaskGanttChart', () => {
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('6/1');
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('6/2');
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('6/3');
-      expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '3');
-      expect(screen.getAllByTestId(/^gantt-grid-line-/)).toHaveLength(3);
+      expect(screen.getByTestId('gantt-grid')).toHaveAttribute('data-grid-count', '30');
+      expect(screen.getAllByTestId(/^gantt-grid-line-/)).toHaveLength(30);
     });
 
     it('タスク名列と時間軸列を分け、各バーを日付ヘッダーと同じ横軸に配置する', () => {
@@ -126,12 +305,12 @@ describe('TaskGanttChart', () => {
       const dayGridCount = Number(screen.getByTestId('gantt-grid').dataset.gridCount);
       const dayWidth = screen.getByTestId('gantt-bar-1').dataset.widthPercent;
 
-      await userEvent.click(screen.getByRole('button', { name: '週' }));
+      fireEvent.click(screen.getByRole('button', { name: '週' }));
       expect(screen.getByTestId('task-gantt-chart')).toHaveAttribute('data-scale', 'week');
       expect(Number(screen.getByTestId('gantt-grid').dataset.gridCount)).toBeLessThan(dayGridCount);
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('週');
 
-      await userEvent.click(screen.getByRole('button', { name: '月' }));
+      fireEvent.click(screen.getByRole('button', { name: '月' }));
       expect(screen.getByTestId('task-gantt-chart')).toHaveAttribute('data-scale', 'month');
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('2026/6');
       expect(screen.getByTestId('gantt-date-axis')).toHaveTextContent('2026/7');
@@ -284,8 +463,8 @@ describe('TaskGanttChart', () => {
         clientX: 100,
         pointerId: 1,
       });
-      fireEvent.pointerMove(window, { clientX: 555, pointerId: 1 });
-      fireEvent.pointerUp(window, { clientX: 555, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 570, pointerId: 1 });
+      fireEvent.pointerUp(window, { clientX: 570, pointerId: 1 });
 
       await waitFor(() => expect(onStartAtChange).toHaveBeenCalledTimes(1));
       expectIsoDate(onStartAtChange.mock.calls[0][1], '2026-06-15');

--- a/packages/client/src/__tests__/__fixtures__/tasks.ts
+++ b/packages/client/src/__tests__/__fixtures__/tasks.ts
@@ -12,6 +12,7 @@ export function makeTask(overrides: Partial<Task> = {}): Task {
     description: null,
     assigneeId: null,
     assigneeUsername: null,
+    startAt: null,
     dueAt: null,
     sourceMessageId: null,
     sourceChannelId: null,

--- a/packages/client/src/components/Task/TaskGanttChart.tsx
+++ b/packages/client/src/components/Task/TaskGanttChart.tsx
@@ -18,6 +18,7 @@ import type { Task } from '@chat-app/shared';
 interface Props {
   tasks: Task[];
   onDueAtChange?: (task: Task, dueAt: string | null) => void | Promise<void>;
+  onStartAtChange?: (task: Task, startAt: string | null) => void | Promise<void>;
 }
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -143,10 +144,15 @@ interface DragState {
   timeline: HTMLElement;
   rangeStart: number;
   totalDuration: number;
-  previewDueAt: string;
+  kind: 'start' | 'due';
+  previewAt: string;
 }
 
-export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
+function effectiveStartAt(task: Task): string {
+  return task.startAt ?? task.createdAt;
+}
+
+export default function TaskGanttChart({ tasks, onDueAtChange, onStartAtChange }: Props) {
   const [scale, setScale] = useState<GanttScale>('day');
   const skipBlurCommitRef = useRef(false);
   const [editing, setEditing] = useState<{
@@ -171,9 +177,9 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
   }
 
   const spans = scheduled.map((task) => {
-    const created = startOfDay(task.createdAt);
+    const created = startOfDay(effectiveStartAt(task));
     const due = startOfDay(task.dueAt!);
-    return { task, start: Math.min(created, due), end: Math.max(created, due) };
+    return { task, start: created, end: Math.max(created, due), due };
   });
   const min = Math.min(...spans.map((span) => span.start));
   const max = Math.max(...spans.map((span) => span.end));
@@ -205,42 +211,57 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
     }
     closeDueEditor();
   };
-  const makeDueAtFromClientX = (drag: DragState, clientX: number): string => {
+  const makeAtFromClientX = (drag: DragState, clientX: number): string => {
     const rect = drag.timeline.getBoundingClientRect();
     const ratio = rect.width === 0 ? 0 : (clientX - rect.left) / rect.width;
     const raw = drag.rangeStart + ratio * drag.totalDuration;
     const snapped = startOfDay(new Date(raw).toISOString());
-    return preserveTimeOnDate(drag.task.dueAt!, snapped);
+    if (drag.kind === 'due') {
+      const start = startOfDay(effectiveStartAt(drag.task));
+      return preserveTimeOnDate(drag.task.dueAt!, Math.max(start, snapped));
+    }
+    const due = startOfDay(drag.task.dueAt!);
+    return preserveTimeOnDate(effectiveStartAt(drag.task), Math.min(due, snapped));
   };
-  const beginDueDrag = (task: Task, timeline: HTMLElement, clientX: number) => {
+  const beginDateDrag = (
+    task: Task,
+    timeline: HTMLElement,
+    clientX: number,
+    kind: 'start' | 'due',
+  ) => {
     if (!task.dueAt) return;
     const initial: DragState = {
       task,
       timeline,
       rangeStart,
       totalDuration,
-      previewDueAt: makeDueAtFromClientX(
-        { task, timeline, rangeStart, totalDuration, previewDueAt: task.dueAt },
+      kind,
+      previewAt: makeAtFromClientX(
+        { task, timeline, rangeStart, totalDuration, kind, previewAt: task.dueAt },
         clientX,
       ),
     };
     setDragState(initial);
   };
-  const handleDueDragMove = (clientX: number) => {
+  const handleDateDragMove = (clientX: number) => {
     setDragState((current) =>
-      current ? { ...current, previewDueAt: makeDueAtFromClientX(current, clientX) } : current,
+      current ? { ...current, previewAt: makeAtFromClientX(current, clientX) } : current,
     );
   };
-  const endDueDrag = (clientX: number) => {
+  const endDateDrag = (clientX: number) => {
     if (!dragState) return;
-    const nextDueAt = makeDueAtFromClientX(dragState, clientX);
-    void onDueAtChange?.(dragState.task, nextDueAt);
+    const nextAt = makeAtFromClientX(dragState, clientX);
+    if (dragState.kind === 'due') {
+      void onDueAtChange?.(dragState.task, nextAt);
+    } else {
+      void onStartAtChange?.(dragState.task, nextAt);
+    }
     setDragState(null);
   };
   useEffect(() => {
     if (!dragState) return undefined;
-    const handlePointerMove = (event: PointerEvent) => handleDueDragMove(event.clientX);
-    const handlePointerUp = (event: PointerEvent) => endDueDrag(event.clientX);
+    const handlePointerMove = (event: PointerEvent) => handleDateDragMove(event.clientX);
+    const handlePointerUp = (event: PointerEvent) => endDateDrag(event.clientX);
     window.addEventListener('pointermove', handlePointerMove);
     window.addEventListener('pointerup', handlePointerUp, { once: true });
     return () => {
@@ -254,10 +275,10 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
       data-testid="task-gantt-chart"
       data-scale={scale}
       onPointerMove={(event) => {
-        if (dragState) handleDueDragMove(event.clientX);
+        if (dragState) handleDateDragMove(event.clientX);
       }}
       onPointerUp={(event) => {
-        if (dragState) endDueDrag(event.clientX);
+        if (dragState) endDateDrag(event.clientX);
       }}
       sx={{ minWidth: 920, p: 2 }}
     >
@@ -398,14 +419,21 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
               />
             )}
 
-            {spans.map(({ task, start, end }) => {
+            {spans.map(({ task, start, end, due }) => {
               const dragPreview =
-                dragState?.task.id === task.id ? startOfDay(dragState.previewDueAt) : null;
-              const displayEnd = dragPreview ?? end;
-              const startPercent = ((start - rangeStart) / totalDuration) * 100;
+                dragState?.task.id === task.id ? startOfDay(dragState.previewAt) : null;
+              const displayStart =
+                dragState?.task.id === task.id && dragState.kind === 'start'
+                  ? (dragPreview ?? start)
+                  : start;
+              const displayEnd =
+                dragState?.task.id === task.id && dragState.kind === 'due'
+                  ? (dragPreview ?? end)
+                  : end;
+              const startPercent = ((displayStart - rangeStart) / totalDuration) * 100;
               const widthPercent = Math.max(
                 (DAY / totalDuration) * 100,
-                ((displayEnd + DAY - start) / totalDuration) * 100,
+                ((displayEnd + DAY - displayStart) / totalDuration) * 100,
               );
               const dependencyNames = (task.dependencyIds ?? [])
                 .map((id) => taskById.get(id)?.title)
@@ -450,7 +478,7 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
                       color="text.secondary"
                       sx={{ display: 'block', mt: 0.5 }}
                     >
-                      {formatDate(start)} — {formatDate(end)}
+                      {formatDate(start)} — {formatDate(due)}
                     </Typography>
                     {dependencyNames.length > 0 && (
                       <Typography
@@ -501,13 +529,41 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
                             `[data-testid="gantt-timeline-${task.id}"]`,
                           );
                           if (timeline instanceof HTMLElement) {
-                            beginDueDrag(task, timeline, event.clientX);
+                            beginDateDrag(task, timeline, event.clientX, 'due');
                           }
                         }}
                         sx={{
                           position: 'absolute',
                           top: -4,
                           right: -6,
+                          width: 12,
+                          height: 32,
+                          border: 0,
+                          borderRadius: 1,
+                          bgcolor: 'primary.dark',
+                          cursor: 'ew-resize',
+                          '&:focus-visible': { outline: 'auto' },
+                        }}
+                      />
+                      <Box
+                        component="button"
+                        type="button"
+                        aria-label="開始日をドラッグして変更"
+                        data-testid={`gantt-start-handle-${task.id}`}
+                        onClick={(event) => event.stopPropagation()}
+                        onPointerDown={(event) => {
+                          event.stopPropagation();
+                          const timeline = event.currentTarget.closest(
+                            `[data-testid="gantt-timeline-${task.id}"]`,
+                          );
+                          if (timeline instanceof HTMLElement) {
+                            beginDateDrag(task, timeline, event.clientX, 'start');
+                          }
+                        }}
+                        sx={{
+                          position: 'absolute',
+                          top: -4,
+                          left: -6,
                           width: 12,
                           height: 32,
                           border: 0,
@@ -524,7 +580,10 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
                         data-testid={`gantt-drag-preview-${task.id}`}
                         sx={{
                           position: 'absolute',
-                          left: `${Math.max(0, widthPercent + startPercent)}%`,
+                          left:
+                            dragState.kind === 'start'
+                              ? `${Math.max(0, startPercent)}%`
+                              : `${Math.max(0, widthPercent + startPercent)}%`,
                           top: 2,
                           transform: 'translateX(-100%)',
                           bgcolor: 'background.paper',
@@ -534,7 +593,7 @@ export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
                           whiteSpace: 'nowrap',
                         }}
                       >
-                        {formatDate(startOfDay(dragState.previewDueAt))}
+                        {formatDate(startOfDay(dragState.previewAt))}
                       </Typography>
                     )}
                   </Box>

--- a/packages/client/src/components/Task/TaskGanttChart.tsx
+++ b/packages/client/src/components/Task/TaskGanttChart.tsx
@@ -1,4 +1,5 @@
-import { Box, Paper, Typography } from '@mui/material';
+import { useState } from 'react';
+import { Box, Paper, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
 import type { Task } from '@chat-app/shared';
 
 interface Props {
@@ -6,15 +7,100 @@ interface Props {
 }
 
 const DAY = 24 * 60 * 60 * 1000;
+const TASK_COLUMN_WIDTH = 220;
+
+type GanttScale = 'day' | 'week' | 'month';
+
+const SCALE_LABELS: Record<GanttScale, string> = {
+  day: '日',
+  week: '週',
+  month: '月',
+};
+
+const SCALE_MIN_WIDTH: Record<GanttScale, number> = {
+  day: 56,
+  week: 96,
+  month: 132,
+};
 
 function startOfDay(value: string): number {
   const date = new Date(value);
   return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
 }
 
+function startOfToday(): number {
+  const date = new Date();
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function addDays(value: number, amount: number): number {
+  const date = new Date(value);
+  date.setDate(date.getDate() + amount);
+  return date.getTime();
+}
+
+function addMonths(value: number, amount: number): number {
+  const date = new Date(value);
+  date.setMonth(date.getMonth() + amount);
+  return date.getTime();
+}
+
+function startOfWeek(value: number): number {
+  const date = new Date(value);
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setDate(date.getDate() + diff);
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function startOfMonth(value: number): number {
+  const date = new Date(value);
+  return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+}
+
+function addScaleUnit(value: number, scale: GanttScale): number {
+  if (scale === 'month') return addMonths(value, 1);
+  return addDays(value, scale === 'week' ? 7 : 1);
+}
+
+function roundRangeStart(value: number, scale: GanttScale): number {
+  if (scale === 'week') return startOfWeek(value);
+  if (scale === 'month') return startOfMonth(value);
+  return value;
+}
+
+function roundRangeEndExclusive(value: number, scale: GanttScale): number {
+  return addScaleUnit(roundRangeStart(value, scale), scale);
+}
+
+function formatDate(value: number): string {
+  return new Date(value).toLocaleDateString('ja-JP');
+}
+
+function formatAxisLabel(value: number, scale: GanttScale): string {
+  const date = new Date(value);
+  if (scale === 'month') {
+    return `${date.getFullYear()}/${date.getMonth() + 1}`;
+  }
+  const monthDay = `${date.getMonth() + 1}/${date.getDate()}`;
+  return scale === 'week' ? `${monthDay}週` : monthDay;
+}
+
+function buildTicks(rangeStart: number, rangeEndExclusive: number, scale: GanttScale): number[] {
+  const ticks: number[] = [];
+  let cursor = rangeStart;
+  while (cursor < rangeEndExclusive) {
+    ticks.push(cursor);
+    cursor = addScaleUnit(cursor, scale);
+  }
+  return ticks;
+}
+
 export default function TaskGanttChart({ tasks }: Props) {
+  const [scale, setScale] = useState<GanttScale>('day');
   const scheduled = tasks.filter((task) => task.dueAt != null);
   const unscheduledCount = tasks.length - scheduled.length;
+
   if (scheduled.length === 0) {
     return (
       <Box data-testid="gantt-empty" sx={{ p: 4, textAlign: 'center' }}>
@@ -33,64 +119,236 @@ export default function TaskGanttChart({ tasks }: Props) {
   });
   const min = Math.min(...spans.map((span) => span.start));
   const max = Math.max(...spans.map((span) => span.end));
-  const totalDays = Math.max(1, Math.round((max - min) / DAY) + 1);
+  const rangeStart = roundRangeStart(min, scale);
+  const rangeEndExclusive = roundRangeEndExclusive(max, scale);
+  const totalDuration = Math.max(DAY, rangeEndExclusive - rangeStart);
+  const ticks = buildTicks(rangeStart, rangeEndExclusive, scale);
+  const timelineWidth = Math.max(720, ticks.length * SCALE_MIN_WIDTH[scale]);
+  const today = startOfToday();
+  const todayVisible = today >= rangeStart && today < rangeEndExclusive;
   const taskById = new Map(tasks.map((task) => [task.id, task]));
+  const gridTemplateColumns = `${TASK_COLUMN_WIDTH}px minmax(720px, 1fr)`;
+  const gridLinePositions = ticks.map((tick) => ((tick - rangeStart) / totalDuration) * 100);
 
   return (
-    <Box data-testid="task-gantt-chart" sx={{ minWidth: 720, p: 2 }}>
-      <Typography variant="caption" color="text.secondary">
-        {new Date(min).toLocaleDateString('ja-JP')} — {new Date(max).toLocaleDateString('ja-JP')}
-      </Typography>
-      {spans.map(({ task, start, end }) => {
-        const startPercent = ((start - min) / DAY / totalDays) * 100;
-        const widthPercent = Math.max(
-          100 / totalDays,
-          (((end - start) / DAY + 1) / totalDays) * 100,
-        );
-        const dependencyNames = (task.dependencyIds ?? [])
-          .map((id) => taskById.get(id)?.title)
-          .filter((title): title is string => Boolean(title));
-        return (
-          <Paper
-            key={task.id}
-            data-testid={`gantt-row-${task.id}`}
-            variant="outlined"
-            sx={{ p: 1, mt: 1 }}
+    <Box data-testid="task-gantt-chart" data-scale={scale} sx={{ minWidth: 920, p: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
+        <Typography variant="caption" color="text.secondary">
+          {formatDate(min)} — {formatDate(max)}
+        </Typography>
+        <ToggleButtonGroup
+          value={scale}
+          exclusive
+          size="small"
+          aria-label="ガント表示粒度"
+          onChange={(_, value: GanttScale | null) => {
+            if (value) setScale(value);
+          }}
+        >
+          {(['day', 'week', 'month'] as const).map((value) => (
+            <ToggleButton key={value} value={value} aria-label={SCALE_LABELS[value]}>
+              {SCALE_LABELS[value]}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Box>
+
+      <Box sx={{ overflowX: 'auto' }}>
+        <Box sx={{ minWidth: TASK_COLUMN_WIDTH + timelineWidth }}>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns,
+              alignItems: 'stretch',
+              position: 'sticky',
+              top: 0,
+              zIndex: 1,
+              bgcolor: 'background.paper',
+            }}
           >
-            <Typography variant="body2" fontWeight={600}>
-              {task.title}
-            </Typography>
             <Box
+              data-testid="gantt-task-column-header"
               sx={{
-                position: 'relative',
-                height: 22,
-                bgcolor: 'action.hover',
-                borderRadius: 1,
-                mt: 0.5,
+                p: 1,
+                borderBottom: 1,
+                borderColor: 'divider',
+                color: 'text.secondary',
+                fontSize: '0.75rem',
+                fontWeight: 700,
               }}
             >
+              タスク
+            </Box>
+            <Box
+              data-testid="gantt-timeline-column-header"
+              sx={{
+                p: 1,
+                borderBottom: 1,
+                borderColor: 'divider',
+                color: 'text.secondary',
+                fontSize: '0.75rem',
+                fontWeight: 700,
+              }}
+            >
+              期間
+            </Box>
+          </Box>
+
+          <Box
+            data-testid="gantt-date-axis"
+            data-timeline-start={String(rangeStart)}
+            data-timeline-end={String(rangeEndExclusive)}
+            sx={{ display: 'grid', gridTemplateColumns, minHeight: 36 }}
+          >
+            <Box sx={{ borderBottom: 1, borderColor: 'divider' }} />
+            <Box sx={{ position: 'relative', borderBottom: 1, borderColor: 'divider' }}>
+              {ticks.map((tick, index) => {
+                const next = addScaleUnit(tick, scale);
+                const left = ((tick - rangeStart) / totalDuration) * 100;
+                const width = ((next - tick) / totalDuration) * 100;
+                return (
+                  <Typography
+                    key={tick}
+                    variant="caption"
+                    data-testid={`gantt-axis-label-${index}`}
+                    sx={{
+                      position: 'absolute',
+                      left: `${left}%`,
+                      width: `${width}%`,
+                      p: 0.75,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      color: 'text.secondary',
+                      borderLeft: index === 0 ? 1 : 0,
+                      borderRight: 1,
+                      borderColor: 'divider',
+                    }}
+                  >
+                    {formatAxisLabel(tick, scale)}
+                  </Typography>
+                );
+              })}
+            </Box>
+          </Box>
+
+          <Box
+            data-testid="gantt-grid"
+            data-grid-count={ticks.length}
+            sx={{ position: 'relative' }}
+          >
+            {gridLinePositions.map((left, index) => (
               <Box
-                data-testid={`gantt-bar-${task.id}`}
-                data-start-percent={startPercent.toFixed(2)}
-                data-width-percent={widthPercent.toFixed(2)}
+                key={`${ticks[index]}-${index}`}
+                data-testid={`gantt-grid-line-${index}`}
                 sx={{
                   position: 'absolute',
-                  left: `${startPercent}%`,
-                  width: `${widthPercent}%`,
-                  height: '100%',
-                  bgcolor: 'primary.main',
-                  borderRadius: 1,
+                  top: 0,
+                  bottom: 0,
+                  left: `calc(${TASK_COLUMN_WIDTH}px + ${left}%)`,
+                  width: 1,
+                  bgcolor: 'divider',
+                  opacity: 0.9,
+                  pointerEvents: 'none',
                 }}
               />
-            </Box>
-            {dependencyNames.length > 0 && (
-              <Typography variant="caption" color="text.secondary">
-                先行: {dependencyNames.join('、')}
-              </Typography>
+            ))}
+            {todayVisible && (
+              <Box
+                data-testid="gantt-today-line"
+                aria-label="今日"
+                sx={{
+                  position: 'absolute',
+                  top: 0,
+                  bottom: 0,
+                  left: `calc(${TASK_COLUMN_WIDTH}px + ${((today - rangeStart) / totalDuration) * 100}%)`,
+                  width: 2,
+                  bgcolor: 'error.main',
+                  pointerEvents: 'none',
+                }}
+              />
             )}
-          </Paper>
-        );
-      })}
+
+            {spans.map(({ task, start, end }) => {
+              const startPercent = ((start - rangeStart) / totalDuration) * 100;
+              const widthPercent = Math.max(
+                (DAY / totalDuration) * 100,
+                ((end + DAY - start) / totalDuration) * 100,
+              );
+              const dependencyNames = (task.dependencyIds ?? [])
+                .map((id) => taskById.get(id)?.title)
+                .filter((title): title is string => Boolean(title));
+
+              return (
+                <Paper
+                  key={task.id}
+                  data-testid={`gantt-row-${task.id}`}
+                  data-layout="task-and-timeline"
+                  variant="outlined"
+                  sx={{
+                    display: 'grid',
+                    gridTemplateColumns,
+                    position: 'relative',
+                    overflow: 'hidden',
+                    mt: 1,
+                  }}
+                >
+                  <Box sx={{ p: 1, borderRight: 1, borderColor: 'divider' }}>
+                    <Typography variant="body2" fontWeight={600}>
+                      {task.title}
+                    </Typography>
+                    <Typography
+                      data-testid={`gantt-period-label-${task.id}`}
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ display: 'block', mt: 0.5 }}
+                    >
+                      {formatDate(start)} — {formatDate(end)}
+                    </Typography>
+                    {dependencyNames.length > 0 && (
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ display: 'block' }}
+                      >
+                        先行: {dependencyNames.join('、')}
+                      </Typography>
+                    )}
+                  </Box>
+                  <Box
+                    sx={{
+                      position: 'relative',
+                      minHeight: 54,
+                      bgcolor: 'action.hover',
+                    }}
+                  >
+                    <Box
+                      data-testid={`gantt-bar-${task.id}`}
+                      data-start-percent={startPercent.toFixed(2)}
+                      data-width-percent={widthPercent.toFixed(2)}
+                      data-timeline-start={String(rangeStart)}
+                      data-timeline-end={String(rangeEndExclusive)}
+                      sx={{
+                        position: 'absolute',
+                        left: `${startPercent}%`,
+                        width: `${widthPercent}%`,
+                        top: '50%',
+                        transform: 'translateY(-50%)',
+                        minWidth: 12,
+                        height: 24,
+                        bgcolor: 'primary.main',
+                        borderRadius: 1,
+                        boxShadow: 1,
+                      }}
+                    />
+                  </Box>
+                </Paper>
+              );
+            })}
+          </Box>
+        </Box>
+      </Box>
+
       {unscheduledCount > 0 && (
         <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
           期限なし: {unscheduledCount}件

--- a/packages/client/src/components/Task/TaskGanttChart.tsx
+++ b/packages/client/src/components/Task/TaskGanttChart.tsx
@@ -60,17 +60,13 @@ function addMonths(value: number, amount: number): number {
   return date.getTime();
 }
 
-function startOfWeek(value: number): number {
-  const date = new Date(value);
-  const day = date.getDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  date.setDate(date.getDate() + diff);
-  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
-}
-
 function startOfMonth(value: number): number {
   const date = new Date(value);
   return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+}
+
+function endOfVisibleRangeLabel(value: number): number {
+  return addDays(value, -1);
 }
 
 function addScaleUnit(value: number, scale: GanttScale): number {
@@ -78,14 +74,18 @@ function addScaleUnit(value: number, scale: GanttScale): number {
   return addDays(value, scale === 'week' ? 7 : 1);
 }
 
-function roundRangeStart(value: number, scale: GanttScale): number {
-  if (scale === 'week') return startOfWeek(value);
-  if (scale === 'month') return startOfMonth(value);
-  return value;
+function pageMonthsForScale(scale: GanttScale): number {
+  if (scale === 'day') return 1;
+  if (scale === 'week') return 3;
+  return 24;
 }
 
-function roundRangeEndExclusive(value: number, scale: GanttScale): number {
-  return addScaleUnit(roundRangeStart(value, scale), scale);
+function rangeStartForPage(pageAnchor: number): number {
+  return pageAnchor;
+}
+
+function rangeEndForPage(pageAnchor: number, scale: GanttScale): number {
+  return addMonths(pageAnchor, pageMonthsForScale(scale));
 }
 
 function formatDate(value: number): string {
@@ -162,6 +162,7 @@ export default function TaskGanttChart({ tasks, onDueAtChange, onStartAtChange }
     initialValue: string;
   } | null>(null);
   const [dragState, setDragState] = useState<DragState | null>(null);
+  const [pageAnchor, setPageAnchor] = useState(() => startOfMonth(startOfToday()));
   const scheduled = tasks.filter((task) => task.dueAt != null);
   const unscheduledCount = tasks.length - scheduled.length;
 
@@ -181,10 +182,8 @@ export default function TaskGanttChart({ tasks, onDueAtChange, onStartAtChange }
     const due = startOfDay(task.dueAt!);
     return { task, start: created, end: Math.max(created, due), due };
   });
-  const min = Math.min(...spans.map((span) => span.start));
-  const max = Math.max(...spans.map((span) => span.end));
-  const rangeStart = roundRangeStart(min, scale);
-  const rangeEndExclusive = roundRangeEndExclusive(max, scale);
+  const rangeStart = rangeStartForPage(pageAnchor);
+  const rangeEndExclusive = rangeEndForPage(pageAnchor, scale);
   const totalDuration = Math.max(DAY, rangeEndExclusive - rangeStart);
   const ticks = buildTicks(rangeStart, rangeEndExclusive, scale);
   const timelineWidth = Math.max(720, ticks.length * SCALE_MIN_WIDTH[scale]);
@@ -193,6 +192,23 @@ export default function TaskGanttChart({ tasks, onDueAtChange, onStartAtChange }
   const taskById = new Map(tasks.map((task) => [task.id, task]));
   const gridTemplateColumns = `${TASK_COLUMN_WIDTH}px minmax(720px, 1fr)`;
   const gridLinePositions = ticks.map((tick) => ((tick - rangeStart) / totalDuration) * 100);
+  const visibleSpans = spans.filter(
+    ({ start, end }) => end + DAY > rangeStart && start < rangeEndExclusive,
+  );
+  const goToPreviousPage = () => {
+    setPageAnchor((current) => addMonths(current, -pageMonthsForScale(scale)));
+  };
+  const goToNextPage = () => {
+    setPageAnchor((current) => addMonths(current, pageMonthsForScale(scale)));
+  };
+  const goToToday = () => {
+    setPageAnchor(startOfMonth(startOfToday()));
+  };
+  const switchScale = (value: GanttScale | null) => {
+    if (!value) return;
+    setScale(value);
+    setPageAnchor(startOfMonth(startOfToday()));
+  };
   const openDueEditor = (task: Task, anchorEl: HTMLElement) => {
     if (!task.dueAt) return;
     const value = formatDateTimeLocal(task.dueAt);
@@ -283,17 +299,41 @@ export default function TaskGanttChart({ tasks, onDueAtChange, onStartAtChange }
       sx={{ minWidth: 920, p: 2 }}
     >
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
-        <Typography variant="caption" color="text.secondary">
-          {formatDate(min)} — {formatDate(max)}
-        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Button
+            size="small"
+            variant="outlined"
+            aria-label="前の表示範囲へ"
+            onClick={goToPreviousPage}
+          >
+            前へ
+          </Button>
+          <Button size="small" variant="outlined" onClick={goToToday}>
+            今日へ戻る
+          </Button>
+          <Button
+            size="small"
+            variant="outlined"
+            aria-label="次の表示範囲へ"
+            onClick={goToNextPage}
+          >
+            次へ
+          </Button>
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            data-testid="gantt-visible-range"
+            sx={{ minWidth: 160 }}
+          >
+            {formatDate(rangeStart)} — {formatDate(endOfVisibleRangeLabel(rangeEndExclusive))}
+          </Typography>
+        </Stack>
         <ToggleButtonGroup
           value={scale}
           exclusive
           size="small"
           aria-label="ガント表示粒度"
-          onChange={(_, value: GanttScale | null) => {
-            if (value) setScale(value);
-          }}
+          onChange={(_, value: GanttScale | null) => switchScale(value)}
         >
           {(['day', 'week', 'month'] as const).map((value) => (
             <ToggleButton key={value} value={value} aria-label={SCALE_LABELS[value]}>
@@ -419,21 +459,23 @@ export default function TaskGanttChart({ tasks, onDueAtChange, onStartAtChange }
               />
             )}
 
-            {spans.map(({ task, start, end, due }) => {
+            {visibleSpans.map(({ task, start, end, due }) => {
               const dragPreview =
                 dragState?.task.id === task.id ? startOfDay(dragState.previewAt) : null;
               const displayStart =
                 dragState?.task.id === task.id && dragState.kind === 'start'
                   ? (dragPreview ?? start)
                   : start;
+              const displayStartClamped = Math.max(rangeStart, displayStart);
               const displayEnd =
                 dragState?.task.id === task.id && dragState.kind === 'due'
                   ? (dragPreview ?? end)
                   : end;
-              const startPercent = ((displayStart - rangeStart) / totalDuration) * 100;
+              const displayEndExclusiveClamped = Math.min(displayEnd + DAY, rangeEndExclusive);
+              const startPercent = ((displayStartClamped - rangeStart) / totalDuration) * 100;
               const widthPercent = Math.max(
                 (DAY / totalDuration) * 100,
-                ((displayEnd + DAY - displayStart) / totalDuration) * 100,
+                ((displayEndExclusiveClamped - displayStartClamped) / totalDuration) * 100,
               );
               const dependencyNames = (task.dependencyIds ?? [])
                 .map((id) => taskById.get(id)?.title)

--- a/packages/client/src/components/Task/TaskGanttChart.tsx
+++ b/packages/client/src/components/Task/TaskGanttChart.tsx
@@ -1,9 +1,23 @@
-import { useState } from 'react';
-import { Box, Paper, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  IconButton,
+  Paper,
+  Popover,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
 import type { Task } from '@chat-app/shared';
 
 interface Props {
   tasks: Task[];
+  onDueAtChange?: (task: Task, dueAt: string | null) => void | Promise<void>;
 }
 
 const DAY = 24 * 60 * 60 * 1000;
@@ -77,6 +91,34 @@ function formatDate(value: number): string {
   return new Date(value).toLocaleDateString('ja-JP');
 }
 
+function formatDateTimeLocal(value: string): string {
+  const date = new Date(value);
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  const hh = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}T${hh}:${min}`;
+}
+
+function dateTimeLocalToIso(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function preserveTimeOnDate(baseIso: string, dateValue: number): string {
+  const base = new Date(baseIso);
+  const date = new Date(dateValue);
+  return new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    base.getHours(),
+    base.getMinutes(),
+    base.getSeconds(),
+    base.getMilliseconds(),
+  ).toISOString();
+}
+
 function formatAxisLabel(value: number, scale: GanttScale): string {
   const date = new Date(value);
   if (scale === 'month') {
@@ -96,8 +138,24 @@ function buildTicks(rangeStart: number, rangeEndExclusive: number, scale: GanttS
   return ticks;
 }
 
-export default function TaskGanttChart({ tasks }: Props) {
+interface DragState {
+  task: Task;
+  timeline: HTMLElement;
+  rangeStart: number;
+  totalDuration: number;
+  previewDueAt: string;
+}
+
+export default function TaskGanttChart({ tasks, onDueAtChange }: Props) {
   const [scale, setScale] = useState<GanttScale>('day');
+  const skipBlurCommitRef = useRef(false);
+  const [editing, setEditing] = useState<{
+    task: Task;
+    anchorEl: HTMLElement;
+    value: string;
+    initialValue: string;
+  } | null>(null);
+  const [dragState, setDragState] = useState<DragState | null>(null);
   const scheduled = tasks.filter((task) => task.dueAt != null);
   const unscheduledCount = tasks.length - scheduled.length;
 
@@ -129,9 +187,80 @@ export default function TaskGanttChart({ tasks }: Props) {
   const taskById = new Map(tasks.map((task) => [task.id, task]));
   const gridTemplateColumns = `${TASK_COLUMN_WIDTH}px minmax(720px, 1fr)`;
   const gridLinePositions = ticks.map((tick) => ((tick - rangeStart) / totalDuration) * 100);
+  const openDueEditor = (task: Task, anchorEl: HTMLElement) => {
+    if (!task.dueAt) return;
+    const value = formatDateTimeLocal(task.dueAt);
+    setEditing({ task, anchorEl, value, initialValue: value });
+  };
+  const closeDueEditor = () => setEditing(null);
+  const commitDueEditor = () => {
+    if (!editing) return;
+    if (!editing.value) {
+      void onDueAtChange?.(editing.task, null);
+      closeDueEditor();
+      return;
+    }
+    if (editing.value !== editing.initialValue) {
+      void onDueAtChange?.(editing.task, dateTimeLocalToIso(editing.value));
+    }
+    closeDueEditor();
+  };
+  const makeDueAtFromClientX = (drag: DragState, clientX: number): string => {
+    const rect = drag.timeline.getBoundingClientRect();
+    const ratio = rect.width === 0 ? 0 : (clientX - rect.left) / rect.width;
+    const raw = drag.rangeStart + ratio * drag.totalDuration;
+    const snapped = startOfDay(new Date(raw).toISOString());
+    return preserveTimeOnDate(drag.task.dueAt!, snapped);
+  };
+  const beginDueDrag = (task: Task, timeline: HTMLElement, clientX: number) => {
+    if (!task.dueAt) return;
+    const initial: DragState = {
+      task,
+      timeline,
+      rangeStart,
+      totalDuration,
+      previewDueAt: makeDueAtFromClientX(
+        { task, timeline, rangeStart, totalDuration, previewDueAt: task.dueAt },
+        clientX,
+      ),
+    };
+    setDragState(initial);
+  };
+  const handleDueDragMove = (clientX: number) => {
+    setDragState((current) =>
+      current ? { ...current, previewDueAt: makeDueAtFromClientX(current, clientX) } : current,
+    );
+  };
+  const endDueDrag = (clientX: number) => {
+    if (!dragState) return;
+    const nextDueAt = makeDueAtFromClientX(dragState, clientX);
+    void onDueAtChange?.(dragState.task, nextDueAt);
+    setDragState(null);
+  };
+  useEffect(() => {
+    if (!dragState) return undefined;
+    const handlePointerMove = (event: PointerEvent) => handleDueDragMove(event.clientX);
+    const handlePointerUp = (event: PointerEvent) => endDueDrag(event.clientX);
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp, { once: true });
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [dragState]);
 
   return (
-    <Box data-testid="task-gantt-chart" data-scale={scale} sx={{ minWidth: 920, p: 2 }}>
+    <Box
+      data-testid="task-gantt-chart"
+      data-scale={scale}
+      onPointerMove={(event) => {
+        if (dragState) handleDueDragMove(event.clientX);
+      }}
+      onPointerUp={(event) => {
+        if (dragState) endDueDrag(event.clientX);
+      }}
+      sx={{ minWidth: 920, p: 2 }}
+    >
       <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 1 }}>
         <Typography variant="caption" color="text.secondary">
           {formatDate(min)} — {formatDate(max)}
@@ -270,10 +399,13 @@ export default function TaskGanttChart({ tasks }: Props) {
             )}
 
             {spans.map(({ task, start, end }) => {
+              const dragPreview =
+                dragState?.task.id === task.id ? startOfDay(dragState.previewDueAt) : null;
+              const displayEnd = dragPreview ?? end;
               const startPercent = ((start - rangeStart) / totalDuration) * 100;
               const widthPercent = Math.max(
                 (DAY / totalDuration) * 100,
-                ((end + DAY - start) / totalDuration) * 100,
+                ((displayEnd + DAY - start) / totalDuration) * 100,
               );
               const dependencyNames = (task.dependencyIds ?? [])
                 .map((id) => taskById.get(id)?.title)
@@ -285,6 +417,7 @@ export default function TaskGanttChart({ tasks }: Props) {
                   data-testid={`gantt-row-${task.id}`}
                   data-layout="task-and-timeline"
                   variant="outlined"
+                  onClick={(event) => openDueEditor(task, event.currentTarget)}
                   sx={{
                     display: 'grid',
                     gridTemplateColumns,
@@ -294,9 +427,23 @@ export default function TaskGanttChart({ tasks }: Props) {
                   }}
                 >
                   <Box sx={{ p: 1, borderRight: 1, borderColor: 'divider' }}>
-                    <Typography variant="body2" fontWeight={600}>
-                      {task.title}
-                    </Typography>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5 }}>
+                      <Typography variant="body2" fontWeight={600} sx={{ flex: 1 }}>
+                        {task.title}
+                      </Typography>
+                      <Tooltip title="期限を編集">
+                        <IconButton
+                          size="small"
+                          aria-label="期限を編集"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            openDueEditor(task, event.currentTarget);
+                          }}
+                        >
+                          <EditIcon fontSize="small" />
+                        </IconButton>
+                      </Tooltip>
+                    </Box>
                     <Typography
                       data-testid={`gantt-period-label-${task.id}`}
                       variant="caption"
@@ -316,6 +463,7 @@ export default function TaskGanttChart({ tasks }: Props) {
                     )}
                   </Box>
                   <Box
+                    data-testid={`gantt-timeline-${task.id}`}
                     sx={{
                       position: 'relative',
                       minHeight: 54,
@@ -340,7 +488,55 @@ export default function TaskGanttChart({ tasks }: Props) {
                         borderRadius: 1,
                         boxShadow: 1,
                       }}
-                    />
+                    >
+                      <Box
+                        component="button"
+                        type="button"
+                        aria-label="期限をドラッグして変更"
+                        data-testid={`gantt-due-handle-${task.id}`}
+                        onClick={(event) => event.stopPropagation()}
+                        onPointerDown={(event) => {
+                          event.stopPropagation();
+                          const timeline = event.currentTarget.closest(
+                            `[data-testid="gantt-timeline-${task.id}"]`,
+                          );
+                          if (timeline instanceof HTMLElement) {
+                            beginDueDrag(task, timeline, event.clientX);
+                          }
+                        }}
+                        sx={{
+                          position: 'absolute',
+                          top: -4,
+                          right: -6,
+                          width: 12,
+                          height: 32,
+                          border: 0,
+                          borderRadius: 1,
+                          bgcolor: 'primary.dark',
+                          cursor: 'ew-resize',
+                          '&:focus-visible': { outline: 'auto' },
+                        }}
+                      />
+                    </Box>
+                    {dragState?.task.id === task.id && (
+                      <Typography
+                        variant="caption"
+                        data-testid={`gantt-drag-preview-${task.id}`}
+                        sx={{
+                          position: 'absolute',
+                          left: `${Math.max(0, widthPercent + startPercent)}%`,
+                          top: 2,
+                          transform: 'translateX(-100%)',
+                          bgcolor: 'background.paper',
+                          px: 0.5,
+                          borderRadius: 0.5,
+                          boxShadow: 1,
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {formatDate(startOfDay(dragState.previewDueAt))}
+                      </Typography>
+                    )}
                   </Box>
                 </Paper>
               );
@@ -354,6 +550,58 @@ export default function TaskGanttChart({ tasks }: Props) {
           期限なし: {unscheduledCount}件
         </Typography>
       )}
+      <Popover
+        open={Boolean(editing)}
+        anchorEl={editing?.anchorEl ?? null}
+        onClose={closeDueEditor}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+      >
+        {editing && (
+          <Stack spacing={1} sx={{ p: 2, width: 280 }}>
+            <Typography variant="subtitle2">期限を編集</Typography>
+            <TextField
+              label="期限を編集"
+              type="datetime-local"
+              value={editing.value}
+              autoFocus
+              fullWidth
+              size="small"
+              InputLabelProps={{ shrink: true }}
+              onChange={(event) => setEditing({ ...editing, value: event.target.value })}
+              onBlur={() => {
+                if (skipBlurCommitRef.current) {
+                  skipBlurCommitRef.current = false;
+                  return;
+                }
+                commitDueEditor();
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  skipBlurCommitRef.current = true;
+                  commitDueEditor();
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  skipBlurCommitRef.current = true;
+                  closeDueEditor();
+                }
+              }}
+            />
+            <Button
+              variant="outlined"
+              color="secondary"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => {
+                void onDueAtChange?.(editing.task, null);
+                closeDueEditor();
+              }}
+            >
+              期限なしにする
+            </Button>
+          </Stack>
+        )}
+      </Popover>
     </Box>
   );
 }

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -695,6 +695,17 @@ function TaskBoardContent({
     }
   };
 
+  const handleGanttDueAtChange = async (task: Task, dueAt: string | null) => {
+    const prevTasks = tasks;
+    setTasks((prev) => prev.map((t) => (t.id === task.id ? { ...t, dueAt } : t)));
+    try {
+      await api.tasks.update(task.id, { dueAt });
+    } catch {
+      setTasks(prevTasks);
+      showError('タスクの期限を更新できませんでした');
+    }
+  };
+
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* ツールバー: モバイル時は縦スタック、デスクトップ時は横一列 */}
@@ -806,7 +817,7 @@ function TaskBoardContent({
         </Box>
       ) : (
         <Box data-testid="gantt-container" sx={{ flexGrow: 1, overflow: 'auto' }}>
-          <TaskGanttChart tasks={filteredTasks} />
+          <TaskGanttChart tasks={filteredTasks} onDueAtChange={handleGanttDueAtChange} />
         </Box>
       )}
 

--- a/packages/client/src/pages/TaskBoardPage.tsx
+++ b/packages/client/src/pages/TaskBoardPage.tsx
@@ -706,6 +706,17 @@ function TaskBoardContent({
     }
   };
 
+  const handleGanttStartAtChange = async (task: Task, startAt: string | null) => {
+    const prevTasks = tasks;
+    setTasks((prev) => prev.map((t) => (t.id === task.id ? { ...t, startAt } : t)));
+    try {
+      await api.tasks.update(task.id, { startAt });
+    } catch {
+      setTasks(prevTasks);
+      showError('タスクの開始日を更新できませんでした');
+    }
+  };
+
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* ツールバー: モバイル時は縦スタック、デスクトップ時は横一列 */}
@@ -817,7 +828,11 @@ function TaskBoardContent({
         </Box>
       ) : (
         <Box data-testid="gantt-container" sx={{ flexGrow: 1, overflow: 'auto' }}>
-          <TaskGanttChart tasks={filteredTasks} onDueAtChange={handleGanttDueAtChange} />
+          <TaskGanttChart
+            tasks={filteredTasks}
+            onDueAtChange={handleGanttDueAtChange}
+            onStartAtChange={handleGanttStartAtChange}
+          />
         </Box>
       )}
 

--- a/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
+++ b/packages/server/src/__tests__/__fixtures__/pgTestHelper.ts
@@ -415,6 +415,7 @@ export function createTestDatabase() {
       description TEXT,
       status TEXT NOT NULL DEFAULT 'todo',
       assignee_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      start_at TIMESTAMPTZ,
       due_at TIMESTAMPTZ,
       source_message_id INTEGER REFERENCES messages(id) ON DELETE SET NULL,
       source_channel_id INTEGER REFERENCES channels(id) ON DELETE SET NULL,

--- a/packages/server/src/__tests__/integration/tasks-route.test.ts
+++ b/packages/server/src/__tests__/integration/tasks-route.test.ts
@@ -41,6 +41,33 @@ async function createMessage(token: string, channelId: number): Promise<number> 
 }
 
 describe('タスク管理 APIルート', () => {
+  describe('開始日 API', () => {
+    it('PATCH /tasks/:id でstartAtを更新でき、レスポンスのtask.startAtに反映される', async () => {
+      const { token } = await setupRelationshipUser();
+      const task = (await postTask(token, { title: '対象' })).body.task;
+      const response = await request(app)
+        .patch(`/api/tasks/${task.id}`)
+        .set('Cookie', `token=${token}`)
+        .send({ startAt: '2026-06-10T00:00:00Z' });
+
+      expect(response.status).toBe(200);
+      expect(new Date(response.body.task.startAt).toISOString()).toBe('2026-06-10T00:00:00.000Z');
+    });
+
+    it('PATCH /tasks/:id でstartAt:nullを更新でき、レスポンスのtask.startAtがnullになる', async () => {
+      const { token } = await setupRelationshipUser();
+      const task = (await postTask(token, { title: '対象', startAt: '2026-06-10T00:00:00Z' })).body
+        .task;
+      const response = await request(app)
+        .patch(`/api/tasks/${task.id}`)
+        .set('Cookie', `token=${token}`)
+        .send({ startAt: null });
+
+      expect(response.status).toBe(200);
+      expect(response.body.task.startAt).toBeNull();
+    });
+  });
+
   describe('親子・依存関係 API', () => {
     it('POST /tasks で親タスクと先行タスクを指定できる', async () => {
       const { token } = await setupRelationshipUser();

--- a/packages/server/src/__tests__/task.test.ts
+++ b/packages/server/src/__tests__/task.test.ts
@@ -528,6 +528,18 @@ describe('タスク管理機能（taskService）', () => {
       expect(updated.dueAt).toBeTruthy();
     });
 
+    it('start_at を更新でき、取得したタスクのstartAtに反映される', async () => {
+      const updated = await taskService.updateTask(taskId, { startAt: '2026-06-10T00:00:00Z' });
+      expect(updated.startAt).toBeTruthy();
+      expect(new Date(updated.startAt!).toISOString()).toBe('2026-06-10T00:00:00.000Z');
+    });
+
+    it('start_at を null に更新すると開始日を未設定に戻せる', async () => {
+      await taskService.updateTask(taskId, { startAt: '2026-06-10T00:00:00Z' });
+      const updated = await taskService.updateTask(taskId, { startAt: null });
+      expect(updated.startAt).toBeNull();
+    });
+
     it('存在しないタスク ID を更新しようとするとエラーになる', async () => {
       await expect(taskService.updateTask(9999, { title: '更新' })).rejects.toThrow(
         'Task not found',

--- a/packages/server/src/routes/tasks.ts
+++ b/packages/server/src/routes/tasks.ts
@@ -41,6 +41,7 @@ router.post('/', authenticateToken, async (req, res, next) => {
     title,
     description,
     assigneeId,
+    startAt,
     dueAt,
     sourceMessageId,
     sourceChannelId,
@@ -50,6 +51,7 @@ router.post('/', authenticateToken, async (req, res, next) => {
     title?: string;
     description?: string;
     assigneeId?: number | null;
+    startAt?: string | null;
     dueAt?: string | null;
     sourceMessageId?: number | null;
     sourceChannelId?: number | null;
@@ -66,6 +68,7 @@ router.post('/', authenticateToken, async (req, res, next) => {
       title,
       description,
       assigneeId,
+      startAt,
       dueAt,
       sourceMessageId,
       sourceChannelId,
@@ -130,17 +133,27 @@ router.patch('/:id', authenticateToken, async (req, res, next) => {
     return next(createError('Invalid task ID', 400));
   }
 
-  const { title, description, status, assigneeId, dueAt, isHidden, parentTaskId, dependencyIds } =
-    req.body as {
-      title?: string;
-      description?: string | null;
-      status?: string;
-      assigneeId?: number | null;
-      dueAt?: string | null;
-      isHidden?: boolean;
-      parentTaskId?: number | null;
-      dependencyIds?: number[];
-    };
+  const {
+    title,
+    description,
+    status,
+    assigneeId,
+    startAt,
+    dueAt,
+    isHidden,
+    parentTaskId,
+    dependencyIds,
+  } = req.body as {
+    title?: string;
+    description?: string | null;
+    status?: string;
+    assigneeId?: number | null;
+    startAt?: string | null;
+    dueAt?: string | null;
+    isHidden?: boolean;
+    parentTaskId?: number | null;
+    dependencyIds?: number[];
+  };
 
   try {
     const task = await taskService.updateTask(taskId, {
@@ -148,6 +161,7 @@ router.patch('/:id', authenticateToken, async (req, res, next) => {
       description,
       status: status as import('@chat-app/shared').TaskStatus | undefined,
       assigneeId,
+      startAt,
       dueAt,
       isHidden,
       parentTaskId,

--- a/packages/server/src/services/taskService.ts
+++ b/packages/server/src/services/taskService.ts
@@ -17,6 +17,7 @@ interface TaskRow {
   status: string;
   assignee_id: number | null;
   assignee_username: string | null;
+  start_at: string | null;
   due_at: string | null;
   source_message_id: number | null;
   source_channel_id: number | null;
@@ -32,7 +33,7 @@ const BASE_SELECT = `
   SELECT
     t.id, t.title, t.description, t.status,
     t.assignee_id, u.username AS assignee_username,
-    t.due_at, t.source_message_id,
+    t.start_at, t.due_at, t.source_message_id,
     COALESCE(t.source_channel_id, m.channel_id) AS source_channel_id,
     t.created_by, t.position, t.is_hidden, t.parent_task_id, t.created_at, t.updated_at
   FROM tasks t
@@ -54,6 +55,7 @@ function rowToTask(
     status: row.status as TaskStatus,
     assigneeId: row.assignee_id,
     assigneeUsername: row.assignee_username,
+    startAt: row.start_at,
     dueAt: row.due_at,
     sourceMessageId: row.source_message_id,
     sourceChannelId: row.source_channel_id,
@@ -126,11 +128,7 @@ async function validateParent(
     visited.add(cursor);
     const row: { parent_task_id: number | null } | null = await clientQueryOne<{
       parent_task_id: number | null;
-    }>(
-      client,
-      'SELECT parent_task_id FROM tasks WHERE id = $1',
-      [cursor],
-    );
+    }>(client, 'SELECT parent_task_id FROM tasks WHERE id = $1', [cursor]);
     cursor = row?.parent_task_id ?? null;
   }
 }
@@ -226,6 +224,7 @@ export async function createTask(createdBy: number, input: CreateTaskInput): Pro
     title,
     description,
     assigneeId,
+    startAt,
     dueAt,
     sourceMessageId,
     sourceChannelId,
@@ -244,12 +243,13 @@ export async function createTask(createdBy: number, input: CreateTaskInput): Pro
     await validateParent(client, null, parentTaskId);
     await validateDependencies(client, null, dependencyIds);
     const result = await client.query<{ id: number }>(
-      `INSERT INTO tasks (title, description, assignee_id, due_at, source_message_id, source_channel_id, created_by, parent_task_id, position)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 0) RETURNING id`,
+      `INSERT INTO tasks (title, description, assignee_id, start_at, due_at, source_message_id, source_channel_id, created_by, parent_task_id, position)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 0) RETURNING id`,
       [
         title.trim(),
         description ?? null,
         assigneeId ?? null,
+        startAt ?? null,
         dueAt ?? null,
         sourceMessageId ?? null,
         sourceChannelId ?? null,
@@ -337,6 +337,7 @@ export async function updateTask(taskId: number, input: UpdateTaskInput): Promis
   if (input.description !== undefined) add('description', input.description);
   if (input.status !== undefined) add('status', input.status);
   if (input.assigneeId !== undefined) add('assignee_id', input.assigneeId);
+  if (input.startAt !== undefined) add('start_at', input.startAt);
   if (input.dueAt !== undefined) add('due_at', input.dueAt);
   if (input.isHidden !== undefined) add('is_hidden', input.isHidden);
   if (input.parentTaskId !== undefined) add('parent_task_id', input.parentTaskId);

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -7,6 +7,7 @@ export interface Task {
   status: TaskStatus;
   assigneeId: number | null;
   assigneeUsername?: string | null;
+  startAt?: string | null;
   dueAt: string | null;
   sourceMessageId: number | null;
   sourceChannelId: number | null;
@@ -26,6 +27,7 @@ export interface CreateTaskInput {
   title: string;
   description?: string;
   assigneeId?: number | null;
+  startAt?: string | null;
   dueAt?: string | null;
   sourceMessageId?: number | null;
   sourceChannelId?: number | null;
@@ -38,6 +40,7 @@ export interface UpdateTaskInput {
   description?: string | null;
   status?: TaskStatus;
   assigneeId?: number | null;
+  startAt?: string | null;
   dueAt?: string | null;
   isHidden?: boolean;
   parentTaskId?: number | null;


### PR DESCRIPTION
## 概要
タスクボードのガント表示を、日付軸付きのガントUIへ改善し、ガント上で期限と開始日を直接編集できるようにしました。

追加で、表示範囲を粒度ごとに固定し、ページネーションで前後に移動できるようにしました。

- 日表示: 1ヶ月
- 週表示: 3ヶ月
- 月表示: 2年

右端ドラッグでは開始位置を変えず、開始位置の変更は左端ドラッグだけで行う操作感にしています。

## 変更内容
- `TaskGanttChart` をタスク名列 + 時間軸列の 2 カラム構成へ変更
- 日付ヘッダー、縦グリッド、今日線、期間ラベルを追加
- 日・週・月の表示粒度切替を追加
- 表示範囲ページネーションを追加
  - `前へ` / `次へ` / `今日へ戻る`
  - 日: 1ヶ月ずつ移動
  - 週: 3ヶ月ずつ移動
  - 月: 2年ずつ移動
- 表示範囲に一部でも重なるタスクだけを描画し、完全に範囲外のタスクは非表示に変更
- 範囲にまたがるタスクバーは表示範囲内でクリップして表示
- ガント行クリックまたは編集アイコンから期限編集ポップオーバーを開けるように変更
- Enter / Blur で期限変更を保存し、Escape でキャンセルできるように変更
- 「期限なしにする」操作を追加
- バー右端ドラッグで期限日 `dueAt` を日単位に変更できるように変更
- バー左端ドラッグで開始日 `startAt` を日単位に変更できるように変更
- 右端を開始日より左へドラッグした場合、開始日は変更せず、期限だけ開始日に丸めるように変更
- 左端を期限より右へドラッグした場合、開始日だけ期限日に丸めるように変更
- `tasks.start_at` / shared type / API / service / pg-mem test schema を追加・更新
- ガント上の更新は `api.tasks.update(task.id, { dueAt })` または `{ startAt }` のみを送り、楽観更新・失敗時ロールバック・エラー通知を実装
- 期限なし件数表示と依存関係ラベル表示を維持
- `TaskGanttChart.test.tsx` / `TaskBoardPage.test.tsx` / server service・route test に回帰テストを追加

## 仕様・受け入れ条件
- 関連 Issue: #414
- 満たした受け入れ条件:
  - ガント表示に日付ヘッダーが表示され、棒線と同じ横軸上で読める
  - 日付ヘッダーに対応する縦グリッドが表示される
  - 今日が表示範囲内にある場合、今日線が表示される
  - 各タスクの棒線上または近傍に期間ラベルが表示される
  - 日・週・月の表示粒度を切り替えられる
  - 日表示は1ヶ月、週表示は3ヶ月、月表示は2年の範囲で表示される
  - 前へ/次へで表示範囲をページ送りできる
  - 今日へ戻るで現在日を含む表示範囲へ戻れる
  - 表示範囲に重なるタスクだけが表示される
  - ガント表示からタスク期限を編集できる
  - ガント表示からタスク開始日を編集できる
  - 右端ドラッグでは開始日を変更しない
  - 開始日の変更は左端ドラッグで行う
  - API 失敗時は楽観更新をロールバックし、エラー通知する
  - 期限なしタスクの件数表示など既存の補助情報は維持される
  - 依存関係テキストの既存表示は維持される

## AI テスト設計レビュー
- Verdict: APPROVED
- レビュアー: codex exec による独立コンテキストレビュー
- レビュー対象:
  - `packages/client/src/__tests__/TaskGanttChart.test.tsx`
  - `packages/client/src/__tests__/TaskBoardPage.test.tsx`
  - `packages/server/src/__tests__/task.test.ts`
  - `packages/server/src/__tests__/integration/tasks-route.test.ts`
- 主な対応:
  - 右端ドラッグが開始日を変更せず、期限だけ開始日に丸めることを検証
  - 左端ドラッグで `startAt` を保存することを検証
  - 左端を期限より右へ動かした場合、開始日が期限日に丸められることを検証
  - `startAt` があるタスクは `createdAt` ではなく `startAt` から描画されることを検証
  - 日/週/月の固定表示範囲と前後ページングを検証
  - 今日へ戻る操作を検証
  - 表示範囲に一部でも重なるタスクだけが描画されることを検証
  - `startAt` 更新の API payload、楽観更新、失敗時ロールバックを検証
  - server service / route で `startAt` 更新と `startAt:null` を検証

## 高リスク変更
- [ ] 該当なし
- [x] DB マイグレーション
- [ ] 認証・認可
- [ ] 削除・外部書き込み
- [ ] 機密情報

## AI 実装レビュー（高リスク変更の場合）
- Verdict: APPROVED
- レビュアー: codex exec による独立コンテキストレビュー
- Blocking findings: none
- Non-blocking findings:
  - API/service は Gantt 以外の更新経路で `startAt > dueAt` / `dueAt < startAt` を受け入れうる。UI drag では clamp 済みのため今回の要求に対しては非ブロッキング。将来、service-level invariant の追加を検討可能。

## 影響範囲
- フロントエンド: タスクボードのガント表示、表示範囲ページネーション、ガント表示からの期限・開始日更新
- バックエンド/API: `POST /api/tasks`, `PATCH /api/tasks/:id`, task service, task response
- DB: `tasks.start_at` nullable column 追加
- shared type: `Task`, `CreateTaskInput`, `UpdateTaskInput` に `startAt` 追加

## 検証結果
- [x] `npm run build` が成功した
- [x] `npm run test` が成功した
- [x] `it.todo` / 空ボディの `it` が残っていない
- 実行結果:
  - `npm run build`: 成功
  - `npm run test`: 成功（server 1,992件 / client 2,650件）
  - `npm run test --workspace=packages/client -- TaskGanttChart.test.tsx`: 成功（24件）
  - `git diff --check`: 成功
  - `atlas schema apply --env local --dry-run`: 成功（schema synced）
  - `rg` による `it.todo` / 空ボディ `it` 検出: 0件

## Playwright 画面動作確認
- 結果: 成功
- 確認したユーザーフロー:
  - `http://localhost:5173/tasks` でガント表示へ切替
  - 日表示で `2026/6/1 — 2026/6/30` の1ヶ月表示になることを確認
  - 日表示で次へを押すと `2026/7/1 — 2026/7/31` へ移動し、前へで戻ることを確認
  - 週表示で `2026/6/1 — 2026/8/31` の3ヶ月表示になることを確認
  - 週表示で次へを押すと `2026/9/1 — 2026/11/30` へ移動することを確認
  - 月表示で `2026/6/1 — 2028/5/31` の2年表示になることを確認
  - 月表示で次へを押すと `2028/6/1 — 2030/5/31` へ移動することを確認
  - 今日へ戻るで現在日を含む表示範囲へ戻ることを確認
  - 範囲に重なるタスクが表示され、範囲外タスクが表示されないことを確認
  - 右端ドラッグ時の PATCH body が `{"dueAt":"2026-06-21T12:00:00.000Z"}` で、`startAt` が送られないことを確認
  - 左端ドラッグ時の PATCH body が `{"startAt":"2026-07-03T10:52:47.146Z"}` で、`dueAt` が送られないことを確認
- コンソール・ネットワーク確認:
  - ガントページネーション確認中の console error: 0
  - 関連 API は 200 OK
  - React Router future flag warning は既存警告として記録
- スクリーンショット等:
  - `output/playwright/gantt-pagination-414/` 配下に未コミット artifact として保存
  - `output/playwright/gantt-start-edit-414/` 配下に未コミット artifact として保存

## 既存テストの変更
- 変更ファイル: `packages/client/src/__tests__/TaskGanttChart.test.tsx`
- 変更理由: 仕様変更
- 変更内容: 右端ドラッグの開始日非変更、左端ドラッグの開始日更新、`startAt` 表示、clamp 挙動、日/週/月の固定表示範囲、前後ページング、今日へ戻る、範囲重なりフィルタのテストを追加。旧仕様と矛盾する「右端を作成日前へ動かしても丸めない」テストを削除。固定表示範囲化に合わせて既存ガント軸テストの期待グリッド数とドラッグ座標を更新。
- アサーションを弱めた、または削除した場合の根拠: ユーザー要望により右端ドラッグと表示範囲の仕様が変わったため、旧仕様テストを新仕様テストへ置換。

- 変更ファイル: `packages/client/src/__tests__/TaskBoardPage.test.tsx`
- 変更理由: 仕様変更
- 変更内容: ガント表示モックを `onStartAtChange` 対応に更新し、`startAt` のみ更新、楽観更新、失敗時ロールバックとエラー通知のテストを追加。
- アサーションを弱めた、または削除した場合の根拠: 既存アサーションは弱体化していない。

- 変更ファイル: `packages/server/src/__tests__/task.test.ts`
- 変更理由: 仕様変更
- 変更内容: `start_at` 更新、`start_at:null` クリアの service test を追加。
- アサーションを弱めた、または削除した場合の根拠: 既存アサーションは弱体化していない。

- 変更ファイル: `packages/server/src/__tests__/integration/tasks-route.test.ts`
- 変更理由: 仕様変更
- 変更内容: PATCH `startAt` / `startAt:null` の route test を追加。
- アサーションを弱めた、または削除した場合の根拠: 既存アサーションは弱体化していない。

- 変更ファイル: `packages/server/src/__tests__/__fixtures__/pgTestHelper.ts`
- 変更理由: 仕様変更
- 変更内容: pg-mem の tasks schema に `start_at` を追加。
- アサーションを弱めた、または削除した場合の根拠: テストDBスキーマ追従のみ。

- 変更ファイル: `packages/client/src/__tests__/__fixtures__/tasks.ts`
- 変更理由: 仕様変更
- 変更内容: task fixture に `startAt: null` を追加。
- アサーションを弱めた、または削除した場合の根拠: fixture の型追従のみ。

## 未解決事項・人間に求める仕様判断
- なし

## 関連Issue
Fixes #414

## チェックリスト
- [x] AI テスト設計レビューが `APPROVED` になっている
- [x] Blocking 指摘への対応を再レビュー済み
- [x] 高リスク変更の場合、AI 実装レビューが `APPROVED` になっている
- [x] Playwright 確認を実施した、または `N/A` の根拠を記載した
- [x] 不要なデバッグコードやコメントが残っていない
- [x] 変数名や関数名がプロジェクトの命名規則に従っている
- [x] ドキュメント（READMEやCLAUDE.md等）の更新が必要な場合、それらも修正した（N/A）
- [x] `it.todo` / 空ボディの `it` が残っていない（`it.skip` の場合は別 issue 参照コメントを残す）